### PR TITLE
remove use of uninitialized var; fixes #191

### DIFF
--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -114,7 +114,7 @@ namespace geojson {
                 else {
                     // This isn't a terminal node, therefore represents an object or array
                     for (auto &property : property_tree) {
-                        if (property.first.empty() || type == PropertyType::List) {
+                        if (property.first.empty()) {
                             type = PropertyType::List;
                             value_list.push_back(JSONProperty(value_key, property.second));
                         }


### PR DESCRIPTION
Use of uninitialized variables causes undefined behavior, this PR removes the use of the variable.


## Changes

- JSONProperty construction from ptree

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
