### PR TITLE
Reservoir_Timeless response_meters function excess_meters_initialized to 0.

### DIFF
--- a/src/models/kernels/reservoir/Reservoir_Timeless.cpp
+++ b/src/models/kernels/reservoir/Reservoir_Timeless.cpp
@@ -98,14 +98,20 @@ namespace Reservoir{
          * @brief Function to update the reservoir storage in meters and return a response in meters to
          * an influx.
          *
+         * Note that the function also takes a reference parameter for holding the amount of excess water for the reservoir
+         * beyond its maximum storage after accounting for the input amount.  All calls to this function will initialize this
+         * parameter, without accounting for any previous value, so any usage should ensure the passed reference does not
+         * contain a value that is still needed but not stored elsewhere.
+         *
          * @param in_flux_meters influx in meters
-         * @param excess_water_meters excess water in meters
+         * @param excess_water_meters Reference to an amount of excess water in meters, after considering input and max storage.
          * @return sum_of_outlet_fluxes_meters sum of the outlet fluxes in meters
          */
         double Reservoir::response_meters(double in_flux_meters, double &excess_water_meters)
         {
             double outlet_flux_meters = 0;
             double sum_of_outlet_fluxes_meters = 0;
+            excess_water_meters = 0;
 
             //Update current storage from influx.
             state.current_storage_height_meters += in_flux_meters;
@@ -148,9 +154,7 @@ namespace Reservoir{
             {
                 /// \todo TODO: Return appropriate warning
                 cout << "WARNING: Reservoir calculated a storage above the maximum storage."  << endl;
-
                 excess_water_meters = (state.current_storage_height_meters - parameters.maximum_storage_meters);
-
                 state.current_storage_height_meters = parameters.maximum_storage_meters;
             }
 


### PR DESCRIPTION
Initialized excess_water_meters to 0 in Reservoir_Timeless response_meters function and added corresponding comments.

## Testing

1. Passes all reservoir related unit tests.
2. Current master does fail these two tests:
[  FAILED  ] Formulation_Manager_Test.basic_reading
[  FAILED  ] Formulation_Manager_Test.basic_run
Possibly something being worked on that I am unaware of.

## Notes
@robertbartel has made this same fix to Reservoir.cpp

Fixes #124 

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
