### PR TITLE
Work-around for issue of assignment and move semantics for streams

### DIFF
--- a/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
+++ b/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
@@ -127,7 +127,7 @@ void Tshirt_C_Realization_Test::TearDown() {
 void Tshirt_C_Realization_Test::open_standalone_c_impl_data_stream() {
     ASSERT_FALSE(standalone_output_data_file.empty());
 
-    standalone_data_ingest_stream = std::ifstream(standalone_output_data_file.c_str());
+    standalone_data_ingest_stream.open(standalone_output_data_file.c_str());
 
     ASSERT_TRUE(standalone_data_ingest_stream.is_open());
 


### PR DESCRIPTION
Work-around for issue of assignment and move semantics for streams nott supported in gcc 4.8.5 to instead have stream open data file.


## Changes
One line change in https://github.com/NOAA-OWP/ngen/blob/master/test/realizations/catchments/Tshirt_C_Realization_Test.cpp

## Notes

Fixes #172 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
