### PR TITLE
Fix move bug on std::ofstream in driver code

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -226,7 +226,7 @@ int main(int argc, char *argv[]) {
       }else{
         //Create nexus realization, add to map
         int num = std::stoi( feat_id.substr(4) );
-        nexus_outfiles[feat_id] = std::ofstream("./"+feature->get_id()+"_output.csv", std::ios::trunc);
+        nexus_outfiles[feat_id].open("./"+feature->get_id()+"_output.csv", std::ios::trunc);
 
         nexus_realizations[feat_id] = std::make_unique<HY_PointHydroNexus>(
                                       HY_PointHydroNexus(num, feat_id,


### PR DESCRIPTION
Closes #110 

## Changes

- directly `open()` the outfile stream instead of constructing the stream and assigning the open stream to the map

## Testing

1. Re-ran the driver locally and was able to produce the appropriate nexus outflows

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
