### PR TITLE
Simple cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,20 @@ If the software is configurable, describe it in detail, either here or in other 
 
 ## Usage
 
-Show users how to use the software.
-Be specific.
-Use appropriate formatting when showing code snippets.
+To run the *ngen* engine, the following command line positional arguments are supported:
+- `catchment_data_path` -- path to catchment data geojson input file.
+- `catchment subset ids` -- list of comma separated ids (NO SPACES!!!) to subset the catchment data, i.e. 'cat-0,cat-1'
+- `nexus_data_path` -- path to nexus data geojson input file
+- `nexus subset ids` -- list of comma separated ids (NO SPACES!!!) to subset the nexus data, i.e. 'nex-0,nex-1'
+- `realization_config_path` -- path to json configuration file for realization/formulations associated with the hydrofabric inputs.
+
+An example of a complete invocation to run a subset of a hydrofabric.  
+Note if the `realization_config` config doesn't explicitly define only the subset catchments
+in the catchment subset ids, this will not work.  This is a known bug being addressed (see issue #166)
+`ngen ./data/catchment_data.geojson "cat-88,cat-89" ./data/nexus_data.geojson "nex-92" ./data/refactored_example_realization_config.json`
+
+To simulate every catchment in the input hydrofabric, leave the subset lists empty, i.e.:
+`ngen ./data/catchment_data.geojson "" ./data/nexus_data.geojson "" ./data/refactored_example_realization_config.json`
 
 ## How to test the software
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -116,10 +116,15 @@ int main(int argc, char *argv[]) {
         std::vector<string> nexus_subset_ids;
 
         if( argc < 6) {
-
-          std::cout<<"Missing required args:"<<std::endl;
-          std::cout<<"ngen <catchment_data_path> <catchment subset ids> <nexus_data_path> <nexus subset ids> <realization_config_path>"<<std::endl;
-          exit(-1);
+            std::cout << "Missing required args:" << std::endl;
+            std::cout << argv[0] << " <catchment_data_path> <catchment subset ids> <nexus_data_path> <nexus subset ids>"
+                      << " <realization_config_path>" << std::endl;
+            if(argc > 3) {
+                std::cout << std::endl << "Note:" << std::endl
+                          << "Arguments for <catchment subset ids> and <nexus subset ids> must be given." << std::endl
+                          << "Use empty string (\"\") as explicit argument when no subset is needed." << std::endl;
+            }
+            exit(-1);
         }
         else {
           bool error = false;


### PR DESCRIPTION
Need to be able to run the executable for different inputs without the need to re-compile it with hard-coded input paths.

## Additions

- Add a simple set of CLI args to facilitate more flexible running of different hydrofabrics and configurations.

## Notes
Some explicit tests of these args might be in order, especially if we want to maintain them and use them for an extended amount of time.  I think it will be best to move to a more robust arg parsing utility in the near future, so little focus was given beyond the simplest input validation (does file exist...)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:


### Target Environment support

- [x] Linux
- [x] MacOS
