### PR TITLE
Fixing compilation of core_nexus library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ add_subdirectory("src/realizations/catchment")
 
 target_link_libraries(ngen PUBLIC
         NGen::core
+        NGen::core_catchment
+        NGen::core_nexus
         NGen::realizations_catchment
         )
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,8 +6,8 @@ dynamic_sourced_cxx_library(core "${CMAKE_CURRENT_SOURCE_DIR}")
 add_library(NGen::core ALIAS core)
 
 target_include_directories(core PUBLIC
-        ../../include/core
-        ../../include/core/catchment
+        ${PROJECT_SOURCE_DIR}/include/core
+        ${PROJECT_SOURCE_DIR}/include/core/catchment
         )
 
 add_subdirectory("catchment")

--- a/src/core/catchment/CMakeLists.txt
+++ b/src/core/catchment/CMakeLists.txt
@@ -6,8 +6,8 @@ dynamic_sourced_cxx_library(core_catchment "${CMAKE_CURRENT_SOURCE_DIR}")
 add_library(NGen::core_catchment ALIAS core_catchment)
 
 target_include_directories(core_catchment PUBLIC
-        ../../../include/core
-        ../../../include/core/catchment
+        ${PROJECT_SOURCE_DIR}/include/core
+        ${PROJECT_SOURCE_DIR}/include/core/catchment
         )
 
 # TODO: consider setting a minimum or required version

--- a/src/core/nexus/CMakeLists.txt
+++ b/src/core/nexus/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(NGen::core_nexus ALIAS core_nexus)
 
 target_include_directories(core_nexus PUBLIC
         ../../../include/core
+        ../../../include/core/nexus
         )
 
 # TODO: consider setting a minimum or required version

--- a/src/core/nexus/CMakeLists.txt
+++ b/src/core/nexus/CMakeLists.txt
@@ -6,8 +6,8 @@ dynamic_sourced_cxx_library(core_nexus "${CMAKE_CURRENT_SOURCE_DIR}")
 add_library(NGen::core_nexus ALIAS core_nexus)
 
 target_include_directories(core_nexus PUBLIC
-        ../../../include/core
-        ../../../include/core/nexus
+        ${PROJECT_SOURCE_DIR}/include/core
+        ${PROJECT_SOURCE_DIR}/include/core/nexus
         )
 
 # TODO: consider setting a minimum or required version

--- a/src/realizations/catchment/CMakeLists.txt
+++ b/src/realizations/catchment/CMakeLists.txt
@@ -6,11 +6,11 @@ dynamic_sourced_cxx_library(realizations_catchment "${CMAKE_CURRENT_SOURCE_DIR}"
 add_library(NGen::realizations_catchment ALIAS realizations_catchment)
 
 target_include_directories(realizations_catchment PUBLIC
-        ../../../include/core
-        ../../../include/core/catchment
-        ../../../include/realizations/catchment
-        ../../../models
-        ../../../models/kernels
+        ${PROJECT_SOURCE_DIR}/include/core
+        ${PROJECT_SOURCE_DIR}/include/core/catchment
+        ${PROJECT_SOURCE_DIR}/include/realizations/catchment
+        ${PROJECT_SOURCE_DIR}/models
+        ${PROJECT_SOURCE_DIR}/models/kernels
         )
 
 target_link_libraries(realizations_catchment PUBLIC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,8 @@ macro(add_automated_test TESTNAME)
             gtest
             gtest_main
             NGen::core
+            NGen::core_catchment
+            NGen::core_nexus
             NGen::realizations_catchment)
     gtest_discover_tests(${TESTNAME}
             WORKING_DIRECTORY ${PROJECT_DIR}
@@ -30,6 +32,8 @@ macro(add_automated_test_w_mock TESTNAME)
             gmock
             gtest_main
             NGen::core
+            NGen::core_catchment
+            NGen::core_nexus
             NGen::realizations_catchment
             )
     gtest_discover_tests(${TESTNAME}


### PR DESCRIPTION

## Additions

- Adding omitted include directory to `src/core/nexus/CMakeLists.txt`
- Explicitly adding all nested directory libraries to main `ngen` target and macros for testing targets
- Changing usage of `target_include_directories` in various `CMakeLists.txt` files to use the built-in CMake variable for the project root directory instead of an equivalent relative path

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
