### PR TITLE
Fix GIUH Logic for Tshirt C

### DIFF
--- a/include/core/catchment/giuh/GIUH.hpp
+++ b/include/core/catchment/giuh/GIUH.hpp
@@ -109,6 +109,12 @@ namespace giuh {
          */
         double calc_giuh_output(double dt, double direct_runoff) override;
 
+        std::vector<double> get_interpolated_incremental_ordinates() const override;
+
+        std::vector<int> get_interpolated_ordinate_times() override;
+
+        std::vector<double> get_interpolated_regularized_ordinates() const override;
+
         /**
          * Set the object's interpolation regularity value, also triggering recalculation of the interpolated,
          * regularized CDF ordinates IFF the new regularity value is different from the previous.

--- a/include/core/catchment/giuh/GIUH.hpp
+++ b/include/core/catchment/giuh/GIUH.hpp
@@ -33,17 +33,22 @@ namespace giuh {
          * Factory create a ``giuh_kernel_impl`` object, deriving CDF times and frequencies from a regularized
          * interpolation interval value and a collection of incremental runoff values.
          *
-         * The function essentially transforms the provided runoff values vector into a CDF vector setting each ``i``-th
-         * ordinate to the ``i``-th incremental value plus the ``(i-1)``-th ordinate value.  A corresponding vector of
-         * times is also created, with each value being ``interpolation_regularity_seconds`` larger than the previous
-         * (starting at ``0``).  These are then used in a call to the ``giuh_kernel_impl`` constructor, with the
-         * resulting object returned.
+         * The function essentially transforms the provided runoff values vector into a CDF frequency vector by setting
+         * each ``i``-th frequency value to the ``(i-1)``-th frequency value plus the ``i``-th incremental value.  The
+         * ``0``-th index values is set to ``0``.
+         *
+         * A corresponding vector of regularized times is also created, with each value being
+         * ``interpolation_regularity_seconds`` larger than the previous (again, starting at ``0``).
+         *
+         * These vectors are then used in a call to the ``giuh_kernel_impl`` constructor, with the resulting object
+         * returned.
          *
          * @param catchment_id
          * @param comid
-         * @param interpolation_regularity_seconds
-         * @param incremental_runoffs
-         * @return
+         * @param interpolation_regularity_seconds  The regular interval between the provided incremental runoff values.
+         * @param incremental_runoffs   A collection of incremental runoff values (akin to `
+         *                              `get_interpolated_incremental_runoff()``).
+         * @return A new ``giuh_kernel_impl`` object induced from the implied CDF ordinates.
          */
         static giuh_kernel_impl make_from_incremental_runoffs(std::string catchment_id,
                                                               std::string comid,
@@ -67,30 +72,57 @@ namespace giuh {
             return giuh_kernel_impl(catchment_id, comid, ordinate_times, ordinates, interpolation_regularity_seconds);
         }
 
+        /**
+         * Initialize, using the given (not-necessarily-regular) CDF times and cumulative frequencies, and the provided
+         * interpolation regularity interval size.
+         *
+         * The give CDF times and frequencies form the base data for the object.  These values will not change.  From
+         * these, interpolated regularized values will be inferred.  These will be set during object construction,
+         * although they can potentially be changed by later changing the interpolation regularity interval value.
+         *
+         * @param catchment_id
+         * @param comid
+         * @param cdf_times A vector of base CDF time values, which may or may not be spaced in regular intervals.
+         * @param cdf_cumulative_freqs A vector of CDF cumulative frequency values, corresponding to each of the times
+         *                             in the ``cdf_times`` parameter.
+         * @param interpolation_regularity_seconds The size of regular intervals to use when interpolating the
+         *                                         regularize CDF ordinates.
+         */
         giuh_kernel_impl(
                 std::string catchment_id,
                 std::string comid,
                 std::vector<double> cdf_times,
                 std::vector<double> cdf_cumulative_freqs,
                 unsigned int interpolation_regularity_seconds
-                ) : giuh_kernel(std::move(catchment_id), std::move(comid), interpolation_regularity_seconds)
-        {
-            this->cdf_times = std::move(cdf_times);
-            // TODO: might be able to get this by calculating from times, rather than being passed
-            this->cdf_cumulative_freqs = std::move(cdf_cumulative_freqs);
-
+        ) : giuh_kernel(std::move(catchment_id), std::move(comid), interpolation_regularity_seconds),
+            cdf_times(std::move(cdf_times)), cdf_cumulative_freqs(std::move(cdf_cumulative_freqs)) {
             carry_overs_list_head = nullptr;
 
             // TODO: have this be called by constructor, but consider later handling this concurrently
             interpolate_regularized_cdf();
         }
 
+        /**
+         * Initialize, using the given (not-necessarily-regular) CDF times and cumulative frequencies, and assuming
+         * a default interpolation regularity of 60 seconds.
+         *
+         * The give CDF times and frequencies form the base data for the object.  These values will not change.  From
+         * these, interpolated regularized values will be inferred.  These will be set during object construction,
+         * although they can potentially be changed by later changing the interpolation regularity interval value.
+         *
+         * @param catchment_id
+         * @param comid
+         * @param cdf_times A vector of base CDF time values, which may or may not be spaced in regular intervals.
+         * @param cdf_cumulative_freqs A vector of CDF cumulative frequency values, corresponding to each of the times
+         *                             in the ``cdf_times`` parameter.
+         */
         giuh_kernel_impl(
                 std::string catchment_id,
                 std::string comid,
                 std::vector<double> cdf_times,
                 std::vector<double> cdf_cumulative_freqs
-        ) : giuh_kernel_impl(std::move(catchment_id), std::move(comid), cdf_times, cdf_cumulative_freqs, 60) {
+        ) : giuh_kernel_impl(std::move(catchment_id), std::move(comid), std::move(cdf_times),
+                             std::move(cdf_cumulative_freqs), 60) {
 
         }
 
@@ -109,11 +141,11 @@ namespace giuh {
          */
         double calc_giuh_output(double dt, double direct_runoff) override;
 
-        std::vector<double> get_interpolated_incremental_ordinates() const override;
+        std::vector<double> get_interpolated_incremental_runoff() const override;
 
-        std::vector<int> get_interpolated_ordinate_times() override;
+        std::vector<int> get_regularized_times_s() override;
 
-        std::vector<double> get_interpolated_regularized_ordinates() const override;
+        std::vector<double> get_interpolated_regularized_cdf() const override;
 
         /**
          * Set the object's interpolation regularity value, also triggering recalculation of the interpolated,
@@ -125,21 +157,39 @@ namespace giuh {
         void set_interpolation_regularity_seconds(unsigned int regularity_seconds) override;
 
     private:
-        // TODO: document how member variables are named with 'cdf_*' being things that come from external data, and
-        //  'interpolated_*' being things that get produced within the class (to help keep straight what things are).
-        /** Ranked order of time of travel cell values for CDF. */
-        std::vector<double> cdf_cumulative_freqs;
-        /** CDF times in seconds. */
-        std::vector<double> cdf_times;
-        /** The corresponding, regular time values for each of the interpolated CDF ordinates. */
-        std::vector<int> interpolated_ordinate_times_seconds;
-        /** The regularized CDF ordinate interpolated values. */
-        std::vector<double> interpolated_regularized_ordinates;
         /**
-         * The incremental increases at each index of the interpolated, regularized CDF ordinate value, from the value
-         * at the previous index.
+         * The cumulative frequency (or rank order) of each ``i``-th cell in the travel time cumulative distribution
+         * function, as originally supplied to the object.
+         *
+         * For all values in the collection, where the collection is of size ``s``, the ``i``-th value is equal to:
+         *      ``i / (s - 1)``
          */
-        std::vector<double> interpolated_incremental_runoff_values;
+        const std::vector<double> cdf_cumulative_freqs;
+        /**
+         * The travel time in seconds for each i-th cell in the cumulative distribution function, as originally supplied
+         * to the object.
+         */
+        const std::vector<double> cdf_times;
+        /**
+         * Regular time values (in seconds) for interpolated CDF ordinates, regularized according to the value of
+         * ``interpolation_regularity_seconds``.
+         *
+         * This a collection of size ``s``, where the values can be defined by a function ``t(i)``, where:
+         *      ``t(0) = 0``
+         *      ``t(i) == t(i-1) + interpolation_regularity_seconds`` for all ``0 < i < s``
+         *
+         * E.g., for regularity of 60 seconds, something like ``0, 60, 120, 180, 240 ...``.
+         */
+        std::vector<int> regularized_times_s;
+        /**
+         * The regularized CDF values interpolated from the original CDF data from ``cdf_cumulative_freqs`` when using
+         * the regularized times in ``regularized_times_s``.
+         */
+        std::vector<double> interpolated_regularized_cdf;
+        /**
+         * The incremental increase at each index ``i`` of ``interpolated_regularized_cdf`` from index ``i-1``.
+         */
+        std::vector<double> interpolated_incremental_runoff;
         /** List to hold carry-over amounts from previous inputs, which didn't all flow out at that time step. */
         std::shared_ptr<giuh_carry_over> carry_overs_list_head;
 

--- a/include/core/catchment/giuh/giuh_kernel.hpp
+++ b/include/core/catchment/giuh/giuh_kernel.hpp
@@ -54,29 +54,29 @@ namespace giuh {
             return comid;
         }
 
-        virtual std::vector<int> get_interpolated_ordinate_times() {
+        virtual std::vector<int> get_regularized_times_s() {
             return {((int) interpolation_regularity_seconds)};
         }
 
         /**
-         * Get the object's interpolation regularity value - the difference in seconds between each regularized CDF.
+         * Get the interpolation regularity value: the difference in seconds between each regularized time value.
          *
-         * @return The object's interpolation regularity value - the difference in seconds between each regularized CDF.
+         * @return The interpolation regularity value.
          */
         unsigned int get_interpolation_regularity_seconds() const {
             return interpolation_regularity_seconds;
         }
 
-        virtual std::vector<double> get_interpolated_incremental_ordinates() const {
+        virtual std::vector<double> get_interpolated_incremental_runoff() const {
             return {1.0};
         };
 
-        virtual std::vector<double> get_interpolated_regularized_ordinates() const {
+        virtual std::vector<double> get_interpolated_regularized_cdf() const {
             return {1.0};
         };
 
         /**
-         * Set the object's interpolation regularity value.
+         * Set the object's interpolation regularity value, used to interpolate regularized CDF and time values.
          *
          * @param regularity_seconds The interpolation regularity value - i.e., the difference between each of the
          *                           corresponding times of regularized CDF ordinate - in seconds

--- a/include/core/catchment/giuh/giuh_kernel.hpp
+++ b/include/core/catchment/giuh/giuh_kernel.hpp
@@ -2,6 +2,7 @@
 #define NGEN_GIUH_KERNEL_HPP
 
 #include <iostream>
+#include <vector>
 #include <string>
 
 namespace giuh {
@@ -53,6 +54,10 @@ namespace giuh {
             return comid;
         }
 
+        virtual std::vector<int> get_interpolated_ordinate_times() {
+            return {((int) interpolation_regularity_seconds)};
+        }
+
         /**
          * Get the object's interpolation regularity value - the difference in seconds between each regularized CDF.
          *
@@ -61,6 +66,14 @@ namespace giuh {
         unsigned int get_interpolation_regularity_seconds() const {
             return interpolation_regularity_seconds;
         }
+
+        virtual std::vector<double> get_interpolated_incremental_ordinates() const {
+            return {1.0};
+        };
+
+        virtual std::vector<double> get_interpolated_regularized_ordinates() const {
+            return {1.0};
+        };
 
         /**
          * Set the object's interpolation regularity value.

--- a/src/core/catchment/giuh/GIUH.cpp
+++ b/src/core/catchment/giuh/GIUH.cpp
@@ -73,6 +73,18 @@ double giuh_kernel_impl::calc_giuh_output(double dt, double direct_runoff)
     return current_contribution + prior_inputs_contributions;
 }
 
+std::vector<double> giuh_kernel_impl::get_interpolated_incremental_ordinates() const {
+    return interpolated_incremental_runoff_values;
+}
+
+std::vector<int> giuh_kernel_impl::get_interpolated_ordinate_times() {
+    return interpolated_ordinate_times_seconds;
+}
+
+std::vector<double> giuh_kernel_impl::get_interpolated_regularized_ordinates() const {
+    return interpolated_regularized_ordinates;
+}
+
 void giuh_kernel_impl::set_interpolation_regularity_seconds(unsigned int regularity_seconds) {
     if (get_interpolation_regularity_seconds() != regularity_seconds) {
         giuh_kernel::set_interpolation_regularity_seconds(regularity_seconds);

--- a/src/core/catchment/giuh/GIUH.cpp
+++ b/src/core/catchment/giuh/GIUH.cpp
@@ -9,7 +9,7 @@ double giuh_kernel_impl::calc_giuh_output(double dt, double direct_runoff)
     double prior_inputs_contributions = 0.0;
 
     // Clean up any finished nodes from the head of the list also
-    while (carry_overs_list_head != nullptr && carry_overs_list_head->last_outputted_cdf_index >= interpolated_ordinate_times_seconds.size() - 1) {
+    while (carry_overs_list_head != nullptr && carry_overs_list_head->last_outputted_cdf_index >= regularized_times_s.size() - 1) {
         carry_overs_list_head = carry_overs_list_head->next;
     }
     // The set a pointer for the carry over list node value to work on, starting with the head
@@ -19,15 +19,15 @@ double giuh_kernel_impl::calc_giuh_output(double dt, double direct_runoff)
     while (carry_over_node != nullptr) {
         // Get the index for time and regularized CDF value for getting the contribution at this time step
         // Starting from the largest, work back until the range from last index to new index is not bigger than dt
-        unsigned long new_index = interpolated_ordinate_times_seconds.size() - 1;
-        while ((interpolated_ordinate_times_seconds[new_index] - interpolated_ordinate_times_seconds[carry_over_node->last_outputted_cdf_index]) > dt) {
+        unsigned long new_index = regularized_times_s.size() - 1;
+        while ((regularized_times_s[new_index] - regularized_times_s[carry_over_node->last_outputted_cdf_index]) > dt) {
             --new_index;
         }
 
         // Add in the proportion of this carry-over's runoff
         double proportion = 0.0;
         for (unsigned i = carry_over_node->last_outputted_cdf_index + 1; i <= new_index; ++i) {
-            proportion += interpolated_incremental_runoff_values[i];
+            proportion += interpolated_incremental_runoff[i];
         }
         prior_inputs_contributions += carry_over_node->original_input_amount * proportion;
 
@@ -35,7 +35,7 @@ double giuh_kernel_impl::calc_giuh_output(double dt, double direct_runoff)
         carry_over_node->last_outputted_cdf_index = new_index;
 
         // Before moving to next, prune immediately following nodes that have outputted all the original input
-        while (carry_over_node->next != nullptr && carry_over_node->next->last_outputted_cdf_index >= interpolated_ordinate_times_seconds.size() - 1) {
+        while (carry_over_node->next != nullptr && carry_over_node->next->last_outputted_cdf_index >= regularized_times_s.size() - 1) {
             carry_over_node->next = carry_over_node->next->next;
         }
 
@@ -49,18 +49,18 @@ double giuh_kernel_impl::calc_giuh_output(double dt, double direct_runoff)
         }
     }
 
-    if (dt >= interpolated_ordinate_times_seconds.back()) {
+    if (dt >= regularized_times_s.back()) {
         return prior_inputs_contributions + direct_runoff;
     }
 
     // TODO: disallow (or otherwise cleanly handle) dt arguments not divisible by interpolation_regularity_seconds
     // Get the index for time and regularized CDF value for getting the contribution at this time step
-    unsigned long contribution_ordinate_index = interpolated_ordinate_times_seconds.size() - 1;
-    while (interpolated_ordinate_times_seconds[contribution_ordinate_index] > dt) {
+    unsigned long contribution_ordinate_index = regularized_times_s.size() - 1;
+    while (regularized_times_s[contribution_ordinate_index] > dt) {
         --contribution_ordinate_index;
     }
     // Calculate ...
-    double current_contribution = direct_runoff * interpolated_regularized_ordinates[contribution_ordinate_index];
+    double current_contribution = direct_runoff * interpolated_regularized_cdf[contribution_ordinate_index];
 
     // If we have the list's tail, append to it; otherwise there is no current list, so start one
     if (carry_over_node != nullptr) {
@@ -73,18 +73,25 @@ double giuh_kernel_impl::calc_giuh_output(double dt, double direct_runoff)
     return current_contribution + prior_inputs_contributions;
 }
 
-std::vector<double> giuh_kernel_impl::get_interpolated_incremental_ordinates() const {
-    return interpolated_incremental_runoff_values;
+std::vector<double> giuh_kernel_impl::get_interpolated_incremental_runoff() const {
+    return interpolated_incremental_runoff;
 }
 
-std::vector<int> giuh_kernel_impl::get_interpolated_ordinate_times() {
-    return interpolated_ordinate_times_seconds;
+std::vector<int> giuh_kernel_impl::get_regularized_times_s() {
+    return regularized_times_s;
 }
 
-std::vector<double> giuh_kernel_impl::get_interpolated_regularized_ordinates() const {
-    return interpolated_regularized_ordinates;
+std::vector<double> giuh_kernel_impl::get_interpolated_regularized_cdf() const {
+    return interpolated_regularized_cdf;
 }
 
+/**
+ * Set the object's interpolation regularity value, also triggering recalculation of the interpolated,
+ * regularized CDF ordinates IFF the new regularity value is different from the previous.
+ *
+ * @param regularity_seconds The interpolation regularity value - i.e., the difference between each of the
+ *                           corresponding times of regularized CDF ordinate - in seconds
+ */
 void giuh_kernel_impl::set_interpolation_regularity_seconds(unsigned int regularity_seconds) {
     if (get_interpolation_regularity_seconds() != regularity_seconds) {
         giuh_kernel::set_interpolation_regularity_seconds(regularity_seconds);
@@ -96,28 +103,28 @@ void giuh_kernel_impl::set_interpolation_regularity_seconds(unsigned int regular
 void giuh_kernel_impl::interpolate_regularized_cdf()
 {
     // Clear any previous values
-    if (!interpolated_ordinate_times_seconds.empty()) {
-        interpolated_ordinate_times_seconds.clear();
+    if (!regularized_times_s.empty()) {
+        regularized_times_s.clear();
     }
-    if (!interpolated_regularized_ordinates.empty()) {
-        interpolated_regularized_ordinates.clear();
+    if (!interpolated_regularized_cdf.empty()) {
+        interpolated_regularized_cdf.clear();
     }
 
     // Interpolate regularized CDF (might should be done out of constructor, perhaps concurrently)
-    interpolated_ordinate_times_seconds.push_back(0);
-    interpolated_regularized_ordinates.push_back(0);
+    regularized_times_s.push_back(0);
+    interpolated_regularized_cdf.push_back(0);
     // Increment the ordinate time based on the regularity (loop below will do this at the end of each iter)
     unsigned int time_for_ordinate =
-            interpolated_ordinate_times_seconds.back() + get_interpolation_regularity_seconds();
+            regularized_times_s.back() + get_interpolation_regularity_seconds();
 
     // Loop through ordinate times, initializing all but the last ordinate
     while (time_for_ordinate < this->cdf_times.back()) {
-        interpolated_ordinate_times_seconds.push_back(time_for_ordinate);
+        regularized_times_s.push_back(time_for_ordinate);
 
         // Find index 'i' of largest CDF time less than the time for the current ordinate
         // Start by getting the index of the first time greater than time_for_ordinate
         int cdf_times_index_for_iteration = 0;
-        while (this->cdf_times[cdf_times_index_for_iteration] < interpolated_ordinate_times_seconds.back()) {
+        while (this->cdf_times[cdf_times_index_for_iteration] < regularized_times_s.back()) {
             cdf_times_index_for_iteration++;
         }
         // With the index of the first larger, back up one to get the last smaller
@@ -131,20 +138,20 @@ void giuh_kernel_impl::interpolate_regularized_cdf()
                          this->cdf_cumulative_freqs[cdf_times_index_for_iteration]) +
                         this->cdf_cumulative_freqs[cdf_times_index_for_iteration];
         // Push that to the back of that collection
-        interpolated_regularized_ordinates.push_back(result);
+        interpolated_regularized_cdf.push_back(result);
 
         // At the end of each loop iteration, increment the ordinate time based on the regularity
-        time_for_ordinate = interpolated_ordinate_times_seconds.back() + get_interpolation_regularity_seconds();
+        time_for_ordinate = regularized_times_s.back() + get_interpolation_regularity_seconds();
     }
 
     // As the last step of the actual interpolation, the last ordinate time gets set to have everything
-    interpolated_ordinate_times_seconds.push_back(time_for_ordinate);
-    interpolated_regularized_ordinates.push_back(1.0);
+    regularized_times_s.push_back(time_for_ordinate);
+    interpolated_regularized_cdf.push_back(1.0);
 
     // With the ordinate values interpolated, now calculate the derived, incremental values between each ordinate step
-    interpolated_incremental_runoff_values.resize(interpolated_regularized_ordinates.size());
-    for (unsigned i = 0; i < interpolated_regularized_ordinates.size(); i++) {
-        interpolated_incremental_runoff_values[i] =
-                i == 0 ? 0 : interpolated_regularized_ordinates[i] - interpolated_regularized_ordinates[i - 1];
+    interpolated_incremental_runoff.resize(interpolated_regularized_cdf.size());
+    for (unsigned i = 0; i < interpolated_regularized_cdf.size(); i++) {
+        interpolated_incremental_runoff[i] =
+                i == 0 ? 0 : interpolated_regularized_cdf[i] - interpolated_regularized_cdf[i - 1];
     }
 }

--- a/src/core/catchment/giuh/GiuhJsonReader.cpp
+++ b/src/core/catchment/giuh/GiuhJsonReader.cpp
@@ -30,8 +30,10 @@ std::vector<double> GiuhJsonReader::extract_cumulative_frequency_ordinates(ptree
     if (catchment_data_node.get_child_optional("CDF.CumulativeFreq") != boost::none) {
         freq_node_name = "CDF.CumulativeFreq";
     }
+    // TODO: later apply logic to be able to handle if there is a 'CDF.minHydro.Runoff', though that may also belong
+    //  elsewhere since those are not cumulative frequencies.
     else {
-        freq_node_name = "CDF.minHydro.Runoff";
+        throw std::runtime_error("Unable to find GIUH cumulative frequencies data node in parsed GIUH JSON");
     }
 
     for (ptree::value_type freqs : catchment_data_node.get_child(freq_node_name)) {

--- a/src/core/catchment/giuh/GiuhJsonReader.cpp
+++ b/src/core/catchment/giuh/GiuhJsonReader.cpp
@@ -26,7 +26,15 @@ std::vector<double> GiuhJsonReader::extract_cumulative_frequency_ordinates(ptree
     std::vector<double> cumulative_freqs;
 
     // TODO: account for error condition of unmatching JSON structure for freqs
-    for (ptree::value_type freqs : catchment_data_node.get_child("CDF.CumulativeFreq")) {
+    std::string freq_node_name;
+    if (catchment_data_node.get_child_optional("CDF.CumulativeFreq") != boost::none) {
+        freq_node_name = "CDF.CumulativeFreq";
+    }
+    else {
+        freq_node_name = "CDF.minHydro.Runoff";
+    }
+
+    for (ptree::value_type freqs : catchment_data_node.get_child(freq_node_name)) {
         cumulative_freqs.push_back(freqs.second.get_value<double>());
     }
     return cumulative_freqs;

--- a/src/core/catchment/giuh/GiuhJsonReader.cpp
+++ b/src/core/catchment/giuh/GiuhJsonReader.cpp
@@ -27,6 +27,7 @@ std::vector<double> GiuhJsonReader::extract_cumulative_frequency_ordinates(ptree
 
     // TODO: account for error condition of unmatching JSON structure for freqs
     std::string freq_node_name;
+    double check = 0.0;
     if (catchment_data_node.get_child_optional("CDF.CumulativeFreq") != boost::none) {
         freq_node_name = "CDF.CumulativeFreq";
     }
@@ -36,6 +37,11 @@ std::vector<double> GiuhJsonReader::extract_cumulative_frequency_ordinates(ptree
 
     for (ptree::value_type freqs : catchment_data_node.get_child(freq_node_name)) {
         cumulative_freqs.push_back(freqs.second.get_value<double>());
+        check += cumulative_freqs.back();
+    }
+    double eps = 0.0001;
+    if (check > 1.0 + eps || check < 1.0 - eps) {
+      throw std::runtime_error("GIUH oridnates do no sum to 1: sum = "+std::to_string(check)+"\n");
     }
     return cumulative_freqs;
 }

--- a/src/core/catchment/giuh/GiuhJsonReader.cpp
+++ b/src/core/catchment/giuh/GiuhJsonReader.cpp
@@ -27,7 +27,6 @@ std::vector<double> GiuhJsonReader::extract_cumulative_frequency_ordinates(ptree
 
     // TODO: account for error condition of unmatching JSON structure for freqs
     std::string freq_node_name;
-    double check = 0.0;
     if (catchment_data_node.get_child_optional("CDF.CumulativeFreq") != boost::none) {
         freq_node_name = "CDF.CumulativeFreq";
     }
@@ -37,11 +36,12 @@ std::vector<double> GiuhJsonReader::extract_cumulative_frequency_ordinates(ptree
 
     for (ptree::value_type freqs : catchment_data_node.get_child(freq_node_name)) {
         cumulative_freqs.push_back(freqs.second.get_value<double>());
-        check += cumulative_freqs.back();
     }
     double eps = 0.0001;
-    if (check > 1.0 + eps || check < 1.0 - eps) {
-      throw std::runtime_error("GIUH oridnates do no sum to 1: sum = "+std::to_string(check)+"\n");
+    if (cumulative_freqs.back() > 1.0 + eps || cumulative_freqs.back() < 1.0 - eps) {
+        throw std::runtime_error(
+                "GIUH cumulative frequencies do not have 1 as final value " + std::to_string(cumulative_freqs.back()) +
+                "\n");
     }
     return cumulative_freqs;
 }

--- a/src/realizations/catchment/Tshirt_C_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_C_Realization.cpp
@@ -197,9 +197,9 @@ void Tshirt_C_Realization::create_formulation(geojson::PropertyMap properties) {
         std::shared_ptr<giuh::giuh_kernel_impl> giuh_kernel = giuh_reader->get_giuh_kernel_for_id(catchment_id);
         giuh_kernel->set_interpolation_regularity_seconds(3600);
         // This needs to have all but the first interpolated incremental value (which is always 0 from the kernel), so
-        giuh_cdf_ordinates = std::vector<double>(giuh_kernel->get_interpolated_incremental_ordinates().size() - 1);
+        giuh_cdf_ordinates = std::vector<double>(giuh_kernel->get_interpolated_incremental_runoff().size() - 1);
         for (int i = 0; i < giuh_cdf_ordinates.size(); ++ i) {
-            giuh_cdf_ordinates[i] = giuh_kernel->get_interpolated_incremental_ordinates()[i+1];
+            giuh_cdf_ordinates[i] = giuh_kernel->get_interpolated_incremental_runoff()[i + 1];
         }
     }
     // Create this with 0 values initially
@@ -287,9 +287,9 @@ void Tshirt_C_Realization::create_formulation(boost::property_tree::ptree &confi
         std::shared_ptr<giuh::giuh_kernel_impl> giuh_kernel = giuh_reader->get_giuh_kernel_for_id(catchment_id);
         giuh_kernel->set_interpolation_regularity_seconds(3600);
         // This needs to have all but the first interpolated incremental value (which is always 0 from the kernel), so
-        giuh_cdf_ordinates = std::vector<double>(giuh_kernel->get_interpolated_incremental_ordinates().size() - 1);
+        giuh_cdf_ordinates = std::vector<double>(giuh_kernel->get_interpolated_incremental_runoff().size() - 1);
         for (int i = 0; i < giuh_cdf_ordinates.size(); ++ i) {
-            giuh_cdf_ordinates[i] = giuh_kernel->get_interpolated_incremental_ordinates()[i+1];
+            giuh_cdf_ordinates[i] = giuh_kernel->get_interpolated_incremental_runoff()[i + 1];
         }
     }
     // Create this with 0 values initially

--- a/src/realizations/catchment/Tshirt_C_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_C_Realization.cpp
@@ -2,6 +2,7 @@
 #include "Constants.h"
 #include <utility>
 #include "tshirt_c.h"
+#include "GIUH.hpp"
 #include <exception>
 #include <functional>
 #include <string>
@@ -193,8 +194,13 @@ void Tshirt_C_Realization::create_formulation(geojson::PropertyMap properties) {
                 giuh.at("crosswalk_path").as_string()
         );
 
-
-        giuh_cdf_ordinates = giuh_reader->extract_cumulative_frequency_ordinates(catchment_id);
+        std::shared_ptr<giuh::giuh_kernel_impl> giuh_kernel = giuh_reader->get_giuh_kernel_for_id(catchment_id);
+        giuh_kernel->set_interpolation_regularity_seconds(3600);
+        // This needs to have all but the first interpolated incremental value (which is always 0 from the kernel), so
+        giuh_cdf_ordinates = std::vector<double>(giuh_kernel->get_interpolated_incremental_ordinates().size() - 1);
+        for (int i = 0; i < giuh_cdf_ordinates.size(); ++ i) {
+            giuh_cdf_ordinates[i] = giuh_kernel->get_interpolated_incremental_ordinates()[i+1];
+        }
     }
     // Create this with 0 values initially
     giuh_runoff_queue_per_timestep = std::vector<double>(giuh_cdf_ordinates.size() + 1);
@@ -278,7 +284,13 @@ void Tshirt_C_Realization::create_formulation(boost::property_tree::ptree &confi
         );
 
 
-        giuh_cdf_ordinates = giuh_reader->extract_cumulative_frequency_ordinates(catchment_id);
+        std::shared_ptr<giuh::giuh_kernel_impl> giuh_kernel = giuh_reader->get_giuh_kernel_for_id(catchment_id);
+        giuh_kernel->set_interpolation_regularity_seconds(3600);
+        // This needs to have all but the first interpolated incremental value (which is always 0 from the kernel), so
+        giuh_cdf_ordinates = std::vector<double>(giuh_kernel->get_interpolated_incremental_ordinates().size() - 1);
+        for (int i = 0; i < giuh_cdf_ordinates.size(); ++ i) {
+            giuh_cdf_ordinates[i] = giuh_kernel->get_interpolated_incremental_ordinates()[i+1];
+        }
     }
     // Create this with 0 values initially
     giuh_runoff_queue_per_timestep = std::vector<double>(giuh_cdf_ordinates.size() + 1);


### PR DESCRIPTION
Fixing the logic for initializing the correct GIUH ordinates over the appropriate interpolation regularity in the logic for creating Tshirt_C realizations.