### PR TITLE
Added bounds checking to retrieving velocity from reservoir outlet vector

### DIFF
--- a/models/kernels/Nonlinear_Reservoir.hpp
+++ b/models/kernels/Nonlinear_Reservoir.hpp
@@ -347,7 +347,22 @@ class Nonlinear_Reservoir
      */
     double velocity_meters_per_second_for_outlet(int outlet_index)
     {
-        return this->outlets[outlet_index]->get_previously_calculated_velocity_meters_per_second();
+        //Check bounds on outlet vector
+        /// \todo: Implement unordered_map outlet_map
+        if (outlet_index >= 0 && outlet_index < outlets.size())
+            return this->outlets.at(outlet_index)->get_previously_calculated_velocity_meters_per_second();
+
+        else if (outlets.size() > 0)
+        {
+            cout << "Warning, reservoir outlet requested is not in the outlets vector. Returning the velocity of the first outlet." << endl;
+            return this->outlets.at(0)->get_previously_calculated_velocity_meters_per_second();
+        }
+
+        else
+        {
+            cout << "Warning, reservoir outlet requested of reservoir with no outlets. Returning a velocity of 0.0 meters per second." << endl;
+            return 0.0;
+        }
     }
 
     /**


### PR DESCRIPTION
Added bounds checking to retrieving velocity from reservoir outlet vector

## Additions
Bounds checking in Nonlinear_Reservoir.hpp

## Changes
Changing method the vector is accessed

## Testing

1. Passed existing unit tests

## Notes
Addresses Issue #88. The next PR mentioned below will close this issue.

## Todos
Another PR to follow with unordered_map outlet_map


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
