### PR TITLE
Added more nonlinear reservoir parameters to hymod_params

### DIFF
--- a/models/hymod/include/Hymod.h
+++ b/models/hymod/include/Hymod.h
@@ -47,11 +47,11 @@ class hymod_kernel
         for ( unsigned long i = 0; i < nash_cascade.size(); ++i )
         {
             //construct a single outlet nonlinear reservoir
-            nash_cascade[i] = Nonlinear_Reservoir(0, params.max_storage_meters, state.Sr[i], params.Kq, 1, 0, 100);
+            nash_cascade[i] = Nonlinear_Reservoir(params.min_storage_meters, params.max_storage_meters, state.Sr[i], params.Kq, params.b, params.activation_threshold_meters_nash_cascade_reservoir, params.reservoir_max_velocity_meters_per_second);
         }
 
         // initalize groundwater reservoir
-        Nonlinear_Reservoir groundwater(0, params.max_storage_meters, state.groundwater_storage_meters, params.Ks, 1, 0, 100);
+        Nonlinear_Reservoir groundwater(params.min_storage_meters, params.max_storage_meters, state.groundwater_storage_meters, params.Ks, params.b, params.activation_threshold_meters_groundwater_reservoir, params.reservoir_max_velocity_meters_per_second);
 
         // add flux to the current state
         state.storage_meters += input_flux_meters;

--- a/models/hymod/include/hymod_params.h
+++ b/models/hymod/include/hymod_params.h
@@ -7,7 +7,11 @@
 */
 struct hymod_params
 {
+    double min_storage_meters; //!< minimum amount of water stored
     double max_storage_meters; //!< maximum amount of water stored
+    double activation_threshold_meters_nash_cascade_reservoir; //!< meters from the bottom of the reservoir to the bottom of the outlet
+    double activation_threshold_meters_groundwater_reservoir; //!< meters from the bottom of the reservoir to the bottom of the outlet
+    double reservoir_max_velocity_meters_per_second; //!<max outlet velocity in meters per second
     double a;               //!< coefficent for distributing runoff and slowflow
     double b;               //!< exponent for flux equation
     //Ks and Kq are coeeficint constants used by the non-linear reservoirs.  There is an implicit unit of time

--- a/test/models/hymod/include/HymodTest.cpp
+++ b/test/models/hymod/include/HymodTest.cpp
@@ -53,7 +53,7 @@ TEST_F(HymodKernelTest, TestRun0)
 {
     double et_storage = 0.0;
 
-    hymod_params params{1000.0, 1.0, 10.0, 0.1, 0.01, 3};
+    hymod_params params{0.0, 1000.0, 0.0, 0.0, 100.0, 1.0, 1.0, 0.1, 0.01, 3};
     double storage = 1.0;
 
     double reservior_storage[] = {1.0, 1.0, 1.0};
@@ -83,7 +83,7 @@ TEST_F(HymodKernelTest, TestWithKnownInput)
     std::vector< std::vector<double> > backing_storage;
 
     // initalize hymod params
-    hymod_params params{400.0, 0.5, 1.3, 0.2, 0.02, 3};
+    hymod_params params{0.0, 400.0, 0.0, 0.0, 100.0, 0.5, 1.0, 0.2, 0.02, 3};
 
     // initalize hymod state for time step zero
     backing_storage.push_back(std::vector<double>{0.0, 0.0, 0.0});


### PR DESCRIPTION
This PR addresses issue #93 to include clearer nonlinear reservoir param names, which are added to hymod_params.

Additions
Nonlinear reservoir params are added to hymod_params.h, Hymod.h, and HymodTest.cpp.

Removals
Previous hymod_params test inputs and hard coded parameter values to nonlinear reservoir instantiation in Hymod.h are removed.

Testing
Passes existing unit tests

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
