### PR TITLE
fix subset arg parsing bug, fixes #173

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -151,6 +151,10 @@ int main(int argc, char *argv[]) {
           //split the subset strings into vectors
           boost::split(catchment_subset_ids, argv[2], [](char c){return c == ','; } );
           boost::split(nexus_subset_ids, argv[4], [](char c){return c == ','; } );
+          //If a single id or no id is passed, the subset vector will have size 1 and be the id or the ""
+          //if we get an empy string, pop it from the subset list.
+          if(nexus_subset_ids.size() == 1 && nexus_subset_ids[0] == "") nexus_subset_ids.pop_back();
+          if(catchment_subset_ids.size() == 1 && catchment_subset_ids[0] == "") catchment_subset_ids.pop_back();
         }
 
     //Read the collection of nexus


### PR DESCRIPTION
Bug fix for #173

## Changes

- add additional checks on subset args passed from the cli

## Testing

1. run `ngen data/catchment_data.geojson "" data/nexus_data.geojson "" data/refactored_example_realization_config.json`
    with no seg fault.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS