### PR TITLE
Update Boost requirement and account for possible test path issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
     endif()
 endif()
 
-find_package(Boost 1.69.0 REQUIRED)
+find_package(Boost 1.72.0 REQUIRED)
 
 target_include_directories(ngen PUBLIC
         "${PROJECT_BINARY_DIR}/include" # For generated config header file in binary tree

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -7,7 +7,7 @@
 | [Google Test](#google-test) | submodule  | `release-1.10.0` | |
 | [C/C++ Compiler](#c-and-c-compiler) | external | see below |  |
 | [CMake](#cmake) | external | \> `3.10` | |
-| [Boost.Geometry](#boostgeometry) | external | `1.72.0` suggested | headers only library |
+| [Boost (Headers Only)](#boost-headers-only) | external | `1.72.0` | headers only library |
 
 # Details
 
@@ -71,17 +71,19 @@ However, a [CMake build system](BUILDS_AND_CMAKE.md#generating-a-build-system) m
 
 Currently, a version of CMake >= `3.10.0` is required.
 
-## Boost.Geometry
+## Boost (Headers Only)
 
-The [Boost.Geometry](https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/compilation.html) library is used by the project and must be included.
+Boost libraries are used by this project.  In particular, [Boost.Geometry](https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/compilation.html) is used, but others are also.  
 
-Note that this library is header-only.
+Currently, only headers-only Boost libraries are utilized.  As such, they are not exhaustively listed here since getting one essentially gets them all.
 
 ### Setup
 
-Since the library is header only, no binaries or compilation are required.  The Boost headers only need to be available on the local machine. 
+Since only headers-only libraries are needed, the Boost headers simply need to be available on the local machine at a location the build process can find.
 
-There are a variety of different ways to get the Boost headers locally.  Various OS may have packages specifically to install them.  Alternatively, the Boost distribution itself can be manually downloaded and unpacked, as described for both [Unix-variants](https://www.boost.org/doc/libs/1_72_0/more/getting_started/unix-variants.html) and [Windows](https://www.boost.org/doc/libs/1_72_0/more/getting_started/windows.html) on the Boost website.
+There are a variety of different ways to get the Boost headers locally.  Various OS may have packages specifically to install them, though one should take note of whether such packages provide a version of Boost that meets this project's requirements.  
+
+Alternatively, the Boost distribution itself can be manually downloaded and unpacked, as described for both [Unix-variants](https://www.boost.org/doc/libs/1_72_0/more/getting_started/unix-variants.html) and [Windows](https://www.boost.org/doc/libs/1_72_0/more/getting_started/windows.html) on the Boost website.
 
 #### Setting **BOOST_ROOT**
 
@@ -93,4 +95,4 @@ The variable should be set to the value of the **boost root directory**, which i
 
 ### Version Requirements
 
-At present, there is only the *recommendation* to use version `1.72.0`.
+At present, a version >= `1.72.0` is required.

--- a/test/core/catchment/giuh/GIUH_Test.cpp
+++ b/test/core/catchment/giuh/GIUH_Test.cpp
@@ -10,15 +10,23 @@ protected:
 
     GIUH_Test()
     {
-        std::vector<std::string> abridged_choices = {"../test/data/giuh/GIUH_abridged.json",
-                                                     "test/data/giuh/GIUH_abridged.json"};
+        std::vector<std::string> abridged_choices = {"test/data/giuh/GIUH_abridged.json",
+                                                     "../test/data/giuh/GIUH_abridged.json",
+                                                     "../../test/data/giuh/GIUH_abridged.json",
+                                                     "data/giuh/GIUH_abridged.json"};
         abridged_json_file = utils::FileChecker::find_first_readable(abridged_choices);
 
-        std::vector<std::string> complete_choices = {"../test/data/giuh/GIUH.json", "test/data/giuh/GIUH.json"};
+        std::vector<std::string> complete_choices = {"test/data/giuh/GIUH.json",
+                                                     "../test/data/giuh/GIUH.json",
+                                                     "../../test/data/giuh/GIUH.json",
+                                                     "data/giuh/GIUH.json"};
         complete_json_file = utils::FileChecker::find_first_readable(complete_choices);
 
         std::vector<std::string> id_map_choices = {"../data/crosswalk.json",
-                                                   "data/crosswalk.json"};
+                                                   "data/crosswalk.json",
+                                                   "data/sugar_creek/crosswalk_subset.json",
+                                                   "../data/sugar_creek/crosswalk_subset.json",
+                                                   "../../data/sugar_creek/crosswalk_subset.json"};
         id_map_json_file = utils::FileChecker::find_first_readable(id_map_choices);
     }
 
@@ -120,7 +128,8 @@ TEST_F(GIUH_Test, TestOutput1)
     // First make sure we have the file, looking in a few different places
     std::vector<std::string> possible_files = {"./giuh_test_samples.json", "../giuh_test_samples.json",
                                                "./test/data/giuh/giuh_test_samples.json",
-                                               "../test/data/giuh/giuh_test_samples.json"};
+                                               "../test/data/giuh/giuh_test_samples.json",
+                                               "../../test/data/giuh/giuh_test_samples.json"};
     std::string sample_data_file;
     bool found_sample_data_file = false;
 
@@ -179,7 +188,8 @@ TEST_F(GIUH_Test, TestOutput2) {
     // First make sure we have the file, looking in a few different places
     std::vector<std::string> possible_files = {"./giuh_test_samples.json", "../giuh_test_samples.json",
                                                "./test/data/giuh/giuh_test_samples.json",
-                                               "../test/data/giuh/giuh_test_samples.json"};
+                                               "../test/data/giuh/giuh_test_samples.json",
+                                               "../../test/data/giuh/giuh_test_samples.json"};
     std::string sample_data_file;
     bool found_sample_data_file = false;
 

--- a/test/forcing/Forcing_Test.cpp
+++ b/test/forcing/Forcing_Test.cpp
@@ -57,8 +57,9 @@ void ForcingTest::TearDown() {
 //Construct a forcing object
 void ForcingTest::setupForcing()
 {
-    std::vector<std::string> forcing_file_names = { "../test/forcing/Sample_Tropical_Hourly_Rainfall.csv",
-                                                    "test/forcing/Sample_Tropical_Hourly_Rainfall.csv" };
+    std::vector<std::string> forcing_file_names = { "test/forcing/Sample_Tropical_Hourly_Rainfall.csv",
+                                                    "../test/forcing/Sample_Tropical_Hourly_Rainfall.csv",
+                                                    "../../test/forcing/Sample_Tropical_Hourly_Rainfall.csv" };
     std::string forcing_file_name = utils::FileChecker::find_first_readable(forcing_file_names);
 
     start_date_time = std::make_shared<time_type>();
@@ -83,8 +84,9 @@ void ForcingTest::setupForcing()
 void ForcingTest::setupForcing_AORC()
 {
     std::vector<std::string> forcing_file_names_AORC = {
+            "test/forcing/cat-10_2015-12-01 00_00_00_2015-12-30 23_00_00.csv",
             "../test/forcing/cat-10_2015-12-01 00_00_00_2015-12-30 23_00_00.csv",
-            "test/forcing/cat-10_2015-12-01 00_00_00_2015-12-30 23_00_00.csv"
+            "../../test/forcing/cat-10_2015-12-01 00_00_00_2015-12-30 23_00_00.csv"
     };
 
     std::string forcing_file_name_AORC = utils::FileChecker::find_first_readable(forcing_file_names_AORC);

--- a/test/models/hymod/include/HymodTest.cpp
+++ b/test/models/hymod/include/HymodTest.cpp
@@ -10,6 +10,7 @@
 
 #include "gtest/gtest.h"
 #include "hymod/include/Hymod.h"
+#include "FileChecker.h"
 
 class HymodKernelTest : public ::testing::Test {
 
@@ -101,18 +102,19 @@ TEST_F(HymodKernelTest, TestWithKnownInput)
 
     double latitude = 41.13;
 
-    // open the file that contains forcings
-    std::ifstream input_file("test/data/model/hymod/hymod_forcing.txt");
+    std::vector<std::string> hymod_forcing_choices = {"test/data/model/hymod/hymod_forcing.txt",
+                                                 "../test/data/model/hymod/hymod_forcing.txt",
+                                                 "../../test/data/model/hymod/hymod_forcing.txt",
+                                                 "data/model/hymod/hymod_forcing.txt"};
+    std::string input_file_name = utils::FileChecker::find_first_readable(hymod_forcing_choices);
 
-    if ( !input_file )
-    {
-        // Account for possibly being within build directory also
-        input_file.open("../test/data/model/hymod/hymod_forcing.txt");
-        if (!input_file) {
-            std::cerr << "Test file not found\n";
-            ASSERT_TRUE(false);
-        }
+    if (input_file_name.empty()) {
+        std::cerr << "Test file not found\n";
+        ASSERT_TRUE(false);
     }
+
+    // open the file that contains forcings
+    std::ifstream input_file(input_file_name.c_str());
 
     // read forcing from the input file
     std::string buffer;


### PR DESCRIPTION
Primarily, this updates the dependency documentation and the CMake build configuration to move to requiring Boost libraries >= version 1.72.0.  This addresses issue #149.

Additionally, there are minor changes to the following file that append additional possible paths to search when looking for testing data:

- GIUH_Test.cpp
- Forcing_Test.cpp
- HymodTest.cpp

All tests pass in the local environment.
