### PR TITLE
Added more nonlinear reservoir parameters to hymod_params

### DIFF
--- a/test/models/hymod/include/HymodTest.cpp
+++ b/test/models/hymod/include/HymodTest.cpp
@@ -53,7 +53,7 @@ TEST_F(HymodKernelTest, TestRun0)
 {
     double et_storage = 0.0;
 
-    hymod_params params{1000.0, 1.0, 10.0, 0.1, 0.01, 3};
+    hymod_params params{0.0, 1000.0, 0.0, 0.0, 100.0, 1.0, 1.0, 0.1, 0.01, 3};
     double storage = 1.0;
 
     double reservior_storage[] = {1.0, 1.0, 1.0};
@@ -83,7 +83,7 @@ TEST_F(HymodKernelTest, TestWithKnownInput)
     std::vector< std::vector<double> > backing_storage;
 
     // initalize hymod params
-    hymod_params params{400.0, 0.5, 1.3, 0.2, 0.02, 3};
+    hymod_params params{0.0, 400.0, 0.0, 0.0, 100.0, 0.5, 1.0, 0.2, 0.02, 3};
 
     // initalize hymod state for time step zero
     backing_storage.push_back(std::vector<double>{0.0, 0.0, 0.0});


### PR DESCRIPTION
This PR addresses issue #93 to include clearer nonlinear reservoir param names, which are added to hymod_params.

## Additions
Nonlinear reservoir params are added to hymod_params in Hymod.h and HymodTest.cpp. 

## Removals
Previous hymod_params test inputs and hard coded parameter values to nonlinear reservoir instantiation in Hymod.h are removed.

## Testing

1. Passes existing unit tests


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
