### PR TITLE
Bug fixes and minor cleanup

### DIFF
--- a/include/realizations/catchment/Simple_Lumped_Model_Realization.hpp
+++ b/include/realizations/catchment/Simple_Lumped_Model_Realization.hpp
@@ -26,6 +26,19 @@ class Simple_Lumped_Model_Realization : public HY_CatchmentArea
             time_step_t t
         );
 
+        /**
+         * @brief Explicit move constructor
+         * This constuctor explicitly moves a Simple_Lumped_Model_Realization
+         * and is required to properly move the HY_CatchmentRealization forcing object
+         */
+        Simple_Lumped_Model_Realization(Simple_Lumped_Model_Realization &&);
+        /**
+         * @brief Explicit copy constructor
+         * This constuctor explicitly copies Simple_Lumped_Model_Realization
+         * and is required to properly copy the HY_CatchmentRealization forcing object
+         * as well connectet the hymod_state.Sr* to the copied cascade_backing_storage vector
+         */
+        Simple_Lumped_Model_Realization(const Simple_Lumped_Model_Realization &);
         virtual ~Simple_Lumped_Model_Realization();
 
         double get_response(double input_flux, time_step_t t, time_step_t dt, void* et_params);

--- a/models/hymod/include/Hymod.h
+++ b/models/hymod/include/Hymod.h
@@ -17,9 +17,12 @@ struct hymod_params
     double max_storage_meters; //!< maximum amount of water stored
     double a;               //!< coefficent for distributing runoff and slowflow
     double b;               //!< exponent for flux equation
+    //Ks and Kq are coeeficint constants used by the non-linear reservoirs.  There is an implicit unit of time
+    //in these parameters to make `a*(dS/S)^b` have approriate units of meters/second
+    //this implies that for any given timstep, dt, the approriate coefficients may be different.
     double Ks;              //!< slow flow coefficent
     double Kq;              //!< quick flow coefficent
-    double n;               //!< number of nash cascades
+    int n;               //!< number of nash cascades
 };
 
 //! Hymod state structure

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -144,7 +144,6 @@ int main(int argc, char *argv[]) {
     double Kq = 0.01;
     long n = 3;
     double t = 0;
-    std::vector<double> sr_tmp = {1.0, 1.0, 1.0};
     time_step_t dt = 3600; //tshirt time step
 
     for(auto& feature : *nexus_collection)
@@ -156,6 +155,7 @@ int main(int argc, char *argv[]) {
         forcing_params forcing_p(forcing_paths[feat_id], start_time, end_time);
         if (feature->get_property("realization").as_string() == "hymod") {
             //Create the hymod instance
+            std::vector<double> sr_tmp = {1.0, 1.0, 1.0};
             catchment_realizations[feature->get_id()] = std::make_unique<_hymod>( _hymod(forcing_p, storage, max_storage, a, b, Ks, Kq, n, sr_tmp, t) );
         }
         else if(feature->get_property("realization").as_string() == "tshirt") {

--- a/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
+++ b/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
@@ -31,6 +31,27 @@ Simple_Lumped_Model_Realization::Simple_Lumped_Model_Realization(
     state[0].storage_meters = storage_meters;
 }
 
+Simple_Lumped_Model_Realization::Simple_Lumped_Model_Realization(Simple_Lumped_Model_Realization && other)
+:fluxes( std::move(other.fluxes) ), params( std::move(other.params) ),
+cascade_backing_storage( std::move(other.cascade_backing_storage) ),
+state( std::move(other.state) )
+{
+  this->forcing = std::move(other.forcing);
+}
+
+Simple_Lumped_Model_Realization::Simple_Lumped_Model_Realization(const Simple_Lumped_Model_Realization & other)
+:fluxes( other.fluxes ), params( other.params),
+cascade_backing_storage( other.cascade_backing_storage ),
+state( other.state )
+{
+  this->forcing = other.forcing;
+  //rehook state.Sr* -> cascade_backing_storage
+  for(auto &s : state)
+  {
+    s.second.Sr = cascade_backing_storage[s.first].data();
+  }
+}
+
 Simple_Lumped_Model_Realization::~Simple_Lumped_Model_Realization()
 {
     //dtor

--- a/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
+++ b/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
@@ -2,8 +2,6 @@
 
 #include <cmath>
 
-
-
 Simple_Lumped_Model_Realization::Simple_Lumped_Model_Realization(
     forcing_params forcing_config,
     double storage_meters,
@@ -77,11 +75,11 @@ double Simple_Lumped_Model_Realization::calc_et(double soil_m, void* et_params)
     return 0.0;
 }
 
+
 double Simple_Lumped_Model_Realization::get_response(double input_flux, time_step_t t, time_step_t dt, void* et_params)
-{   //TODO input_flux = this->forcing.get_input(t)
+{
     //TODO input_et = this->forcing.get_et(t)
     double precip = this->forcing.get_next_hourly_precipitation_meters_per_second();
-
     add_time(t+1, params.n);
     //FIXME should this run "daily" or hourly (t) which should really be dt
     //Do we keep an "internal dt" i.e. this->dt and reconcile with t?

--- a/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
+++ b/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
@@ -24,14 +24,11 @@ Simple_Lumped_Model_Realization::Simple_Lumped_Model_Realization(
     params.Kq = Kq;
     params.n = n;
 
-    add_time(t, n);
-
-    state[t].storage_meters = storage_meters;
-    for ( int i = 0; i < n; ++i)
-    {
-        state[t].Sr[i] = Sr[i];
-    }
-
+    //Init the first time explicity using passed in data
+    fluxes[0] = hymod_fluxes();
+    cascade_backing_storage.emplace(0, Sr); //Move ownership of init vector to container
+    state[0] = hymod_state(0.0, 0.0, cascade_backing_storage[0].data());
+    state[0].storage_meters = storage_meters;
 }
 
 Simple_Lumped_Model_Realization::~Simple_Lumped_Model_Realization()


### PR DESCRIPTION
The Simple_Lumped_Model_Realization used default copy construction, which copied the `cascading_backing_storage` vectors.  In turn the `state` map copied the underlying `Sr` pointer, but this no longer pointed to the correct vector backing store.  This lead to an undefined state for `Sr`.  An explicit copy constructor that re-links these pointers fixes this issue.  A move constructor also solves this for cases where move semantics can be used to transfer ownership (i.e. when adding to a container, or making a smart pointer).  Some other minor bugs in constructor initialization were also addressed.

## Additions

- `Simple_Lumped_Model_Realization(Simple_LumpedModel_Realization &)`
- `Simple_Lumped_Model_Realization(Simple_LumpedModel_Realization &&)`

## Changes

- `Simple_Lumped_Model_Realization` construction explicitly initializes time 0
- `hymod_params.n` changed from `double` to `int`
- Driver code recreates `tmp_sr` for each hymod realization being created

## Testing

All working unit tests passed locally, ngen application binary runs without crash, produces "reasonable" output

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS