### PR TITLE
Simple one time step driver for hymod realized catchment.

### DIFF
--- a/models/kernels/Pdm03.h
+++ b/models/kernels/Pdm03.h
@@ -23,7 +23,7 @@ extern "C"
         double Kv;
     };
 
-    void Pdm03(int modelDay,
+    inline void Pdm03(int modelDay,
         double Cpar,
         double B,
         double *XHuz,
@@ -54,7 +54,7 @@ extern "C"
     %%=========================================================================
     */
 
-    void Pdm03(int modelDay, double Cpar, double B, double *XHuz, double Huz,
+    inline void Pdm03(int modelDay, double Cpar, double B, double *XHuz, double Huz,
               double *OV, double *AE, double *XCuz, double effPrecip, double PE, double Kv)
     {
       /* local variables */
@@ -94,7 +94,7 @@ extern "C"
 
     }
 
-    void pdm03_wrapper(pdm03_struct* pdm_data)
+    inline void pdm03_wrapper(pdm03_struct* pdm_data)
     {
         return Pdm03(pdm_data->modelDay,
         pdm_data->Cpar,

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -1,9 +1,48 @@
 #include <iostream>
 
 #include "NGenConfig.h"
+#include <Simple_Lumped_Model_Realization.hpp>
+#include <HY_PointHydroNexus.hpp>
 
 int main(int argc, char *argv[]) {
     std::cout << "Hello there " << ngen_VERSION_MAJOR << "."
               << ngen_VERSION_MINOR << "."
               << ngen_VERSION_PATCH << std::endl;
+
+
+    //Create a nexus
+    HY_PointHydroNexus* nexus_1 = new HY_PointHydroNexus(1, "nex-1", 1);
+
+    //Mock up some catchment parameters
+    double storage = 1.0;
+    double max_storage = 1000.0;
+    double a = 1.0;
+    double b = 10.0;
+    double Ks = 0.1;
+    double Kq = 0.01;
+    long n = 3;
+    double t = 0;
+    std::vector<double> sr_tmp = {1.0, 1.0, 1.0};
+
+    //Create the realization
+    Simple_Lumped_Model_Realization* catchment_1 = new Simple_Lumped_Model_Realization(storage, max_storage,
+                                                                                       a, b, Ks, Kq, n, sr_tmp, t);
+    //et_struct
+    // create the struct used for ET
+    pdm03_struct pdm_et_data;
+    pdm_et_data.B = 1.3;
+    pdm_et_data.Kv = 0.99;
+    pdm_et_data.modelDay = 0.0;
+    pdm_et_data.Huz = 400.0;
+    pdm_et_data.Cpar = pdm_et_data.Huz / (1.0+pdm_et_data.B);
+
+    //Run one time step
+    double water = catchment_1->get_response(0, 0, &pdm_et_data);
+    std::cout<<"Response of cat-1: "<<water<<std::endl;
+    //nexus_1->add_upstream_flow(water, "cat-1", 0);
+    nexus_1->add_upstream_flow(water, 1, 0);
+    std::cout<<"nexus_1 has "<<nexus_1->get_downstream_flow(1, 0, 100.0)<<std::endl;
+    
+    delete catchment_1;
+    delete nexus_1;
 }

--- a/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
+++ b/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
@@ -40,15 +40,14 @@ Simple_Lumped_Model_Realization::~Simple_Lumped_Model_Realization()
 
 void Simple_Lumped_Model_Realization::add_time(time_t t, double n)
 {
-    if ( state.find(t) != state.end() )
+    if ( state.find(t) == state.end() )
     {
         // create storage for fluxes
         fluxes[t] = hymod_fluxes();
         // create a safe backing array for the Sr arrays that are part of state
-        cascade_backing_storage[t].resize(params.n);
+        cascade_backing_storage[t].resize(params.n); //NJF TODO use params.n or input double n???  And why double?
 
         // create storage for the state
-
         state[t] = hymod_state(0.0, 0.0, cascade_backing_storage[t].data());
     }
 }


### PR DESCRIPTION
A simple driver example.

## Additions

Added a simple single time step Simple_Lumped_Model_Realization and manually connected nexus to ngen.cpp.

## Changes

Fixed a bug in hymod add_time function.

Inlined the pdm03 functions to prevent duplicate symbols during linking.

## Testing

Built project and ran driver to verify output of nexus.

Testing was run, and forcing test segfaults, not sure why at this point.

## Notes

This driver doesn't HAVE to get merged, but wanted to get a reference up to review.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

[==========] Running 27 tests from 7 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from HymodKernelTest
[ RUN      ] HymodKernelTest.TestRun0
[       OK ] HymodKernelTest.TestRun0 (0 ms)
[ RUN      ] HymodKernelTest.TestWithKnownInput
Test file not found
/Users/nels.frazier/workspace/ngen/test/models/hymod/include/HymodTest.cpp:109: Failure
Value of: false
  Actual: false
Expected: true
[  FAILED  ] HymodKernelTest.TestWithKnownInput (1 ms)
[ RUN      ] HymodKernelTest.TestCalcET0
[       OK ] HymodKernelTest.TestCalcET0 (0 ms)
[----------] 3 tests from HymodKernelTest (1 ms total)

[----------] 8 tests from NonlinearReservoirKernelTest
[ RUN      ] NonlinearReservoirKernelTest.TestRunNoOutletReservoir
[       OK ] NonlinearReservoirKernelTest.TestRunNoOutletReservoir (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunOneOutletReservoir
[       OK ] NonlinearReservoirKernelTest.TestRunOneOutletReservoir (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirNoActivation
[       OK ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirNoActivation (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirExceedMaxStorage
WARNING: Nonlinear reservoir calculated a storage above the maximum storage.
[       OK ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirExceedMaxStorage (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirFallsBelowMinimumStorage
[       OK ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirFallsBelowMinimumStorage (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirExceedMaxVelocity
WARNING: Nonlinear reservoir calculated an outlet velocity over max velocity, and therefore set the outlet velocity to max velocity
.
[       OK ] NonlinearReservoirKernelTest.TestRunOneOutletReservoirExceedMaxVelocity (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunMultipleOutletReservoir
[       OK ] NonlinearReservoirKernelTest.TestRunMultipleOutletReservoir (0 ms)
[ RUN      ] NonlinearReservoirKernelTest.TestRunMultipleOutletOutOfOrderNonlinearReservoir
[       OK ] NonlinearReservoirKernelTest.TestRunMultipleOutletOutOfOrderNonlinearReservoir (0 ms)
[----------] 8 tests from NonlinearReservoirKernelTest (1 ms total)

[----------] 5 tests from JSONProperty_Test
[ RUN      ] JSONProperty_Test.natural_property_test
[       OK ] JSONProperty_Test.natural_property_test (0 ms)
[ RUN      ] JSONProperty_Test.real_property_test
[       OK ] JSONProperty_Test.real_property_test (0 ms)
[ RUN      ] JSONProperty_Test.string_property_test
[       OK ] JSONProperty_Test.string_property_test (0 ms)
[ RUN      ] JSONProperty_Test.boolean_property_test
[       OK ] JSONProperty_Test.boolean_property_test (0 ms)
[ RUN      ] JSONProperty_Test.object_property_test
[       OK ] JSONProperty_Test.object_property_test (1 ms)
[----------] 5 tests from JSONProperty_Test (1 ms total)

[----------] 6 tests from JSONGeometry_Test
[ RUN      ] JSONGeometry_Test.point_test
[       OK ] JSONGeometry_Test.point_test (0 ms)
[ RUN      ] JSONGeometry_Test.linestring_test
[       OK ] JSONGeometry_Test.linestring_test (1 ms)
[ RUN      ] JSONGeometry_Test.polygon_test
[       OK ] JSONGeometry_Test.polygon_test (0 ms)
[ RUN      ] JSONGeometry_Test.multipoint_test
[       OK ] JSONGeometry_Test.multipoint_test (1 ms)
[ RUN      ] JSONGeometry_Test.multilinestring_test
[       OK ] JSONGeometry_Test.multilinestring_test (0 ms)
[ RUN      ] JSONGeometry_Test.multipolygon_test
[       OK ] JSONGeometry_Test.multipolygon_test (1 ms)
[----------] 6 tests from JSONGeometry_Test (3 ms total)

[----------] 3 tests from Feature_Test
[ RUN      ] Feature_Test.geometry_test
[       OK ] Feature_Test.geometry_test (4 ms)
[ RUN      ] Feature_Test.geometry_collection_test
[       OK ] Feature_Test.geometry_collection_test (1 ms)
[ RUN      ] Feature_Test.ptree_test
[       OK ] Feature_Test.ptree_test (3 ms)
[----------] 3 tests from Feature_Test (8 ms total)

[----------] 1 test from FeatureCollection_Test
[ RUN      ] FeatureCollection_Test.ptree_test
[       OK ] FeatureCollection_Test.ptree_test (1 ms)
[----------] 1 test from FeatureCollection_Test (1 ms total)

[----------] 1 test from ForcingTest
[ RUN      ] ForcingTest.TestForcingDataRead
Segmentation fault: 11
