### PR TITLE
Fix to AORC forcing reader to start at second line of CSV

### DIFF
--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -184,8 +184,8 @@ class Forcing
 	//Get the data from CSV File
 	std::vector<std::vector<std::string> > data_list = reader.getData();
 
-        //Iterate through CSV starting on the third row
-        for (int i = 2; i < data_list.size(); i++)
+        //Iterate through CSV starting on the second row
+        for (int i = 1; i < data_list.size(); i++)
         {
                 //Row vector
                 std::vector<std::string>& vec = data_list[i];


### PR DESCRIPTION
Fixed AORC forcing reader to start at second line of CSV


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
