### PR TITLE
Add HY_HydroLocation

### DIFF
--- a/include/core/HY_HydroLocation.hpp
+++ b/include/core/HY_HydroLocation.hpp
@@ -1,0 +1,59 @@
+#ifndef HY_HYDROLOCATION_HPP
+#define HY_HYDROLOCATION_HPP
+
+#include <memory>
+
+#include "GM_Object.hpp"
+#include "HY_HydroLocationType.hpp"
+
+//! HY_HydroLocation: class representing a hydrologic position
+/**
+    HY_HydroLocation
+
+    This class represents a location where a hydrologic interaction of note is performed.
+*/
+
+class HY_HydroLocation : public GM_Object
+{
+    public:
+
+    typedef bg::model::d2::point_xy<double> point_t;    //!< the type for a 2d point
+    typedef bg::model::polygon<point_t> polygon_t       //!< the type for the polygon of the location
+
+    //! Constructor for when the attached nexus is not known
+    HY_HydroLocation(polygon_type input_shape, HY_HydroLocationType input_type, point_t input_point) :
+        _shape(input_shape), _type(input_type), _point(input_point), _realized_nexus()
+    {}
+
+    //! Constructor for when attached nexus is know
+    HY_HydroLocation(polygon_type input_shape, HY_HydroLocationType input_type, point_t input_point, std::shared_ptr<HY_HydroNexus> nexus) :
+        _shape(input_shape), _type(input_type), _point(input_point), _realized_nexus(nexus)
+    {}
+
+    //! get the shape of the location
+    std::shared_ptr<HY_HydroNexus>& geometry() { return _shape; }
+    const std::shared_ptr<HY_HydroNexus>& geometry() const { return _shape; }
+
+    //! get the type if the location
+    HY_HydroLocationType& itype() { return _type; }
+    const HY_HydroLocationType& itype() const { return _type; }
+
+    //! get the central point for the location
+    point_t& point() { return _point; }
+    const point_t& point() const { return _point; }
+
+    //! get the attached nexus for this location
+    std::shared_ptr<HY_HydroNexus>& realized_nexus() { return _realized_nexus; }
+    const std::shared_ptr<HY_HydroNexus>& realized_nexus() const { return _realized_nexus; }
+
+
+    private:
+
+    polygon_type _shape;                                //!< shape for location
+    HY_HydroLocationType _type;                         //!< type for location
+    point_t _referenced_position;                       //!< reference position for location
+    std::shared_ptr<HY_HydroNexus> _realized_nexus;     //!< nexus connected to this location
+}
+
+
+#endif // HY_HYDROLOCATION_HPP

--- a/include/core/HY_HydroLocationType.hpp
+++ b/include/core/HY_HydroLocationType.hpp
@@ -25,7 +25,8 @@ enum HY_HydroLocationType
     sinkhole,
     source,
     waterfall,
-    weir
+    weir,
+    undefined
 }
 
 

--- a/test/core/nexus/NexusTests.cpp
+++ b/test/core/nexus/NexusTests.cpp
@@ -1,0 +1,50 @@
+#include "gtest/gtest.h"
+
+#include "HY_HydroLocation.hpp"
+#include <vector>
+#include <memory>
+
+class Nexus_Test : public ::testing::Test {
+
+protected:
+
+    Nexus_Test()
+    {
+
+    }
+
+    ~Nexus_Test() override {
+
+    }
+
+    void SetUp() override;
+
+    void TearDown() override;
+
+    std::string abridged_json_file;
+    std::string complete_json_file;
+    std::string id_map_json_file;
+
+};
+
+void Nexus_Test::SetUp() {
+
+
+}
+
+void Nexus_Test::TearDown() {
+
+}
+
+//! Test that a HY_Hydrolocation can be created.
+TEST_F(Nexus_Test, TestInit0)
+{
+    HY_HydroLocation::point_t point(50,30);                                                  //!< Test data point
+    HY_HydroLocation::polygon_t polygon;                                                     //!< Test data location
+    HY_Features::HY_HydroLocationType type(HY_Features::HY_HydroLocationType::undefined);    //!< Test data type
+
+    std::shared_ptr<HY_HydroLocation> location = std::make_shared<HY_HydroLocation>(polygon, type, point);
+
+    ASSERT_TRUE(location != nullptr);
+}
+


### PR DESCRIPTION
Addresses Issue #185 

## Additions
Adds the HY_HydroLocation class that will be used as the base class for PointNexusTypes.
-

## Removals

-

## Changes

-

## Testing

Running main() from /home/dwj/projects/ngen/test/googletest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Nexus_Test
[ RUN      ] Nexus_Test.TestInit0
[       OK ] Nexus_Test.TestInit0 (0 ms)
[----------] 1 test from Nexus_Test (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.


## Screenshots


## Notes

-

## Todos

- Modify Point Nexus Classes to derive from this class

## Checklist

- [X ] PR has an informative and human-readable title
- [X ] Changes are limited to a single goal (no scope creep)
- [X ] Code can be automatically merged (no conflicts)
- [X ] Code follows project standards (link if applicable)
- [X ] Passes all existing automated tests
- [X ] Any _change_ in functionality is tested
- [X ] New functions are documented (with a description, list of inputs, and expected output)
- [X ] Placeholder code is flagged / future todos are captured in comments
- [X ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
