### PR TITLE
Build collection subset feature

### DIFF
--- a/include/geojson/FeatureBuilder.hpp
+++ b/include/geojson/FeatureBuilder.hpp
@@ -471,11 +471,25 @@ namespace geojson {
         return build_collection(tree);
     }
 
+    static GeoJSON read(const std::string &file_path, std::vector<std::string> &ids) {
+        boost::property_tree::ptree tree;
+        boost::property_tree::json_parser::read_json(file_path, tree);
+        return build_collection(tree, ids);
+    }
+
     static GeoJSON read(std::stringstream &data) {
         boost::property_tree::ptree tree;
         boost::property_tree::json_parser::read_json(data, tree);
         return build_collection(tree);
     }
+
+    static GeoJSON read(std::stringstream &data, std::vector<std::string> &ids) {
+        boost::property_tree::ptree tree;
+        boost::property_tree::json_parser::read_json(data, tree);
+        return build_collection(tree, ids);
+    }
+
+
 }
 
 #endif // GEOJSON_FEATURE_BUILDER_H

--- a/src/geojson/FeatureCollection.cpp
+++ b/src/geojson/FeatureCollection.cpp
@@ -4,7 +4,10 @@
 using namespace geojson;
 
 Feature FeatureCollection::get_feature(int index) const {
-    return features[index];
+    if( index >= 0 && index < features.size() )
+      return features[index];
+    else
+      return nullptr;
 }
 
 int FeatureCollection::find(Feature feature) {

--- a/test/geojson/FeatureCollection_Test.cpp
+++ b/test/geojson/FeatureCollection_Test.cpp
@@ -56,7 +56,10 @@ class Visitor : public geojson::FeatureVisitor {
         }
 
         std::string get(int index) {
-            return this->types[index];
+            if( index >= 0 && index < types.size() )
+              return this->types[index];
+            else
+              return "NULL";
         }
 
     private:
@@ -128,4 +131,72 @@ TEST_F(FeatureCollection_Test, ptree_test) {
 
     ASSERT_EQ(visitor.get(0), "PointFeature");
     ASSERT_EQ(visitor.get(1), "LineStringFeature");
+}
+
+TEST_F(FeatureCollection_Test, subset_test) {
+    std::string data = "{ "
+        "\"type\": \"FeatureCollection\", "
+        "\"bbox\": [1, 2, 3, 4, 5 ], "
+        "\"features\": [ "
+            "{ "
+                "\"type\": \"Feature\", "
+                "\"id\": \"First\", "
+                "\"geometry\": { "
+                "    \"type\": \"Point\", "
+                "    \"coordinates\": [102.0, 0.5] "
+                "} "
+            "}, "
+            "{ "
+                "\"type\": \"Feature\", "
+                "\"id\": \"Second\", "
+                "\"geometry\": { "
+                    "\"type\": \"LineString\", "
+                    "\"coordinates\": [ "
+                        "[102.0, 0.0], "
+                        "[103.0, 1.0], "
+                        "[104.0, 0.0], "
+                        "[105.0, 1.0] "
+                    "] "
+                "} "
+            "} "
+        "] "
+        "}";
+
+    std::stringstream stream;
+    stream << data;
+    std::vector<std::string> subset = {"First"};
+
+    geojson::GeoJSON collection = geojson::read(stream, subset);
+
+    std::vector<double> bbox = collection->get_bounding_box();
+    ASSERT_EQ(bbox.size(), 5);
+    ASSERT_EQ(bbox[0], 1.0);
+    ASSERT_EQ(bbox[1], 2.0);
+    ASSERT_EQ(bbox[2], 3.0);
+    ASSERT_EQ(bbox[3], 4.0);
+    ASSERT_EQ(bbox[4], 5.0);
+    //Should only have the first feature in the collection
+    ASSERT_EQ(1, collection->get_size());
+
+    geojson::Feature first = collection->get_feature(0);
+    geojson::Feature second = collection->get_feature(1);
+
+    ASSERT_EQ(first->get_id(), "First");
+
+    ASSERT_TRUE(second == nullptr);
+    ASSERT_EQ(first->get_type(), geojson::FeatureType::Point);
+
+    ASSERT_TRUE(first->is_leaf());
+    ASSERT_TRUE(first->is_root());
+
+    ASSERT_EQ(collection->get_feature("First"), first);
+    ASSERT_EQ(collection->get_feature("Second"), nullptr);
+
+    Visitor visitor;
+
+    collection->visit_features(visitor);
+
+    ASSERT_EQ(visitor.get(0), "PointFeature");
+    ASSERT_EQ(visitor.get(1), "NULL");
+    std::cout<<"HERE\n";
 }


### PR DESCRIPTION
Add the ability to read a GeoJSON file but only return a collection of features specified by a list of string identifiers.
Also, fixes #158 

## Additions

FeatureBuilder.h
- `static GeoJSON read(std::stringstream &data, std::vector<std::string> &ids)`
- `static GeoJSON read(const std::string &file_path, std::vector<std::string> &ids)`
- `static GeoJSON build_collection(const boost::property_tree::ptree tree, std::vector<std::string> ids)`

## Changes

-  Bug fix in `FeatureCollection::get_feature(int index)`

## Testing

Unit test for reading subset collection included in `FeatureCollection_Test`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

New and existing tests pass locally
```
[==========] 75 tests from 12 test suites ran. (2909 ms total)
[  PASSED  ] 75 tests.
```

### Target Environment support

- [x] Linux
- [x] MacOS
