### PR TITLE
Add EtSetParams.hpp with a cleaner interface

### DIFF
--- a/models/kernels/evapotranspiration/EtCalcProperty.hpp
+++ b/models/kernels/evapotranspiration/EtCalcProperty.hpp
@@ -42,7 +42,7 @@ extern void calculate_intermediate_variables
   intermediate_vars *inter_vars
 );
 
-extern int is_fabs_less_than_epsilon(double a,double epsilon);  // returns TRUE iff fabs(a)<epsilon
+extern int is_fabs_less_than_eps(double a,double epsilon);  // returns TRUE iff fabs(a)<epsilon
 
 extern double calc_air_saturation_vapor_pressure_Pa(double air_temperature_C);
 
@@ -502,7 +502,7 @@ extern void calculate_intermediate_variables
   inter_vars->psychrometric_constant_Pa_per_C=psychrometric_constant_Pa_per_C;
 }
 
-extern int is_fabs_less_than_epsilon(double a,double epsilon)  // returns true if fabs(a)<epsilon
+extern int is_fabs_less_than_eps(double a,double epsilon)  // returns true if fabs(a)<epsilon
 {
   if(fabs(a)<epsilon) return(TRUE);
   else                return(FALSE);

--- a/models/kernels/evapotranspiration/EtPenmanMonteithMethod.hpp
+++ b/models/kernels/evapotranspiration/EtPenmanMonteithMethod.hpp
@@ -99,7 +99,7 @@ extern double penman_monteith_et_calculation
   double aerodynamic_resistance_s_per_m;
 
   // this method requires more calculations 
-  if(is_fabs_less_than_epsilon(et_params->vegetation_height_m,1.0e-06)==TRUE)
+  if(is_fabs_less_than_eps(et_params->vegetation_height_m,1.0e-06)==TRUE)
   {
     // the vegetation height was not specified.  TODO should warn??
     fprintf(stderr,"WARNING: Vegetation height not specified in the Penman-Monteith routine.  Using 0.5m.\n");

--- a/models/kernels/evapotranspiration/EtSetParams.hpp
+++ b/models/kernels/evapotranspiration/EtSetParams.hpp
@@ -1,0 +1,149 @@
+#ifndef Et_Set_Params_H
+#define Et_Set_Params_H
+
+extern void et_setup(aorc_forcing_data          &aorc_forcing,
+                     solar_radiation_options    &solar_options,
+                     solar_radiation_parameters &solar_params,
+                     solar_radiation_forcing    &solar_forcing,
+                     evapotranspiration_options &et_options,
+                     evapotranspiration_params  &et_params,
+                     evapotranspiration_forcing &et_forcing,
+                     surface_radiation_params   &surf_rad_params,
+                     surface_radiation_forcing  &surf_rad_forcing);
+
+extern void et_setup(aorc_forcing_data          &aorc_forcing,
+                     solar_radiation_options    &solar_options,
+                     solar_radiation_parameters &solar_params,
+                     solar_radiation_forcing    &solar_forcing,
+                     evapotranspiration_options &et_options,
+                     evapotranspiration_params  &et_params,
+                     evapotranspiration_forcing &et_forcing,
+                     surface_radiation_params   &surf_rad_params,
+                     surface_radiation_forcing  &surf_rad_forcing)
+{
+  // FLAGS
+  int yes_aorc; // if TRUE then using AORC forcing data- if FALSE then we must calculate incoming short/longwave rad.
+  int yes_wrf;  // if TRUE then we get radiation winds etc. from WRF output.  TODO not implemented.
+
+  double wind_speed_at_2_m;
+  double et_mm_per_d;
+  double saturation_vapor_pressure_Pa;
+  double actual_vapor_pressure_Pa;
+
+  //###################################################################################################
+  // THE VALUE OF THESE FLAGS DETERMINE HOW THIS CODE BEHAVES.  CYCLE THROUGH THESE FOR THE UNIT TEST.
+  //###################################################################################################
+  // Set this flag to TRUE if meteorological inputs come from AORC
+  et_options.yes_aorc = TRUE;                      // if TRUE, it means that we are using AORC data.
+  et_options.shortwave_radiation_provided = FALSE;
+
+  //###################################################################################################
+  // MAKE UP SOME TYPICAL AORC DATA.  THESE VALUES DRIVE THE UNIT TESTS.
+  //###################################################################################################
+  //read_aorc_data().  TODO: These data come from some aorc reading/parsing function.
+  //---------------------------------------------------------------------------------------------------------------
+
+  aorc_forcing.incoming_longwave_W_per_m2     =  117.1;
+  aorc_forcing.incoming_shortwave_W_per_m2    =  599.7;
+  aorc_forcing.surface_pressure_Pa            =  101300.0;
+  aorc_forcing.specific_humidity_2m_kg_per_kg =  0.00778;      // results in a relative humidity of 40%
+  aorc_forcing.air_temperature_2m_K           =  25.0+TK;
+  aorc_forcing.u_wind_speed_10m_m_per_s       =  1.54;
+  aorc_forcing.v_wind_speed_10m_m_per_s       =  3.2;
+  aorc_forcing.latitude                       =  37.865211;
+  aorc_forcing.longitude                      =  -98.12345;
+  aorc_forcing.time                           =  111111112;
+
+
+  // populate the evapotranspiration forcing data structure:
+  // this part of code does not explicitly setting values, moved to et_wrapper_function()
+
+
+  // ET forcing values that come from somewhere else...
+  //---------------------------------------------------------------------------------------------------------------
+  et_forcing.canopy_resistance_sec_per_m   = 50.0; // TODO: from plant growth model
+  et_forcing.water_temperature_C           = 15.5; // TODO: from soil or lake thermal model
+  et_forcing.ground_heat_flux_W_per_sq_m=-10.0;    // TODO from soil thermal model.  Negative denotes downward.
+
+  if(et_options.yes_aorc==TRUE)
+  {
+    et_params.wind_speed_measurement_height_m=10.0;  // AORC uses 10m.  Must convert to wind speed at 2 m height.
+  }    
+  et_params.humidity_measurement_height_m=2.0; 
+  et_params.vegetation_height_m=0.12;   // used for unit test of aerodynamic resistance used in Penman Monteith method.     
+  et_params.zero_plane_displacement_height_m=0.0003;  // 0.03 cm for unit testing
+  et_params.momentum_transfer_roughness_length_m=0.0;  // zero means that default values will be used in routine.
+  et_params.heat_transfer_roughness_length_m=0.0;      // zero means that default values will be used in routine.
+
+
+  // surface radiation parameter values that are a function of land cover.   Must be assigned from land cover type.
+  //---------------------------------------------------------------------------------------------------------------
+  surf_rad_params.surface_longwave_emissivity=1.0; // this is 1.0 for granular surfaces, maybe 0.97 for water
+  surf_rad_params.surface_shortwave_albedo=0.22;  // this is a function of solar elev. angle for most surfaces.   
+
+
+  if(et_options.yes_aorc!=TRUE)
+  {
+    // these values are needed if we don't have incoming longwave radiation measurements.
+    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
+    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
+    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
+    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
+    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
+    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
+    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
+  }
+
+    // these values are needed if we don't have incoming longwave radiation measurements.
+    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
+    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
+    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
+    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
+    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
+    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
+    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
+    
+
+  // Surface radiation forcing parameter values that must come from other models
+  //---------------------------------------------------------------------------------------------------------------
+  surf_rad_forcing.surface_skin_temperature_C = 12.0;  // TODO from soil thermal model or vegetation model.
+
+  if(et_options.shortwave_radiation_provided=FALSE)
+  {
+    // populate the elements of the structures needed to calculate shortwave (solar) radiation, and calculate it
+    // ### OPTIONS ###
+    solar_options.cloud_base_height_known=FALSE;  // set to TRUE if the solar_forcing.cloud_base_height_m is known.
+
+    // ### PARAMS ###
+    solar_params.latitude_degrees      =  37.25;   // THESE VALUES ARE FOR THE UNIT TEST
+    solar_params.longitude_degrees     = -97.5554; // THESE VALUES ARE FOR THE UNIT TEST
+    solar_params.site_elevation_m      = 303.333;  // THESE VALUES ARE FOR THE UNIT TEST  
+
+    // ### FORCING ###
+    solar_forcing.cloud_cover_fraction         =   0.5;   // THESE VALUES ARE FOR THE UNIT TEST 
+    solar_forcing.atmospheric_turbidity_factor =   2.0;   // 2.0 = clear mountain air, 5.0= smoggy air
+    solar_forcing.day_of_year                  =  208;    // THESE VALUES ARE FOR THE UNIT TEST
+    solar_forcing.zulu_time_h                  =  20.567; // THESE VALUES ARE FOR THE UNIT TEST
+
+    // UNIT TEST RESULTS
+    // CALCULATED SOLAR FLUXES
+    // at time:     20.56700000 UTC
+    // at site latitude: 37.250000 deg. longitude:-97.555400 deg.  elevation:303.333000 m
+    // Shortwave radiation clear-sky flux calculations:
+    // -above canopy/snow perpendicular to Earth-Sun line is      =964.56166277 W/m2
+    // -at the top of a horizontal canopy/snow surface is:        =661.40396086 W/m2
+    // Shortwave radiation clear-sky flux calculations with 0.5000 cloud cover fraction:
+    // -above canopy/snow perpendicular to Earth-Sun line is      =807.82039257 W/m2
+    // -at the top of a horizontal canopy/snow surface is:        =553.92581722 W/m2
+    // CALCULATED ANGLES DESCRIBING VECTOR POINTING TO THE SUN
+    // solar elevation angle:     43.29101185 degrees
+    // solar azimuth:            225.06371958 degrees
+    // local hour angle:          31.01549773 degrees
+    // Number of tests passed=7 of 7.
+    // UNIT TEST PASSED.
+  }
+
+  return;
+}
+
+#endif // Et_Set_Params_H

--- a/test/models/hymod/include/Et_All_Methods_Test.cpp
+++ b/test/models/hymod/include/Et_All_Methods_Test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include <stdio.h>
 #include "kernels/evapotranspiration/EtWrapperFunction.hpp"
+#include "kernels/evapotranspiration/EtSetParams.hpp"
 
 class EtCalcKernelTest : public ::testing::Test {
 
@@ -41,11 +42,6 @@ TEST_F(EtCalcKernelTest, TestEnergyBalanceMethod)
   double et_m_per_s;
   int et_method_option;
 
-
-  // FLAGS
-  int yes_aorc; // if TRUE then using AORC forcing data- if FALSE then we must calculate incoming short/longwave rad.
-  int yes_wrf;  // if TRUE then we get radiation winds etc. from WRF output.  TODO not implemented.
-
   struct aorc_forcing_data aorc;
 
   struct evapotranspiration_options et_options;
@@ -56,152 +52,27 @@ TEST_F(EtCalcKernelTest, TestEnergyBalanceMethod)
   struct surface_radiation_params   surf_rad_params;
   struct surface_radiation_forcing  surf_rad_forcing;
 
-  struct solar_radiation_options    solar_options; 
+  struct solar_radiation_options    solar_options;
   struct solar_radiation_parameters solar_params;
   struct solar_radiation_forcing    solar_forcing;
-  struct solar_radiation_results    solar_results;
 
-
-  double wind_speed_at_2_m;
-  double et_mm_per_d;
-  double numerator,denominator;
-  double saturation_vapor_pressure_Pa;
-  double actual_vapor_pressure_Pa;
-
-  //###################################################################################################
-  // THE VALUE OF THESE FLAGS DETERMINE HOW THIS CODE BEHAVES.  CYCLE THROUGH THESE FOR THE UNIT TEST.
-  //###################################################################################################
-  // Set this flag to TRUE if meteorological inputs come from AORC
-  set_et_options.yes_aorc = TRUE;                      // if TRUE, it means that we are using AORC data.
-  set_et_options.shortwave_radiation_provided = FALSE;
-  et_options.yes_aorc = set_et_options.yes_aorc;
-  et_options.shortwave_radiation_provided = set_et_options.shortwave_radiation_provided;
-
-
-  // -----UNIT TEST RESULTS:-----
-
-  // energy balance method:
-  // calculated instantaneous potential evapotranspiration (PET) =8.594743e-08 m/s
-  // calculated instantaneous potential evapotranspiration (PET) =7.425858 mm/d
-
-
-  //###################################################################################################
-  // MAKE UP SOME TYPICAL AORC DATA.  THESE VALUES DRIVE THE UNIT TESTS.
-  //###################################################################################################
-  //read_aorc_data().  TODO: These data come from some aorc reading/parsing function.
-  //---------------------------------------------------------------------------------------------------------------
-
-  aorc.incoming_longwave_W_per_m2     =  117.1;
-  aorc.incoming_shortwave_W_per_m2    =  599.7;
-  aorc.surface_pressure_Pa            =  101300.0;
-  aorc.specific_humidity_2m_kg_per_kg =  0.00778;      // results in a relative humidity of 40%
-  aorc.air_temperature_2m_K           =  25.0+TK;
-  aorc.u_wind_speed_10m_m_per_s       =  1.54;
-  aorc.v_wind_speed_10m_m_per_s       =  3.2;
-  aorc.latitude                       =  37.865211;
-  aorc.longitude                      =  -98.12345;
-  aorc.time                           =  111111112;
-
-
-  // populate the evapotranspiration forcing data structure:
-  // this part of code does not explicitly setting values, moved to et_wrapper_function()
-
-
-  // ET forcing values that come from somewhere else...
-  //---------------------------------------------------------------------------------------------------------------
-  et_forcing.canopy_resistance_sec_per_m   = 50.0; // TODO: from plant growth model
-  et_forcing.water_temperature_C           = 15.5; // TODO: from soil or lake thermal model
-  et_forcing.ground_heat_flux_W_per_sq_m=-10.0;    // TODO from soil thermal model.  Negative denotes downward.
-
-  if(et_options.yes_aorc==TRUE)
-  {
-    et_params.wind_speed_measurement_height_m=10.0;  // AORC uses 10m.  Must convert to wind speed at 2 m height.
-  }    
-  et_params.humidity_measurement_height_m=2.0; 
-  et_params.vegetation_height_m=0.12;   // used for unit test of aerodynamic resistance used in Penman Monteith method.     
-  et_params.zero_plane_displacement_height_m=0.0003;  // 0.03 cm for unit testing
-  et_params.momentum_transfer_roughness_length_m=0.0;  // zero means that default values will be used in routine.
-  et_params.heat_transfer_roughness_length_m=0.0;      // zero means that default values will be used in routine.
-
-
-  // surface radiation parameter values that are a function of land cover.   Must be assigned from land cover type.
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_params.surface_longwave_emissivity=1.0; // this is 1.0 for granular surfaces, maybe 0.97 for water
-  surf_rad_params.surface_shortwave_albedo=0.22;  // this is a function of solar elev. angle for most surfaces.   
-
-
-  if(et_options.yes_aorc!=TRUE)
-  {
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-  }
-
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-    
-
-  // Surface radiation forcing parameter values that must come from other models
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_forcing.surface_skin_temperature_C = 12.0;  // TODO from soil thermal model or vegetation model.
-
-  if(et_options.shortwave_radiation_provided=FALSE)
-  {
-    // populate the elements of the structures needed to calculate shortwave (solar) radiation, and calculate it
-    // ### OPTIONS ###
-    solar_options.cloud_base_height_known=FALSE;  // set to TRUE if the solar_forcing.cloud_base_height_m is known.
-
-    // ### PARAMS ###
-    solar_params.latitude_degrees      =  37.25;   // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.longitude_degrees     = -97.5554; // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.site_elevation_m      = 303.333;  // THESE VALUES ARE FOR THE UNIT TEST  
-
-    // ### FORCING ###
-    solar_forcing.cloud_cover_fraction         =   0.5;   // THESE VALUES ARE FOR THE UNIT TEST 
-    solar_forcing.atmospheric_turbidity_factor =   2.0;   // 2.0 = clear mountain air, 5.0= smoggy air
-    solar_forcing.day_of_year                  =  208;    // THESE VALUES ARE FOR THE UNIT TEST
-    solar_forcing.zulu_time_h                  =  20.567; // THESE VALUES ARE FOR THE UNIT TEST
-
-    // UNIT TEST RESULTS
-    // CALCULATED SOLAR FLUXES
-    // at time:     20.56700000 UTC
-    // at site latitude: 37.250000 deg. longitude:-97.555400 deg.  elevation:303.333000 m
-    // Shortwave radiation clear-sky flux calculations:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =964.56166277 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =661.40396086 W/m2
-    // Shortwave radiation clear-sky flux calculations with 0.5000 cloud cover fraction:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =807.82039257 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =553.92581722 W/m2
-    // CALCULATED ANGLES DESCRIBING VECTOR POINTING TO THE SUN
-    // solar elevation angle:     43.29101185 degrees
-    // solar azimuth:            225.06371958 degrees
-    // local hour angle:          31.01549773 degrees
-    // Number of tests passed=7 of 7.
-    // UNIT TEST PASSED.
-  }
+  et_setup(aorc, solar_options, solar_params, solar_forcing, set_et_options,
+           et_params, et_forcing, surf_rad_params, surf_rad_forcing);
 
   //et_method_option = 1;    use_energy_balance_method
   //et_method_option = 2;    use_aerodynamic_method
   //et_method_option = 3;    use_combination_method
   //et_method_option = 4;    use_priestley_taylor_method
   //et_method_option = 5;    use_penman_monteith_method
+
+  //set et_method_option 
   et_method_option = 1;
 
+  //read in et_method_option from standard input for convenience of testing
   //std::cout << "Input et_method_option: 1-5" << std::endl;
   //std::cin >> et_method_option;
 
-  //the following two variables are set in function et_function_calc_wrapper()
+  //the following two variables are set in function et_setup()
   //set_et_options->yes_aorc=TRUE;
   //set_et_options->shortwave_radiation_provided=FALSE;
   set_et_options.use_energy_balance_method   = FALSE;
@@ -209,7 +80,6 @@ TEST_F(EtCalcKernelTest, TestEnergyBalanceMethod)
   set_et_options.use_combination_method      = FALSE;
   set_et_options.use_priestley_taylor_method = FALSE;
   set_et_options.use_penman_monteith_method  = FALSE;
-
 
   if (et_method_option == 1)
     set_et_options.use_energy_balance_method   = TRUE;
@@ -225,8 +95,6 @@ TEST_F(EtCalcKernelTest, TestEnergyBalanceMethod)
   et_m_per_s = et_wrapper_function(&aorc, &solar_options, &solar_params, &solar_forcing,
                                    &set_et_options, &et_params, &et_forcing, 
                                    &surf_rad_params, &surf_rad_forcing);
-
-  printf("In main: calculated instantaneous potential evapotranspiration (PET) =%8.6e m/s\n",et_m_per_s);
 
   //EXPECT_DOUBLE_EQ (8.594743e-08, et_m_per_s);
   EXPECT_LT(abs(et_m_per_s-8.594743e-08), 1.0e-08);
@@ -241,11 +109,6 @@ TEST_F(EtCalcKernelTest, TestAerodynamicMethod)
   double et_m_per_s;
   int et_method_option;
 
-
-  // FLAGS
-  int yes_aorc; // if TRUE then using AORC forcing data- if FALSE then we must calculate incoming short/longwave rad.
-  int yes_wrf;  // if TRUE then we get radiation winds etc. from WRF output.  TODO not implemented.
-
   struct aorc_forcing_data aorc;
 
   struct evapotranspiration_options et_options;
@@ -256,152 +119,27 @@ TEST_F(EtCalcKernelTest, TestAerodynamicMethod)
   struct surface_radiation_params   surf_rad_params;
   struct surface_radiation_forcing  surf_rad_forcing;
 
-  struct solar_radiation_options    solar_options; 
+  struct solar_radiation_options    solar_options;
   struct solar_radiation_parameters solar_params;
   struct solar_radiation_forcing    solar_forcing;
-  struct solar_radiation_results    solar_results;
 
-
-  double wind_speed_at_2_m;
-  double et_mm_per_d;
-  double numerator,denominator;
-  double saturation_vapor_pressure_Pa;
-  double actual_vapor_pressure_Pa;
-
-  //###################################################################################################
-  // THE VALUE OF THESE FLAGS DETERMINE HOW THIS CODE BEHAVES.  CYCLE THROUGH THESE FOR THE UNIT TEST.
-  //###################################################################################################
-  // Set this flag to TRUE if meteorological inputs come from AORC
-  set_et_options.yes_aorc = TRUE;                      // if TRUE, it means that we are using AORC data.
-  set_et_options.shortwave_radiation_provided = FALSE;
-  et_options.yes_aorc = set_et_options.yes_aorc;
-  et_options.shortwave_radiation_provided = set_et_options.shortwave_radiation_provided;
-
-
-  // -----UNIT TEST RESULTS:-----
-
-  // -----aerodynamic method:-----
-  // calculated instantaneous potential evapotranspiration (PET) =8.977490e-08 m/s
-  // calculated instantaneous potential evapotranspiration (PET) =7.756551 mm/d
-  
-
-  //###################################################################################################
-  // MAKE UP SOME TYPICAL AORC DATA.  THESE VALUES DRIVE THE UNIT TESTS.
-  //###################################################################################################
-  //read_aorc_data().  TODO: These data come from some aorc reading/parsing function.
-  //---------------------------------------------------------------------------------------------------------------
-
-  aorc.incoming_longwave_W_per_m2     =  117.1;
-  aorc.incoming_shortwave_W_per_m2    =  599.7;
-  aorc.surface_pressure_Pa            =  101300.0;
-  aorc.specific_humidity_2m_kg_per_kg =  0.00778;      // results in a relative humidity of 40%
-  aorc.air_temperature_2m_K           =  25.0+TK;
-  aorc.u_wind_speed_10m_m_per_s       =  1.54;
-  aorc.v_wind_speed_10m_m_per_s       =  3.2;
-  aorc.latitude                       =  37.865211;
-  aorc.longitude                      =  -98.12345;
-  aorc.time                           =  111111112;
-
-
-  // populate the evapotranspiration forcing data structure:
-  // this part of code does not explicitly setting values, moved to et_wrapper_function()
-
-
-  // ET forcing values that come from somewhere else...
-  //---------------------------------------------------------------------------------------------------------------
-  et_forcing.canopy_resistance_sec_per_m   = 50.0; // TODO: from plant growth model
-  et_forcing.water_temperature_C           = 15.5; // TODO: from soil or lake thermal model
-  et_forcing.ground_heat_flux_W_per_sq_m=-10.0;    // TODO from soil thermal model.  Negative denotes downward.
-
-  if(et_options.yes_aorc==TRUE)
-  {
-    et_params.wind_speed_measurement_height_m=10.0;  // AORC uses 10m.  Must convert to wind speed at 2 m height.
-  }    
-  et_params.humidity_measurement_height_m=2.0; 
-  et_params.vegetation_height_m=0.12;   // used for unit test of aerodynamic resistance used in Penman Monteith method.     
-  et_params.zero_plane_displacement_height_m=0.0003;  // 0.03 cm for unit testing
-  et_params.momentum_transfer_roughness_length_m=0.0;  // zero means that default values will be used in routine.
-  et_params.heat_transfer_roughness_length_m=0.0;      // zero means that default values will be used in routine.
-
-
-  // surface radiation parameter values that are a function of land cover.   Must be assigned from land cover type.
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_params.surface_longwave_emissivity=1.0; // this is 1.0 for granular surfaces, maybe 0.97 for water
-  surf_rad_params.surface_shortwave_albedo=0.22;  // this is a function of solar elev. angle for most surfaces.   
-
-
-  if(et_options.yes_aorc!=TRUE)
-  {
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-  }
-
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-    
-
-  // Surface radiation forcing parameter values that must come from other models
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_forcing.surface_skin_temperature_C = 12.0;  // TODO from soil thermal model or vegetation model.
-
-  if(et_options.shortwave_radiation_provided=FALSE)
-  {
-    // populate the elements of the structures needed to calculate shortwave (solar) radiation, and calculate it
-    // ### OPTIONS ###
-    solar_options.cloud_base_height_known=FALSE;  // set to TRUE if the solar_forcing.cloud_base_height_m is known.
-
-    // ### PARAMS ###
-    solar_params.latitude_degrees      =  37.25;   // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.longitude_degrees     = -97.5554; // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.site_elevation_m      = 303.333;  // THESE VALUES ARE FOR THE UNIT TEST  
-
-    // ### FORCING ###
-    solar_forcing.cloud_cover_fraction         =   0.5;   // THESE VALUES ARE FOR THE UNIT TEST 
-    solar_forcing.atmospheric_turbidity_factor =   2.0;   // 2.0 = clear mountain air, 5.0= smoggy air
-    solar_forcing.day_of_year                  =  208;    // THESE VALUES ARE FOR THE UNIT TEST
-    solar_forcing.zulu_time_h                  =  20.567; // THESE VALUES ARE FOR THE UNIT TEST
-
-    // UNIT TEST RESULTS
-    // CALCULATED SOLAR FLUXES
-    // at time:     20.56700000 UTC
-    // at site latitude: 37.250000 deg. longitude:-97.555400 deg.  elevation:303.333000 m
-    // Shortwave radiation clear-sky flux calculations:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =964.56166277 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =661.40396086 W/m2
-    // Shortwave radiation clear-sky flux calculations with 0.5000 cloud cover fraction:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =807.82039257 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =553.92581722 W/m2
-    // CALCULATED ANGLES DESCRIBING VECTOR POINTING TO THE SUN
-    // solar elevation angle:     43.29101185 degrees
-    // solar azimuth:            225.06371958 degrees
-    // local hour angle:          31.01549773 degrees
-    // Number of tests passed=7 of 7.
-    // UNIT TEST PASSED.
-  }
+  et_setup(aorc, solar_options, solar_params, solar_forcing, set_et_options,
+           et_params, et_forcing, surf_rad_params, surf_rad_forcing);
 
   //et_method_option = 1;    use_energy_balance_method
   //et_method_option = 2;    use_aerodynamic_method
   //et_method_option = 3;    use_combination_method
   //et_method_option = 4;    use_priestley_taylor_method
   //et_method_option = 5;    use_penman_monteith_method
+
+  //set et_method_option 
   et_method_option = 2;
 
+  //read in et_method_option from standard input for convenience of testing
   //std::cout << "Input et_method_option: 1-5" << std::endl;
   //std::cin >> et_method_option;
 
-  //the following two variables are set in function et_function_calc_wrapper()
+  //the following two variables are set in function et_setup()
   //set_et_options->yes_aorc=TRUE;
   //set_et_options->shortwave_radiation_provided=FALSE;
   set_et_options.use_energy_balance_method   = FALSE;
@@ -424,8 +162,6 @@ TEST_F(EtCalcKernelTest, TestAerodynamicMethod)
   et_m_per_s = et_wrapper_function(&aorc, &solar_options, &solar_params, &solar_forcing,
                                    &set_et_options, &et_params, &et_forcing, 
                                    &surf_rad_params, &surf_rad_forcing);
-
-  printf("In main: calculated instantaneous potential evapotranspiration (PET) =%8.6e m/s\n",et_m_per_s);
 
   //EXPECT_DOUBLE_EQ (8.977490e-08, et_m_per_s);
   EXPECT_LT(abs(et_m_per_s-8.977490e-08), 1.0e-08);
@@ -440,11 +176,6 @@ TEST_F(EtCalcKernelTest, TestCombinationMethod)
   double et_m_per_s;
   int et_method_option;
 
-
-  // FLAGS
-  int yes_aorc; // if TRUE then using AORC forcing data- if FALSE then we must calculate incoming short/longwave rad.
-  int yes_wrf;  // if TRUE then we get radiation winds etc. from WRF output.  TODO not implemented.
-
   struct aorc_forcing_data aorc;
 
   struct evapotranspiration_options et_options;
@@ -455,152 +186,27 @@ TEST_F(EtCalcKernelTest, TestCombinationMethod)
   struct surface_radiation_params   surf_rad_params;
   struct surface_radiation_forcing  surf_rad_forcing;
 
-  struct solar_radiation_options    solar_options; 
+  struct solar_radiation_options    solar_options;
   struct solar_radiation_parameters solar_params;
   struct solar_radiation_forcing    solar_forcing;
-  struct solar_radiation_results    solar_results;
 
-
-  double wind_speed_at_2_m;
-  double et_mm_per_d;
-  double numerator,denominator;
-  double saturation_vapor_pressure_Pa;
-  double actual_vapor_pressure_Pa;
-
-  //###################################################################################################
-  // THE VALUE OF THESE FLAGS DETERMINE HOW THIS CODE BEHAVES.  CYCLE THROUGH THESE FOR THE UNIT TEST.
-  //###################################################################################################
-  // Set this flag to TRUE if meteorological inputs come from AORC
-  set_et_options.yes_aorc = TRUE;                      // if TRUE, it means that we are using AORC data.
-  set_et_options.shortwave_radiation_provided = FALSE;
-  et_options.yes_aorc = set_et_options.yes_aorc;
-  et_options.shortwave_radiation_provided = set_et_options.shortwave_radiation_provided;
-
-
-  // -----UNIT TEST RESULTS:-----
-
-  // -----combination method:-----
-  // calculated instantaneous potential evapotranspiration (PET) =8.694909e-08 m/s
-  // calculated instantaneous potential evapotranspiration (PET) =7.512402 mm/d
-  
-
-  //###################################################################################################
-  // MAKE UP SOME TYPICAL AORC DATA.  THESE VALUES DRIVE THE UNIT TESTS.
-  //###################################################################################################
-  //read_aorc_data().  TODO: These data come from some aorc reading/parsing function.
-  //---------------------------------------------------------------------------------------------------------------
-
-  aorc.incoming_longwave_W_per_m2     =  117.1;
-  aorc.incoming_shortwave_W_per_m2    =  599.7;
-  aorc.surface_pressure_Pa            =  101300.0;
-  aorc.specific_humidity_2m_kg_per_kg =  0.00778;      // results in a relative humidity of 40%
-  aorc.air_temperature_2m_K           =  25.0+TK;
-  aorc.u_wind_speed_10m_m_per_s       =  1.54;
-  aorc.v_wind_speed_10m_m_per_s       =  3.2;
-  aorc.latitude                       =  37.865211;
-  aorc.longitude                      =  -98.12345;
-  aorc.time                           =  111111112;
-
-
-  // populate the evapotranspiration forcing data structure:
-  // this part of code does not explicitly setting values, moved to et_wrapper_function()
-
-
-  // ET forcing values that come from somewhere else...
-  //---------------------------------------------------------------------------------------------------------------
-  et_forcing.canopy_resistance_sec_per_m   = 50.0; // TODO: from plant growth model
-  et_forcing.water_temperature_C           = 15.5; // TODO: from soil or lake thermal model
-  et_forcing.ground_heat_flux_W_per_sq_m=-10.0;    // TODO from soil thermal model.  Negative denotes downward.
-
-  if(et_options.yes_aorc==TRUE)
-  {
-    et_params.wind_speed_measurement_height_m=10.0;  // AORC uses 10m.  Must convert to wind speed at 2 m height.
-  }    
-  et_params.humidity_measurement_height_m=2.0; 
-  et_params.vegetation_height_m=0.12;   // used for unit test of aerodynamic resistance used in Penman Monteith method.     
-  et_params.zero_plane_displacement_height_m=0.0003;  // 0.03 cm for unit testing
-  et_params.momentum_transfer_roughness_length_m=0.0;  // zero means that default values will be used in routine.
-  et_params.heat_transfer_roughness_length_m=0.0;      // zero means that default values will be used in routine.
-
-
-  // surface radiation parameter values that are a function of land cover.   Must be assigned from land cover type.
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_params.surface_longwave_emissivity=1.0; // this is 1.0 for granular surfaces, maybe 0.97 for water
-  surf_rad_params.surface_shortwave_albedo=0.22;  // this is a function of solar elev. angle for most surfaces.   
-
-
-  if(et_options.yes_aorc!=TRUE)
-  {
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-  }
-
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-    
-
-  // Surface radiation forcing parameter values that must come from other models
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_forcing.surface_skin_temperature_C = 12.0;  // TODO from soil thermal model or vegetation model.
-
-  if(et_options.shortwave_radiation_provided=FALSE)
-  {
-    // populate the elements of the structures needed to calculate shortwave (solar) radiation, and calculate it
-    // ### OPTIONS ###
-    solar_options.cloud_base_height_known=FALSE;  // set to TRUE if the solar_forcing.cloud_base_height_m is known.
-
-    // ### PARAMS ###
-    solar_params.latitude_degrees      =  37.25;   // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.longitude_degrees     = -97.5554; // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.site_elevation_m      = 303.333;  // THESE VALUES ARE FOR THE UNIT TEST  
-
-    // ### FORCING ###
-    solar_forcing.cloud_cover_fraction         =   0.5;   // THESE VALUES ARE FOR THE UNIT TEST 
-    solar_forcing.atmospheric_turbidity_factor =   2.0;   // 2.0 = clear mountain air, 5.0= smoggy air
-    solar_forcing.day_of_year                  =  208;    // THESE VALUES ARE FOR THE UNIT TEST
-    solar_forcing.zulu_time_h                  =  20.567; // THESE VALUES ARE FOR THE UNIT TEST
-
-    // UNIT TEST RESULTS
-    // CALCULATED SOLAR FLUXES
-    // at time:     20.56700000 UTC
-    // at site latitude: 37.250000 deg. longitude:-97.555400 deg.  elevation:303.333000 m
-    // Shortwave radiation clear-sky flux calculations:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =964.56166277 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =661.40396086 W/m2
-    // Shortwave radiation clear-sky flux calculations with 0.5000 cloud cover fraction:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =807.82039257 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =553.92581722 W/m2
-    // CALCULATED ANGLES DESCRIBING VECTOR POINTING TO THE SUN
-    // solar elevation angle:     43.29101185 degrees
-    // solar azimuth:            225.06371958 degrees
-    // local hour angle:          31.01549773 degrees
-    // Number of tests passed=7 of 7.
-    // UNIT TEST PASSED.
-  }
+  et_setup(aorc, solar_options, solar_params, solar_forcing, set_et_options,
+           et_params, et_forcing, surf_rad_params, surf_rad_forcing);
 
   //et_method_option = 1;    use_energy_balance_method
   //et_method_option = 2;    use_aerodynamic_method
   //et_method_option = 3;    use_combination_method
   //et_method_option = 4;    use_priestley_taylor_method
   //et_method_option = 5;    use_penman_monteith_method
+
+  //set et_method_option 
   et_method_option = 3;
 
+  //read in et_method_option from standard input for convenience of testing
   //std::cout << "Input et_method_option: 1-5" << std::endl;
   //std::cin >> et_method_option;
 
-  //the following two variables are set in function et_function_calc_wrapper()
+  //the following two variables are set in function et_setup()
   //set_et_options->yes_aorc=TRUE;
   //set_et_options->shortwave_radiation_provided=FALSE;
   set_et_options.use_energy_balance_method   = FALSE;
@@ -623,8 +229,6 @@ TEST_F(EtCalcKernelTest, TestCombinationMethod)
   et_m_per_s = et_wrapper_function(&aorc, &solar_options, &solar_params, &solar_forcing,
                                    &set_et_options, &et_params, &et_forcing, 
                                    &surf_rad_params, &surf_rad_forcing);
-
-  printf("In main: calculated instantaneous potential evapotranspiration (PET) =%8.6e m/s\n",et_m_per_s);
 
   //EXPECT_DOUBLE_EQ (8.694909e-08, et_m_per_s);
   EXPECT_LT(abs(et_m_per_s-8.694909e-08), 1.0e-08);
@@ -639,11 +243,6 @@ TEST_F(EtCalcKernelTest, TestPriestleyTaylorMethod)
   double et_m_per_s;
   int et_method_option;
 
-
-  // FLAGS
-  int yes_aorc; // if TRUE then using AORC forcing data- if FALSE then we must calculate incoming short/longwave rad.
-  int yes_wrf;  // if TRUE then we get radiation winds etc. from WRF output.  TODO not implemented.
-
   struct aorc_forcing_data aorc;
 
   struct evapotranspiration_options et_options;
@@ -654,152 +253,27 @@ TEST_F(EtCalcKernelTest, TestPriestleyTaylorMethod)
   struct surface_radiation_params   surf_rad_params;
   struct surface_radiation_forcing  surf_rad_forcing;
 
-  struct solar_radiation_options    solar_options; 
+  struct solar_radiation_options    solar_options;
   struct solar_radiation_parameters solar_params;
   struct solar_radiation_forcing    solar_forcing;
-  struct solar_radiation_results    solar_results;
 
-
-  double wind_speed_at_2_m;
-  double et_mm_per_d;
-  double numerator,denominator;
-  double saturation_vapor_pressure_Pa;
-  double actual_vapor_pressure_Pa;
-
-  //###################################################################################################
-  // THE VALUE OF THESE FLAGS DETERMINE HOW THIS CODE BEHAVES.  CYCLE THROUGH THESE FOR THE UNIT TEST.
-  //###################################################################################################
-  // Set this flag to TRUE if meteorological inputs come from AORC
-  set_et_options.yes_aorc = TRUE;                      // if TRUE, it means that we are using AORC data.
-  set_et_options.shortwave_radiation_provided = FALSE;
-  et_options.yes_aorc = set_et_options.yes_aorc;
-  et_options.shortwave_radiation_provided = set_et_options.shortwave_radiation_provided;
-
-
-  // -----UNIT TEST RESULTS:-----
-
-  // -----Priestley-Taylor method: -----
-  // calculated instantaneous potential evapotranspiration (PET) =8.249098e-08 m/s
-  // calculated instantaneous potential evapotranspiration (PET) =7.127221 mm/d
-  
-
-  //###################################################################################################
-  // MAKE UP SOME TYPICAL AORC DATA.  THESE VALUES DRIVE THE UNIT TESTS.
-  //###################################################################################################
-  //read_aorc_data().  TODO: These data come from some aorc reading/parsing function.
-  //---------------------------------------------------------------------------------------------------------------
-
-  aorc.incoming_longwave_W_per_m2     =  117.1;
-  aorc.incoming_shortwave_W_per_m2    =  599.7;
-  aorc.surface_pressure_Pa            =  101300.0;
-  aorc.specific_humidity_2m_kg_per_kg =  0.00778;      // results in a relative humidity of 40%
-  aorc.air_temperature_2m_K           =  25.0+TK;
-  aorc.u_wind_speed_10m_m_per_s       =  1.54;
-  aorc.v_wind_speed_10m_m_per_s       =  3.2;
-  aorc.latitude                       =  37.865211;
-  aorc.longitude                      =  -98.12345;
-  aorc.time                           =  111111112;
-
-
-  // populate the evapotranspiration forcing data structure:
-  // this part of code does not explicitly setting values, moved to et_wrapper_function()
-
-
-  // ET forcing values that come from somewhere else...
-  //---------------------------------------------------------------------------------------------------------------
-  et_forcing.canopy_resistance_sec_per_m   = 50.0; // TODO: from plant growth model
-  et_forcing.water_temperature_C           = 15.5; // TODO: from soil or lake thermal model
-  et_forcing.ground_heat_flux_W_per_sq_m=-10.0;    // TODO from soil thermal model.  Negative denotes downward.
-
-  if(et_options.yes_aorc==TRUE)
-  {
-    et_params.wind_speed_measurement_height_m=10.0;  // AORC uses 10m.  Must convert to wind speed at 2 m height.
-  }    
-  et_params.humidity_measurement_height_m=2.0; 
-  et_params.vegetation_height_m=0.12;   // used for unit test of aerodynamic resistance used in Penman Monteith method.     
-  et_params.zero_plane_displacement_height_m=0.0003;  // 0.03 cm for unit testing
-  et_params.momentum_transfer_roughness_length_m=0.0;  // zero means that default values will be used in routine.
-  et_params.heat_transfer_roughness_length_m=0.0;      // zero means that default values will be used in routine.
-
-
-  // surface radiation parameter values that are a function of land cover.   Must be assigned from land cover type.
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_params.surface_longwave_emissivity=1.0; // this is 1.0 for granular surfaces, maybe 0.97 for water
-  surf_rad_params.surface_shortwave_albedo=0.22;  // this is a function of solar elev. angle for most surfaces.   
-
-
-  if(et_options.yes_aorc!=TRUE)
-  {
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-  }
-
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-    
-
-  // Surface radiation forcing parameter values that must come from other models
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_forcing.surface_skin_temperature_C = 12.0;  // TODO from soil thermal model or vegetation model.
-
-  if(et_options.shortwave_radiation_provided=FALSE)
-  {
-    // populate the elements of the structures needed to calculate shortwave (solar) radiation, and calculate it
-    // ### OPTIONS ###
-    solar_options.cloud_base_height_known=FALSE;  // set to TRUE if the solar_forcing.cloud_base_height_m is known.
-
-    // ### PARAMS ###
-    solar_params.latitude_degrees      =  37.25;   // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.longitude_degrees     = -97.5554; // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.site_elevation_m      = 303.333;  // THESE VALUES ARE FOR THE UNIT TEST  
-
-    // ### FORCING ###
-    solar_forcing.cloud_cover_fraction         =   0.5;   // THESE VALUES ARE FOR THE UNIT TEST 
-    solar_forcing.atmospheric_turbidity_factor =   2.0;   // 2.0 = clear mountain air, 5.0= smoggy air
-    solar_forcing.day_of_year                  =  208;    // THESE VALUES ARE FOR THE UNIT TEST
-    solar_forcing.zulu_time_h                  =  20.567; // THESE VALUES ARE FOR THE UNIT TEST
-
-    // UNIT TEST RESULTS
-    // CALCULATED SOLAR FLUXES
-    // at time:     20.56700000 UTC
-    // at site latitude: 37.250000 deg. longitude:-97.555400 deg.  elevation:303.333000 m
-    // Shortwave radiation clear-sky flux calculations:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =964.56166277 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =661.40396086 W/m2
-    // Shortwave radiation clear-sky flux calculations with 0.5000 cloud cover fraction:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =807.82039257 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =553.92581722 W/m2
-    // CALCULATED ANGLES DESCRIBING VECTOR POINTING TO THE SUN
-    // solar elevation angle:     43.29101185 degrees
-    // solar azimuth:            225.06371958 degrees
-    // local hour angle:          31.01549773 degrees
-    // Number of tests passed=7 of 7.
-    // UNIT TEST PASSED.
-  }
+  et_setup(aorc, solar_options, solar_params, solar_forcing, set_et_options,
+           et_params, et_forcing, surf_rad_params, surf_rad_forcing);
 
   //et_method_option = 1;    use_energy_balance_method
   //et_method_option = 2;    use_aerodynamic_method
   //et_method_option = 3;    use_combination_method
   //et_method_option = 4;    use_priestley_taylor_method
   //et_method_option = 5;    use_penman_monteith_method
+
+  //set et_method_option 
   et_method_option = 4;
 
+  //read in et_method_option from standard input for convenience of testing
   //std::cout << "Input et_method_option: 1-5" << std::endl;
   //std::cin >> et_method_option;
 
-  //the following two variables are set in function et_function_calc_wrapper()
+  //the following two variables are set in function et_setup()
   //set_et_options->yes_aorc=TRUE;
   //set_et_options->shortwave_radiation_provided=FALSE;
   set_et_options.use_energy_balance_method   = FALSE;
@@ -822,8 +296,6 @@ TEST_F(EtCalcKernelTest, TestPriestleyTaylorMethod)
   et_m_per_s = et_wrapper_function(&aorc, &solar_options, &solar_params, &solar_forcing,
                                    &set_et_options, &et_params, &et_forcing, 
                                    &surf_rad_params, &surf_rad_forcing);
-
-  printf("In main: calculated instantaneous potential evapotranspiration (PET) =%8.6e m/s\n",et_m_per_s);
 
   //EXPECT_DOUBLE_EQ (8.249098e-08, et_m_per_s);
   EXPECT_LT(abs(et_m_per_s-8.249098e-08), 1.0e-08);
@@ -838,11 +310,6 @@ TEST_F(EtCalcKernelTest, TestPenmanMonteithMethod)
   double et_m_per_s;
   int et_method_option;
 
-
-  // FLAGS
-  int yes_aorc; // if TRUE then using AORC forcing data- if FALSE then we must calculate incoming short/longwave rad.
-  int yes_wrf;  // if TRUE then we get radiation winds etc. from WRF output.  TODO not implemented.
-
   struct aorc_forcing_data aorc;
 
   struct evapotranspiration_options et_options;
@@ -853,153 +320,27 @@ TEST_F(EtCalcKernelTest, TestPenmanMonteithMethod)
   struct surface_radiation_params   surf_rad_params;
   struct surface_radiation_forcing  surf_rad_forcing;
 
-  struct solar_radiation_options    solar_options; 
+  struct solar_radiation_options    solar_options;
   struct solar_radiation_parameters solar_params;
   struct solar_radiation_forcing    solar_forcing;
-  struct solar_radiation_results    solar_results;
 
-
-  double wind_speed_at_2_m;
-  double et_mm_per_d;
-  double numerator,denominator;
-  double saturation_vapor_pressure_Pa;
-  double actual_vapor_pressure_Pa;
-
-  //###################################################################################################
-  // THE VALUE OF THESE FLAGS DETERMINE HOW THIS CODE BEHAVES.  CYCLE THROUGH THESE FOR THE UNIT TEST.
-  //###################################################################################################
-  // Set this flag to TRUE if meteorological inputs come from AORC
-  set_et_options.yes_aorc = TRUE;                      // if TRUE, it means that we are using AORC data.
-  set_et_options.shortwave_radiation_provided = FALSE;
-  et_options.yes_aorc = set_et_options.yes_aorc;
-  et_options.shortwave_radiation_provided = set_et_options.shortwave_radiation_provided;
-
-
-  // -----UNIT TEST RESULTS:-----
-
-  //(NOTE: aerodynamic roughness terms are different in this test, calculated from veg. height as per FAO method)
-  // Penman Monteith method:
-  // calculated instantaneous potential evapotranspiration (PET) =1.106268e-07 m/s
-  // calculated instantaneous potential evapotranspiration (PET) =9.558159 mm/d
-  
-
-  //###################################################################################################
-  // MAKE UP SOME TYPICAL AORC DATA.  THESE VALUES DRIVE THE UNIT TESTS.
-  //###################################################################################################
-  //read_aorc_data().  TODO: These data come from some aorc reading/parsing function.
-  //---------------------------------------------------------------------------------------------------------------
-
-  aorc.incoming_longwave_W_per_m2     =  117.1;
-  aorc.incoming_shortwave_W_per_m2    =  599.7;
-  aorc.surface_pressure_Pa            =  101300.0;
-  aorc.specific_humidity_2m_kg_per_kg =  0.00778;      // results in a relative humidity of 40%
-  aorc.air_temperature_2m_K           =  25.0+TK;
-  aorc.u_wind_speed_10m_m_per_s       =  1.54;
-  aorc.v_wind_speed_10m_m_per_s       =  3.2;
-  aorc.latitude                       =  37.865211;
-  aorc.longitude                      =  -98.12345;
-  aorc.time                           =  111111112;
-
-
-  // populate the evapotranspiration forcing data structure:
-  // this part of code does not explicitly setting values, moved to et_wrapper_function()
-
-
-  // ET forcing values that come from somewhere else...
-  //---------------------------------------------------------------------------------------------------------------
-  et_forcing.canopy_resistance_sec_per_m   = 50.0; // TODO: from plant growth model
-  et_forcing.water_temperature_C           = 15.5; // TODO: from soil or lake thermal model
-  et_forcing.ground_heat_flux_W_per_sq_m=-10.0;    // TODO from soil thermal model.  Negative denotes downward.
-
-  if(et_options.yes_aorc==TRUE)
-  {
-    et_params.wind_speed_measurement_height_m=10.0;  // AORC uses 10m.  Must convert to wind speed at 2 m height.
-  }    
-  et_params.humidity_measurement_height_m=2.0; 
-  et_params.vegetation_height_m=0.12;   // used for unit test of aerodynamic resistance used in Penman Monteith method.     
-  et_params.zero_plane_displacement_height_m=0.0003;  // 0.03 cm for unit testing
-  et_params.momentum_transfer_roughness_length_m=0.0;  // zero means that default values will be used in routine.
-  et_params.heat_transfer_roughness_length_m=0.0;      // zero means that default values will be used in routine.
-
-
-  // surface radiation parameter values that are a function of land cover.   Must be assigned from land cover type.
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_params.surface_longwave_emissivity=1.0; // this is 1.0 for granular surfaces, maybe 0.97 for water
-  surf_rad_params.surface_shortwave_albedo=0.22;  // this is a function of solar elev. angle for most surfaces.   
-
-
-  if(et_options.yes_aorc!=TRUE)
-  {
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-  }
-
-    // these values are needed if we don't have incoming longwave radiation measurements.
-    surf_rad_forcing.incoming_shortwave_radiation_W_per_sq_m     = 440.1;     // must come from somewhere
-    surf_rad_forcing.incoming_longwave_radiation_W_per_sq_m      = -1.0e+05;  // this huge negative value tells to calc.
-    surf_rad_forcing.air_temperature_C                           = 15.0;      // from some forcing data file
-    surf_rad_forcing.relative_humidity_percent                   = 63.0;      // from some forcing data file
-    surf_rad_forcing.ambient_temperature_lapse_rate_deg_C_per_km = 6.49;      // ICAO standard atmosphere lapse rate
-    surf_rad_forcing.cloud_cover_fraction                        = 0.6;       // from some forcing data file
-    surf_rad_forcing.cloud_base_height_m                         = 2500.0/3.281; // assumed 2500 ft.
-    
-
-  // Surface radiation forcing parameter values that must come from other models
-  //---------------------------------------------------------------------------------------------------------------
-  surf_rad_forcing.surface_skin_temperature_C = 12.0;  // TODO from soil thermal model or vegetation model.
-
-  if(et_options.shortwave_radiation_provided=FALSE)
-  {
-    // populate the elements of the structures needed to calculate shortwave (solar) radiation, and calculate it
-    // ### OPTIONS ###
-    solar_options.cloud_base_height_known=FALSE;  // set to TRUE if the solar_forcing.cloud_base_height_m is known.
-
-    // ### PARAMS ###
-    solar_params.latitude_degrees      =  37.25;   // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.longitude_degrees     = -97.5554; // THESE VALUES ARE FOR THE UNIT TEST
-    solar_params.site_elevation_m      = 303.333;  // THESE VALUES ARE FOR THE UNIT TEST  
-
-    // ### FORCING ###
-    solar_forcing.cloud_cover_fraction         =   0.5;   // THESE VALUES ARE FOR THE UNIT TEST 
-    solar_forcing.atmospheric_turbidity_factor =   2.0;   // 2.0 = clear mountain air, 5.0= smoggy air
-    solar_forcing.day_of_year                  =  208;    // THESE VALUES ARE FOR THE UNIT TEST
-    solar_forcing.zulu_time_h                  =  20.567; // THESE VALUES ARE FOR THE UNIT TEST
-
-    // UNIT TEST RESULTS
-    // CALCULATED SOLAR FLUXES
-    // at time:     20.56700000 UTC
-    // at site latitude: 37.250000 deg. longitude:-97.555400 deg.  elevation:303.333000 m
-    // Shortwave radiation clear-sky flux calculations:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =964.56166277 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =661.40396086 W/m2
-    // Shortwave radiation clear-sky flux calculations with 0.5000 cloud cover fraction:
-    // -above canopy/snow perpendicular to Earth-Sun line is      =807.82039257 W/m2
-    // -at the top of a horizontal canopy/snow surface is:        =553.92581722 W/m2
-    // CALCULATED ANGLES DESCRIBING VECTOR POINTING TO THE SUN
-    // solar elevation angle:     43.29101185 degrees
-    // solar azimuth:            225.06371958 degrees
-    // local hour angle:          31.01549773 degrees
-    // Number of tests passed=7 of 7.
-    // UNIT TEST PASSED.
-  }
+  et_setup(aorc, solar_options, solar_params, solar_forcing, set_et_options,
+           et_params, et_forcing, surf_rad_params, surf_rad_forcing);
 
   //et_method_option = 1;    use_energy_balance_method
   //et_method_option = 2;    use_aerodynamic_method
   //et_method_option = 3;    use_combination_method
   //et_method_option = 4;    use_priestley_taylor_method
   //et_method_option = 5;    use_penman_monteith_method
+
+  //set et_method_option 
   et_method_option = 5;
 
+  //read in et_method_option from standard input for convenience of testing
   //std::cout << "Input et_method_option: 1-5" << std::endl;
   //std::cin >> et_method_option;
 
-  //the following two variables are set in function et_function_calc_wrapper()
+  //the following two variables are set in function et_setup()
   //set_et_options->yes_aorc=TRUE;
   //set_et_options->shortwave_radiation_provided=FALSE;
   set_et_options.use_energy_balance_method   = FALSE;
@@ -1022,8 +363,6 @@ TEST_F(EtCalcKernelTest, TestPenmanMonteithMethod)
   et_m_per_s = et_wrapper_function(&aorc, &solar_options, &solar_params, &solar_forcing,
                                    &set_et_options, &et_params, &et_forcing, 
                                    &surf_rad_params, &surf_rad_forcing);
-
-  printf("In main: calculated instantaneous potential evapotranspiration (PET) =%8.6e m/s\n",et_m_per_s);
 
   //EXPECT_DOUBLE_EQ (1.106268e-07, et_m_per_s);
   EXPECT_LT(abs(et_m_per_s-1.106268e-07), 1.0e-07);


### PR DESCRIPTION
Added a function that setup all ET parameters.
This results in a much simpler and cleaner interface 

## Additions

models/kernels/evapotranspiration/EtSetParams.hpp

## Removals

-

## Changes
models/kernels/evapotranspiration/EtCalcProperty.hpp
models/kernels/evapotranspiration/EtPenmanMonteithMethod.hpp
test/models/hymod/include/Et_All_Methods_Test.cpp

## Testing

1. Validation test
2. Unit test

## Screenshots


## Notes

The Et_All_Methods_Test.cpp is a much smaller file so the difference from the previous version looks large.

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [x ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
