### PR TITLE
Further Tshirt code refactoring

### DIFF
--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -85,6 +85,19 @@ namespace tshirt {
 
     protected:
 
+        /**
+         * Perform necessary steps prior to the execution of model calculations for a new time step, for managing member
+         * variables that contain model state.
+         *
+         * This function is intended to be run only at the start of a new execution of the tshirt_model::run method.  It
+         * performs three housekeeping tasks needed before running the next group of time step modeling operations:
+         *
+         *      * the initial maintained `current_state` is moved to `previous_state`
+         *      * a new `current_state` is created
+         *      * a new `fluxes` is created
+         */
+        void manage_state_before_next_time_step_run();
+
         void set_mass_check_error_bound(double error_bound);
 
     private:

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -172,12 +172,12 @@ namespace tshirt {
          * Initialize the subsurface soil reservoir for the model, in the `soil_reservoir` member field.
          *
          * Initialize the subsurface soil reservoir for the model as a Nonlinear_Reservoir object, creating the reservoir
-         * with outlets for both the subsurface lateral flow and the percolation flow. This should only be used during
+         * with outlets for both the subsurface lateral flow and the percolation flow.  This should only be used during
          * object construction.
          *
          * Per the class type of the reservoir, outlets have an associated index value within a reservoir, and certain
-         * outlet-specific functionality requires having appropriate outlet index.  This function also sets corresponding
-         * index values of the lateral flow and percolation flow outlets within the lf_outlet_index and
+         * outlet-specific functionality requires having appropriate outlet index.  These outlet indexes are maintained in
+         * for the lateral flow and percolation flow outlets are maintained this class within the lf_outlet_index and
          * perc_outlet_index member variables respectively.
          *
          * @see Nonlinear_Reservoir

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -77,24 +77,41 @@ namespace tshirt {
          */
         double calc_soil_field_capacity_storage();
 
+        /**
+         * Return the smart pointer to the tshirt::tshirt_model struct for holding this object's current state.
+         *
+         * @return The smart pointer to the tshirt_model struct for holding this object's current state.
+         */
         shared_ptr<tshirt_state> get_current_state();
 
+        /**
+         * Return the shared pointer to the tshirt::tshirt_fluxes struct for holding this object's current fluxes.
+         *
+         * @return The shared pointer to the tshirt_fluxes struct for holding this object's current fluxes.
+         */
         shared_ptr<tshirt_fluxes> get_fluxes();
 
         double get_mass_check_error_bound();
 
-        int mass_check(double input_flux_meters, double timestep_seconds);
+        /**
+         * Check that mass was conserved by the model's calculations of the current time step.
+         *
+         * @param input_storage_m The amount of water input to the system at the time step, in meters.
+         * @param timestep_s The size of the time step, in seconds.
+         * @return The appropriate code value indicating whether mass was conserved in the current time step's calculations.
+         */
+        int mass_check(double input_storage_m, double timestep_s);
 
         /**
          * Run the model to one time step, after performing initial housekeeping steps via a call to
          * `manage_state_before_next_time_step_run`.
          *
          * @param dt the time step
-         * @param input_flux_meters the amount water entering the system this time step, in meters
+         * @param input_storage_m the amount water entering the system this time step, in meters
          * @param et_params ET parameters struct
          * @return
          */
-        int run(double dt, double input_flux_meters, shared_ptr<pdm03_struct> et_params);
+        int run(double dt, double input_storage_m, shared_ptr<pdm03_struct> et_params);
 
     protected:
 
@@ -111,6 +128,11 @@ namespace tshirt {
          */
         void manage_state_before_next_time_step_run();
 
+        /**
+         * Set the mass_check_error_bound member to the absolute value of the given parameter.
+         *
+         * @param error_bound The value used to set the mass_check_error_bound member.
+         */
         void set_mass_check_error_bound(double error_bound);
 
     private:

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -25,7 +25,6 @@ namespace tshirt {
      * Object oriented implementation of the Tshirt hydrological model, as documented at:
      *      https://github.com/NOAA-OWP/ngen/blob/master/doc/T-shirt_model_description.pdf
      *
-     *
      */
     class tshirt_model {
 
@@ -167,6 +166,19 @@ namespace tshirt {
          * previous_state are used for current storage of reservoirs at each given index.
          */
         void initialize_subsurface_lateral_flow_nash_cascade();
+
+        /**
+         * Perform necessary steps prior to the execution of model calculations for a new time step, for managing member
+         * variables that contain model state.
+         *
+         * This function is intended to be run only at the start of a new execution of the tshirt_model::run method.  It
+         * performs three housekeeping tasks needed before running the next group of time step modeling operations:
+         *
+         *      * the initial maintained `current_state` is moved to `previous_state`
+         *      * a new `current_state` is created
+         *      * a new `fluxes` is created
+         */
+        void manage_state_before_next_time_step_run();
 
     };
 }

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -22,91 +22,32 @@ namespace tshirt {
     /**
      * Tshirt model class.
      *
-     * A less static, more OO implementation of the Tshirt hydrological model.
+     * Object oriented implementation of the Tshirt hydrological model, as documented at:
+     *      https://github.com/NOAA-OWP/ngen/blob/master/doc/T-shirt_model_description.pdf
+     *
+     *
      */
     class tshirt_model {
 
     public:
 
-        tshirt_model(tshirt_params model_params,
-                     const shared_ptr<tshirt_state>& initial_state) : model_params(model_params),
-                                                                      previous_state(initial_state),
-                                                                      current_state(initial_state) {
-            // ********** Calculate Sfc, as this will get used a few times ...
-            double Sfc = calc_soil_field_capacity_storage();
+        /**
+         * Constructor for model object based on model parameters and initial state.
+         *
+         * @param model_params Model parameters tshirt_params struct.
+         * @param initial_state Shared smart pointer to tshirt_state struct hold initial state values
+         */
+        tshirt_model(tshirt_params model_params, const shared_ptr<tshirt_state>& initial_state);
 
-            // ********** Sanity check the size of the Nash Cascade storage vector in the state parameter.
-            // We expect the Nash size model parameter 'nash_n' to be equal to the size of the
-            // 'nash_cascade_storeage_meters' member of the passed 'initial_state param
-            if (initial_state->nash_cascade_storeage_meters.size() != model_params.nash_n) {
-                // Infer that empty vector should be initialized to a vector of size 'nash_n' with all 0.0 values
-                if (initial_state->nash_cascade_storeage_meters.empty()) {
-                    initial_state->nash_cascade_storeage_meters.resize(model_params.nash_n);
-                    for (unsigned i = 0; i < model_params.nash_n; ++i) {
-                        initial_state->nash_cascade_storeage_meters[i] = 0.0;
-                    }
-                }
-                else {
-
-                    cerr << "ERROR: Nash Cascade size parameter in tshirt model init doesn't match storage vector size";
-                    cerr << " in state parameter" << endl;
-                    // TODO: return error of some kind here
-                }
-            }
-
-            // ********** Create the vector of Nash Cascade reservoirs used at the end of the soil lateral flow outlet
-            soil_lf_nash_res.resize(model_params.nash_n);
-            // TODO: verify correctness of activation_threshold (Sfc) and max_velocity (max_lateral_flow) arg values
-            for (unsigned long i = 0; i < soil_lf_nash_res.size(); ++i) {
-                //construct a single outlet nonlinear reservoir
-                soil_lf_nash_res[i] = make_unique<Nonlinear_Reservoir>(
-                        Nonlinear_Reservoir(0.0, model_params.max_soil_storage_meters,
-                                            previous_state->nash_cascade_storeage_meters[i], model_params.Kn, 1.0,
-                                            0.0, model_params.max_lateral_flow));
-            }
-
-            // ********** Create the soil reservoir
-            // Build the vector of pointers to reservoir outlets
-            vector<std::shared_ptr<Reservoir_Outlet>> soil_res_outlets(2);
-
-            // init subsurface later flow outlet
-            soil_res_outlets[lf_outlet_index] = std::make_shared<Reservoir_Outlet>(
-                    Reservoir_Outlet(model_params.Klf, 1.0, Sfc, model_params.max_lateral_flow));
-
-            // init subsurface percolation flow outlet
-            // The max perc flow should be equal to the params.satdk value
-            soil_res_outlets[perc_outlet_index] = std::make_shared<Reservoir_Outlet>(
-                    Reservoir_Outlet(model_params.satdk * model_params.slope, 1.0, Sfc,
-                                     std::numeric_limits<double>::max()));
-            // Create the reservoir, included the created vector of outlet pointers
-            soil_reservoir = Nonlinear_Reservoir(0.0, model_params.max_soil_storage_meters, previous_state->soil_storage_meters,
-                                                 soil_res_outlets);
-
-            // ********** Create the groundwater reservoir
-            // Given the equation:
-            //      double groundwater_flow_meters_per_second = params.Cgw * ( exp(params.expon * state.groundwater_storage_meters / params.max_groundwater_storage_meters) - 1 );
-            // The max value should be when groundwater_storage_meters == max_groundwater_storage_meters, or ...
-            double max_gw_velocity = std::numeric_limits<double>::max();//model_params.Cgw * (exp(model_params.expon) - 1);
-
-            // Build vector of pointers to outlets to pass the custom exponential outlet through
-            vector<std::shared_ptr<Reservoir_Outlet>> gw_outlets_vector(1);
-            // TODO: verify activation threshold
-            gw_outlets_vector[0] = make_shared<Reservoir_Exponential_Outlet>(
-                    Reservoir_Exponential_Outlet(model_params.Cgw, model_params.expon, 0.0, max_gw_velocity));
-            // Create the reservoir, passing the outlet via the vector argument
-            groundwater_reservoir = Nonlinear_Reservoir(0.0, model_params.max_groundwater_storage_meters,
-                                                        previous_state->groundwater_storage_meters, gw_outlets_vector);
-
-            // ********** Set fluxes to null for now: it is bogus until first call of run function, which initializes it
-            fluxes = nullptr;
-
-            // ********** Set this statically to this default value
-            mass_check_error_bound = 0.000001;
-
-        }
-
-        tshirt_model(tshirt_params model_params) :
-            tshirt_model(model_params, make_shared<tshirt_state>(tshirt_state(0.0, 0.0))) {}
+        /**
+         * Constructor for model object with parameters only.
+         *
+         * Constructor creates a "default" initial state, with soil_storage_meters and groundwater_storage_meters set to
+         * 0.0, and then otherwise proceeds as the constructor accepting the second parameter for initial state.
+         *
+         * @param model_params Model parameters tshirt_params struct.
+         */
+        tshirt_model(tshirt_params model_params);
 
         /**
          * Calculate losses due to evapotranspiration.

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -25,6 +25,19 @@ namespace tshirt {
      * Object oriented implementation of the Tshirt hydrological model, as documented at:
      *      https://github.com/NOAA-OWP/ngen/blob/master/doc/T-shirt_model_description.pdf
      *
+     * The core logic for the model is implemented within the `run` function.  The resulting state calculated by a call
+     * to `run` is stored by a struct referenced via the `current_state` member.  A `previous_state` member also
+     * exists for holding the state prior to the most recent call to `run`.  Calculated fluxes are held by the `fluxes`
+     * member, for which there is not 'previous' analog.
+     *
+     * How state members are adjusted at the start of a call to `run` should be controlled via the implementation of
+     * `manage_state_before_next_time_step_run`.
+     *
+     * Calls to run will return the result of a nested call to `mass_check`, which performs mass balance verification on
+     * the calculated state at the end of a call to `run`.  The amount of acceptable difference is accessible with the
+     * `get_mass_check_error_bound` function.  It is also possible to change the value of this (hard-coded in the
+     * default implementation) with the protected `set_mass_check_error_bound` function.
+     *
      */
     class tshirt_model {
 
@@ -73,8 +86,8 @@ namespace tshirt {
         int mass_check(double input_flux_meters, double timestep_seconds);
 
         /**
-         * Run the model to one time step, moving the initial `current_state` value to `previous_state` and resetting
-         * other members applicable only to in the context of the current time step so that they are recalculated.
+         * Run the model to one time step, after performing initial housekeeping steps via a call to
+         * `manage_state_before_next_time_step_run`.
          *
          * @param dt the time step
          * @param input_flux_meters the amount water entering the system this time step, in meters
@@ -179,19 +192,6 @@ namespace tshirt {
          * previous_state are used for current storage of reservoirs at each given index.
          */
         void initialize_subsurface_lateral_flow_nash_cascade();
-
-        /**
-         * Perform necessary steps prior to the execution of model calculations for a new time step, for managing member
-         * variables that contain model state.
-         *
-         * This function is intended to be run only at the start of a new execution of the tshirt_model::run method.  It
-         * performs three housekeeping tasks needed before running the next group of time step modeling operations:
-         *
-         *      * the initial maintained `current_state` is moved to `previous_state`
-         *      * a new `current_state` is created
-         *      * a new `fluxes` is created
-         */
-        void manage_state_before_next_time_step_run();
 
     };
 }

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -126,7 +126,7 @@ namespace tshirt {
          *      * a new `current_state` is created
          *      * a new `fluxes` is created
          */
-        void manage_state_before_next_time_step_run();
+        virtual void manage_state_before_next_time_step_run();
 
         /**
          * Set the mass_check_error_bound member to the absolute value of the given parameter.

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -61,7 +61,7 @@ namespace tshirt {
         /**
          * Calculate soil field capacity storage, the level at which free drainage stops (i.e., "Sfc").
          *
-         * @return
+         * @return The calculated soil field capacity storage.
          */
         double calc_soil_field_capacity_storage();
 
@@ -113,6 +113,60 @@ namespace tshirt {
         shared_ptr<tshirt_fluxes> fluxes;
         /** The size of the error bound that is acceptable when performing mass check calculations. */
         double mass_check_error_bound;
+        /** Soil field capacity storage, or the level at which free drainage stops (i.e., "Sfc"). */
+        double soil_field_capacity_storage;
+
+        /**
+         * Check that the current state of this model object (which could be its provided initial state) is valid, printing
+         * a message and raising an error if not.
+         *
+         * The model parameter for Nash Cascade size, `nash_n`, must correspond appropriately to the size of referenced
+         * `current_state->nash_cascade_storeage_meters` vector.  The latter holds the storage values of the individual
+         * reservoirs within the Nash Cascade.  Note that the function will interpret any `nash_n` greater than `0` as valid
+         * if the vector itself is empty, and initialize such a vector to the correct size with all `0.0` values.
+         */
+        void check_valid();
+
+        /**
+         * Initialize the subsurface groundwater reservoir for the model, in the `groundwater_reservoir` member field.
+         *
+         * Initialize the subsurface groundwater reservoir for the model as a Nonlinear_Reservoir object, creating the
+         * reservoir with a single outlet.  In particular, this is a Reservoir_Exponential_Outlet object, since the outlet
+         * requires the following be used to calculate discharge flow:
+         *
+         *      Cgw * ( exp(expon * S / S_max) - 1 );
+         *
+         * Note that this function should only be used during object construction.
+         *
+         * @see Nonlinear_Reservoir
+         * @see Reservoir_Exponential_Outlet
+         */
+        void initialize_groundwater_reservoir();
+
+        /**
+         * Initialize the subsurface soil reservoir for the model, in the `soil_reservoir` member field.
+         *
+         * Initialize the subsurface soil reservoir for the model as a Nonlinear_Reservoir object, creating the reservoir
+         * with outlets for both the subsurface lateral flow and the percolation flow. This should only be used during
+         * object construction.
+         *
+         * Per the class type of the reservoir, outlets have an associated index value within a reservoir, and certain
+         * outlet-specific functionality requires having appropriate outlet index.  This function also sets corresponding
+         * index values of the lateral flow and percolation flow outlets within the lf_outlet_index and
+         * perc_outlet_index member variables respectively.
+         *
+         * @see Nonlinear_Reservoir
+         */
+        void initialize_soil_reservoir();
+
+        /**
+         * Initialize the Nash Cascade reservoirs applied to the subsurface soil reservoir's lateral flow outlet.
+         *
+         * Initialize the soil_lf_nash_res member, containing the collection of Nonlinear_Reservoir objects used to create
+         * the Nash Cascade for soil_reservoir lateral flow outlet.  The analogous values for Nash Cascade storage from
+         * previous_state are used for current storage of reservoirs at each given index.
+         */
+        void initialize_subsurface_lateral_flow_nash_cascade();
 
     };
 }

--- a/src/models/kernels/reservoir/Nonlinear_Reservoir.cpp
+++ b/src/models/kernels/reservoir/Nonlinear_Reservoir.cpp
@@ -72,6 +72,8 @@ Nonlinear_Reservoir::Nonlinear_Reservoir(double minimum_storage_meters, double m
     }
 }
 
+// TODO: expand docstring
+
 /**
  * @brief Function to update the nonlinear reservoir storage in meters and return a response in meters per second to
  * an influx and time step.

--- a/src/models/tshirt/Tshirt.cpp
+++ b/src/models/tshirt/Tshirt.cpp
@@ -8,6 +8,99 @@
 namespace tshirt {
 
     /**
+     * Constructor for model object based on model parameters and initial state.
+     *
+     * @param model_params Model parameters tshirt_params struct.
+     * @param initial_state Shared smart pointer to tshirt_state struct hold initial state values
+     */
+    tshirt_model::tshirt_model(tshirt_params model_params, const shared_ptr<tshirt_state> &initial_state)
+            : model_params(model_params), previous_state(initial_state), current_state(initial_state)
+    {
+        // ********** Calculate Sfc, as this will get used a few times ...
+        double Sfc = calc_soil_field_capacity_storage();
+
+        // ********** Sanity check the size of the Nash Cascade storage vector in the state parameter.
+        // We expect the Nash size model parameter 'nash_n' to be equal to the size of the
+        // 'nash_cascade_storeage_meters' member of the passed 'initial_state param
+        if (initial_state->nash_cascade_storeage_meters.size() != model_params.nash_n) {
+            // Infer that empty vector should be initialized to a vector of size 'nash_n' with all 0.0 values
+            if (initial_state->nash_cascade_storeage_meters.empty()) {
+                initial_state->nash_cascade_storeage_meters.resize(model_params.nash_n);
+                for (unsigned i = 0; i < model_params.nash_n; ++i) {
+                    initial_state->nash_cascade_storeage_meters[i] = 0.0;
+                }
+            }
+            else {
+
+                cerr << "ERROR: Nash Cascade size parameter in tshirt model init doesn't match storage vector size";
+                cerr << " in state parameter" << endl;
+                // TODO: return error of some kind here
+            }
+        }
+
+        // ********** Create the vector of Nash Cascade reservoirs used at the end of the soil lateral flow outlet
+        soil_lf_nash_res.resize(model_params.nash_n);
+        // TODO: verify correctness of activation_threshold (Sfc) and max_velocity (max_lateral_flow) arg values
+        for (unsigned long i = 0; i < soil_lf_nash_res.size(); ++i) {
+            //construct a single outlet nonlinear reservoir
+            soil_lf_nash_res[i] = make_unique<Nonlinear_Reservoir>(
+                    Nonlinear_Reservoir(0.0, model_params.max_soil_storage_meters,
+                                        previous_state->nash_cascade_storeage_meters[i], model_params.Kn, 1.0,
+                                        0.0, model_params.max_lateral_flow));
+        }
+
+        // ********** Create the soil reservoir
+        // Build the vector of pointers to reservoir outlets
+        vector<std::shared_ptr<Reservoir_Outlet>> soil_res_outlets(2);
+
+        // init subsurface later flow outlet
+        soil_res_outlets[lf_outlet_index] = std::make_shared<Reservoir_Outlet>(
+                Reservoir_Outlet(model_params.Klf, 1.0, Sfc, model_params.max_lateral_flow));
+
+        // init subsurface percolation flow outlet
+        // The max perc flow should be equal to the params.satdk value
+        soil_res_outlets[perc_outlet_index] = std::make_shared<Reservoir_Outlet>(
+                Reservoir_Outlet(model_params.satdk * model_params.slope, 1.0, Sfc,
+                                 std::numeric_limits<double>::max()));
+        // Create the reservoir, included the created vector of outlet pointers
+        soil_reservoir = Nonlinear_Reservoir(0.0, model_params.max_soil_storage_meters, previous_state->soil_storage_meters,
+                                             soil_res_outlets);
+
+        // ********** Create the groundwater reservoir
+        // Given the equation:
+        //      double groundwater_flow_meters_per_second = params.Cgw * ( exp(params.expon * state.groundwater_storage_meters / params.max_groundwater_storage_meters) - 1 );
+        // The max value should be when groundwater_storage_meters == max_groundwater_storage_meters, or ...
+        double max_gw_velocity = std::numeric_limits<double>::max();//model_params.Cgw * (exp(model_params.expon) - 1);
+
+        // Build vector of pointers to outlets to pass the custom exponential outlet through
+        vector<std::shared_ptr<Reservoir_Outlet>> gw_outlets_vector(1);
+        // TODO: verify activation threshold
+        gw_outlets_vector[0] = make_shared<Reservoir_Exponential_Outlet>(
+                Reservoir_Exponential_Outlet(model_params.Cgw, model_params.expon, 0.0, max_gw_velocity));
+        // Create the reservoir, passing the outlet via the vector argument
+        groundwater_reservoir = Nonlinear_Reservoir(0.0, model_params.max_groundwater_storage_meters,
+                                                    previous_state->groundwater_storage_meters, gw_outlets_vector);
+
+        // ********** Set fluxes to null for now: it is bogus until first call of run function, which initializes it
+        fluxes = nullptr;
+
+        // ********** Set this statically to this default value
+        mass_check_error_bound = 0.000001;
+
+    }
+
+    /**
+     * Constructor for model object with parameters only.
+     *
+     * Constructor creates a "default" initial state, with soil_storage_meters and groundwater_storage_meters set to
+     * 0.0, and then otherwise proceeds as the constructor accepting the second parameter for initial state.
+     *
+     * @param model_params Model parameters tshirt_params struct.
+     */
+    tshirt_model::tshirt_model(tshirt_params model_params) :
+        tshirt_model(model_params, make_shared<tshirt_state>(tshirt_state(0.0, 0.0))) {}
+
+    /**
      * Calculate losses due to evapotranspiration.
      *
      * @param soil_m The soil moisture measured in meters.

--- a/src/models/tshirt/Tshirt.cpp
+++ b/src/models/tshirt/Tshirt.cpp
@@ -117,8 +117,8 @@ namespace tshirt {
      * object construction.
      *
      * Per the class type of the reservoir, outlets have an associated index value within a reservoir, and certain
-     * outlet-specific functionality requires having appropriate outlet index.  This function also sets corresponding
-     * index values of the lateral flow and percolation flow outlets within the lf_outlet_index and
+     * outlet-specific functionality requires having appropriate outlet index.  These outlet indexes are maintained in
+     * for the lateral flow and percolation flow outlets are maintained this class within the lf_outlet_index and
      * perc_outlet_index member variables respectively.
      *
      * @see Nonlinear_Reservoir

--- a/src/models/tshirt/Tshirt.cpp
+++ b/src/models/tshirt/Tshirt.cpp
@@ -261,8 +261,8 @@ namespace tshirt {
     }
 
     /**
-     * Run the model to one time step, moving the initial `current_state` value to `previous_state` and resetting
-     * other members applicable only in the context of the current time step so that they are recalculated.
+     * Run the model to one time step, after performing initial housekeeping steps via a call to
+     * `manage_state_before_next_time_step_run`.
      *
      * @param dt the time step size in seconds
      * @param input_flux_meters the amount water entering the system this time step, in meters

--- a/src/models/tshirt/Tshirt.cpp
+++ b/src/models/tshirt/Tshirt.cpp
@@ -269,11 +269,8 @@ namespace tshirt {
      * @return
      */
     int tshirt_model::run(double dt, double input_flux_meters, shared_ptr<pdm03_struct> et_params) {
-        // Do resetting/housekeeping for new calculations
-        // TODO: move this to separate small function; e.g., reset_state_members_for_next_time_step_run
-        previous_state = current_state;
-        current_state = make_shared<tshirt_state>(tshirt_state(0.0, 0.0, vector<double>(model_params.nash_n)));
-        fluxes = make_shared<tshirt_fluxes>(tshirt_fluxes(0.0, 0.0, 0.0, 0.0, 0.0));
+        // Do resetting/housekeeping for new calculations and new state values
+        manage_state_before_next_time_step_run();
 
         double soil_column_moisture_deficit =
                 model_params.max_soil_storage_meters - previous_state->soil_storage_meters;
@@ -326,6 +323,24 @@ namespace tshirt {
         //fluxes->surface_runoff_meters_per_second = surface_runoff;
 
         return mass_check(input_flux_meters, dt);
+    }
+
+    /**
+     * Perform necessary steps prior to the execution of model calculations for a new time step, for managing member
+     * variables that contain model state.
+     *
+     * This function is intended to be run only at the start of a new execution of the tshirt_model::run method.  It
+     * performs three housekeeping tasks needed before running the next group of time step modeling operations:
+     *
+     *      * the initial maintained `current_state` is moved to `previous_state`
+     *      * a new `current_state` is created
+     *      * a new `fluxes` is created
+     */
+    void tshirt_model::manage_state_before_next_time_step_run()
+    {
+        previous_state = current_state;
+        current_state = make_shared<tshirt_state>(tshirt_state(0.0, 0.0, vector<double>(model_params.nash_n)));
+        fluxes = make_shared<tshirt_fluxes>(tshirt_fluxes(0.0, 0.0, 0.0, 0.0, 0.0));
     }
 
     /**


### PR DESCRIPTION
Additional refactoring and documenting of Tshirt code.

## Changes

- Moving `tshirt_model` constructor definitions to .cpp file instead of header.
- Organizing sections of logic into more cohesive, smaller scoped functions with descriptive names (especially in `tshirt_model` constructor).
- Expanding and improving docstrings.
