### PR TITLE
Making adjustments getting reservoir response in Tshirt model

### DIFF
--- a/src/models/kernels/reservoir/Reservoir.cpp
+++ b/src/models/kernels/reservoir/Reservoir.cpp
@@ -118,6 +118,22 @@ namespace Reservoir{
             //Update current storage from influx multiplied by delta time.
             state.current_storage_height_meters += in_flux_meters_per_second * delta_time_seconds;
 
+            //If storage is greater than maximum storage, set to maximum storage and return excess water.
+            if (state.current_storage_height_meters > parameters.maximum_storage_meters)
+            {
+                /// \todo TODO: Return appropriate warning
+                cout << "WARNING: Reservoir calculated a storage above the maximum storage."  << endl;
+
+                state.current_storage_height_meters = parameters.maximum_storage_meters;
+
+                excess_water_meters = (state.current_storage_height_meters - parameters.maximum_storage_meters);
+            }
+            // TODO: since we are now doing this first, does it make sense to add the excess back into the storage if there is
+            //  room after outlet flow loss is accounted for?
+
+            // TODO: should we break up the calculations into smaller amounts, if the timestep is relatively (hour, day, etc.)
+
+
             //Loop through reservoir outlets.
             for (auto& outlet : this->outlets) //pointer to outlets
             {

--- a/src/models/kernels/reservoir/Reservoir.cpp
+++ b/src/models/kernels/reservoir/Reservoir.cpp
@@ -123,10 +123,8 @@ namespace Reservoir{
             {
                 /// \todo TODO: Return appropriate warning
                 cout << "WARNING: Reservoir calculated a storage above the maximum storage."  << endl;
-
+                excess_water_meters = state.current_storage_height_meters - parameters.maximum_storage_meters;
                 state.current_storage_height_meters = parameters.maximum_storage_meters;
-
-                excess_water_meters = (state.current_storage_height_meters - parameters.maximum_storage_meters);
             }
             // TODO: since we are now doing this first, does it make sense to add the excess back into the storage if there is
             //  room after outlet flow loss is accounted for?

--- a/src/models/kernels/reservoir/Reservoir.cpp
+++ b/src/models/kernels/reservoir/Reservoir.cpp
@@ -126,11 +126,6 @@ namespace Reservoir{
                 excess_water_meters = state.current_storage_height_meters - parameters.maximum_storage_meters;
                 state.current_storage_height_meters = parameters.maximum_storage_meters;
             }
-            // TODO: since we are now doing this first, does it make sense to add the excess back into the storage if there is
-            //  room after outlet flow loss is accounted for?
-
-            // TODO: should we break up the calculations into smaller amounts, if the timestep is relatively (hour, day, etc.)
-
 
             //Loop through reservoir outlets.
             for (auto& outlet : this->outlets) //pointer to outlets
@@ -141,6 +136,21 @@ namespace Reservoir{
 
                 //Update storage from outlet velocity multiplied by delta time.
                 state.current_storage_height_meters -= outlet_velocity_meters_per_second * delta_time_seconds;
+
+                // TODO: review whether this is the best way to handle this (e.g., should we break up the calculations
+                //  into smaller amounts?)
+                // If there was excess water from the influx that exceeded the max earlier (as calculated above) but
+                // will now fit, then add it in
+                if (excess_water_meters > 0) {
+                    if (excess_water_meters > parameters.maximum_storage_meters - state.current_storage_height_meters) {
+                        excess_water_meters -= parameters.maximum_storage_meters - state.current_storage_height_meters;
+                        state.current_storage_height_meters = parameters.maximum_storage_meters;
+                    }
+                    else {
+                        state.current_storage_height_meters += excess_water_meters;
+                        excess_water_meters = 0;
+                    }
+                }
 
                 //If storage is less than minimum storage.
                 if (state.current_storage_height_meters < parameters.minimum_storage_meters)
@@ -163,14 +173,6 @@ namespace Reservoir{
 
                 //Add outlet velocity to the sum of velocities.
                 sum_of_outlet_velocities_meters_per_second += outlet_velocity_meters_per_second;
-            }
-
-            //If storage is greater than maximum storage, set to maximum storage and return excess water.
-            if (state.current_storage_height_meters > parameters.maximum_storage_meters) {
-                /// \todo TODO: Return appropriate warning
-                cout << "WARNING: Reservoir calculated a storage above the maximum storage."  << endl;
-                excess_water_meters = state.current_storage_height_meters - parameters.maximum_storage_meters;
-                state.current_storage_height_meters = parameters.maximum_storage_meters;
             }
 
             //Ensure that excess_water_meters is not negative

--- a/src/models/tshirt/Tshirt.cpp
+++ b/src/models/tshirt/Tshirt.cpp
@@ -333,7 +333,7 @@ namespace tshirt {
         // Save "raw" runoff here and have realization class calculate GIUH surface runoff using that kernel
         // TODO: for now add this to runoff, but later adjust calculations to limit flow into reservoir to avoid excess
         fluxes->surface_runoff_meters_per_second = surface_runoff + (subsurface_excess / dt) + (excess_gw_water / dt);
-        //fluxes->surface_runoff_meters_per_second = surface_runoff;
+        //fluxes->surface_runoff_meters_per_second = surface_runoff_depth_m;
 
         return mass_check(input_storage_m, dt);
     }

--- a/src/models/tshirt/Tshirt.cpp
+++ b/src/models/tshirt/Tshirt.cpp
@@ -293,7 +293,8 @@ namespace tshirt {
                                     &surface_runoff, &subsurface_infiltration_flux);
 
         double subsurface_excess, nash_subsurface_excess;
-        soil_reservoir.response_meters_per_second(subsurface_infiltration_flux, dt, subsurface_excess);
+        double mean_timestep_infiltration_m_per_s = subsurface_infiltration_flux / dt;
+        soil_reservoir.response_meters_per_second(mean_timestep_infiltration_m_per_s, (int)dt, subsurface_excess);
 
         // lateral subsurface flow
         double Qlf = soil_reservoir.velocity_meters_per_second_for_outlet(lf_outlet_index);

--- a/test/models/hymod/include/Reservoir_Test.cpp
+++ b/test/models/hymod/include/Reservoir_Test.cpp
@@ -444,11 +444,11 @@ TEST_F(ReservoirKernelTest, TestRunMultipleOutletReservoirOutletVelocityOutOfBou
 
     MultipleOutletReservoir->response_meters_per_second(in_flux_meters_per_second, 10, excess);
 
-    first_outlet_velocity = MultipleOutletReservoir->velocity_meters_per_second_for_outlet(6);
+    first_outlet_velocity = MultipleOutletReservoir->velocity_meters_per_second_for_outlet(2);
 
     first_outlet_velocity = round( first_outlet_velocity * 100.0 ) / 100.0;
 
-    EXPECT_DOUBLE_EQ (1.05, first_outlet_velocity);
+    EXPECT_DOUBLE_EQ (0.40, first_outlet_velocity);
     
     ASSERT_TRUE(true);
 }


### PR DESCRIPTION
Changes for issue #128.

Note in particular that while initially the idea was to change `response_meters_per_second` to have the first parameter be something in meter rather than meters per second, I have removed this and instead make that adjustment within the logic of _tshirt_model_.  That was the only place known thus far to try to pass meters-based value, rather than in the expected meters-per-second.  Conversely, there are many places that are passing in meters-per-second values, so it seems to make more sense to convert once, fixing the Tshirt logic, than to change the _Reservoir_ class and then have to adjust many other things depending on it.  However, this can be discussed further if needed. 