### PR TITLE
GeoJSON Testing Bug Fix

### DIFF
--- a/test/geojson/Feature_Test.cpp
+++ b/test/geojson/Feature_Test.cpp
@@ -302,7 +302,7 @@ TEST_F(Feature_Test, ptree_test) {
       "} "
     "}";
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     tree = boost::property_tree::ptree();
     boost::property_tree::json_parser::read_json(stream, tree);
@@ -349,7 +349,7 @@ TEST_F(Feature_Test, ptree_test) {
       "} "
     "}";
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     tree = boost::property_tree::ptree();
     boost::property_tree::json_parser::read_json(stream, tree);
@@ -390,7 +390,7 @@ TEST_F(Feature_Test, ptree_test) {
       "} "
     "}";
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     tree = boost::property_tree::ptree();
     boost::property_tree::json_parser::read_json(stream, tree);
@@ -436,7 +436,7 @@ TEST_F(Feature_Test, ptree_test) {
       "} "
     "}";
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     tree = boost::property_tree::ptree();
     boost::property_tree::json_parser::read_json(stream, tree);
@@ -490,7 +490,7 @@ TEST_F(Feature_Test, ptree_test) {
       "} "
     "}";
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     tree = boost::property_tree::ptree();
     boost::property_tree::json_parser::read_json(stream, tree);

--- a/test/geojson/JSONGeometry_Test.cpp
+++ b/test/geojson/JSONGeometry_Test.cpp
@@ -58,7 +58,7 @@ TEST_F(JSONGeometry_Test, point_test) {
     ASSERT_EQ(geometry.as_point().get<0>(), x);
     ASSERT_EQ(geometry.as_point().get<1>(), y);
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     boost::property_tree::ptree indirect_tree;
     boost::property_tree::json_parser::read_json(stream, indirect_tree);
@@ -108,7 +108,7 @@ TEST_F(JSONGeometry_Test, linestring_test) {
     ASSERT_EQ(geometry.as_linestring()[3].get<0>(), 105.0);
     ASSERT_EQ(geometry.as_linestring()[3].get<1>(), 1.0);
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     boost::property_tree::ptree indirect_tree;
     boost::property_tree::json_parser::read_json(stream, indirect_tree);
@@ -181,7 +181,7 @@ TEST_F(JSONGeometry_Test, polygon_test) {
     ASSERT_EQ(geometry.as_polygon().inners().size(), 1);
     ASSERT_EQ(geometry.as_polygon().inners()[0].size(), 4);
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     boost::property_tree::ptree indirect_tree;
     boost::property_tree::json_parser::read_json(stream, indirect_tree);
@@ -230,7 +230,7 @@ TEST_F(JSONGeometry_Test, multipoint_test) {
     ASSERT_EQ(geometry.as_multipoint()[3].get<0>(), 30);
     ASSERT_EQ(geometry.as_multipoint()[3].get<1>(), 10);
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     boost::property_tree::ptree indirect_tree;
     boost::property_tree::json_parser::read_json(stream, indirect_tree);
@@ -327,7 +327,7 @@ TEST_F(JSONGeometry_Test, multilinestring_test) {
     ASSERT_EQ(geometry.as_multilinestring()[1][1].get<0>(), -170.0);
     ASSERT_EQ(geometry.as_multilinestring()[1][1].get<1>(), 45.0);
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     boost::property_tree::ptree indirect_tree;
     boost::property_tree::json_parser::read_json(stream, indirect_tree);
@@ -429,7 +429,7 @@ TEST_F(JSONGeometry_Test, multipolygon_test) {
     ASSERT_EQ(geometry.as_multipolygon()[1].outer().size(), 5);
     ASSERT_EQ(geometry.as_multipolygon()[1].inners().size(), 0);
 
-    stream = std::stringstream();
+    stream.str("");
     stream << data;
     boost::property_tree::ptree indirect_tree;
     boost::property_tree::json_parser::read_json(stream, indirect_tree);


### PR DESCRIPTION
Fixes Issue #55 

Fix for bugs in GeoJSON testing that cause compilation errors with g++ 4.8.5.

## Changes
Changes to these files:
ngen/test/geojson/JSONGeometry_Test.cpp
ngen/test/geojson/Feature_Test.cpp


## Testing

1. Passes unit tests.


## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
