### PR TITLE
Fix pointer slicing bug; deactivate max flow using max double

### DIFF
--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -63,7 +63,7 @@ namespace tshirt {
                 max_groundwater_storage_meters(max_gw_storage) {
             this->max_soil_storage_meters = this->depth * maxsmc;
             this->Cschaake = 3.0 * satdk / (2.0e-6);
-            this->max_lateral_flow = satdk * multiplier * this->max_soil_storage_meters;
+            this->max_lateral_flow = std::numeric_limits<double>::max();//satdk * multiplier * this->max_soil_storage_meters;
         }
 
     };
@@ -191,7 +191,7 @@ namespace tshirt {
             // Build vector of pointers to outlets to pass the custom exponential outlet through
             vector<std::shared_ptr<Reservoir_Outlet>> gw_outlets_vector(1);
             // TODO: verify activation threshold
-            gw_outlets_vector[0] = make_shared<Reservoir_Outlet>(
+            gw_outlets_vector[0] = make_shared<Reservoir_Exponential_Outlet>(
                     Reservoir_Exponential_Outlet(model_params.Cgw, model_params.expon, 0.0, max_gw_velocity));
             // Create the reservoir, passing the outlet via the vector argument
             groundwater_reservoir = Nonlinear_Reservoir(0.0, model_params.max_groundwater_storage_meters,


### PR DESCRIPTION
Pointer slicing in initializing groundwater exponential reservoir outlet was causing bad velocity computations.  Side note: turning off max flow threshold by initializing to largest double.

## Changes

- set max flow parameter for tshirt to near infinite (max double)
- make groundwater reservoir outlet pointer a real exponential outlet pointer


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
