### PR TITLE
Fix Units in C-based Tshirt Formulation

### DIFF
--- a/include/realizations/catchment/Tshirt_C_Realization.hpp
+++ b/include/realizations/catchment/Tshirt_C_Realization.hpp
@@ -155,9 +155,10 @@ namespace realization {
          * arg to a nested call to ``run_formulation_for_timesteps``, returning that result code.
          *
          * @param input_flux Input flux (typically expected to be just precipitation) in meters per second.
+         * @param t_delta_s The size of the time step in seconds
          * @return The result code from the execution of the model time step calculations.
          */
-        int run_formulation_for_timestep(double input_flux);
+        int run_formulation_for_timestep(double input_flux, time_step_t t_delta_s);
 
         /**
          * Run model formulation calculations for a series of time steps using the given collection of input flux values
@@ -165,9 +166,10 @@ namespace realization {
          *
          * @param input_fluxes Ordered, per-time-step input flux (typically expected to be just precipitation) in meters
          * per second.
+         * @param t_delta_s The sizes of each of the time steps in seconds
          * @return The result code from the execution of the model time step calculations.
          */
-        int run_formulation_for_timesteps(std::vector<double> input_fluxes);
+        int run_formulation_for_timesteps(std::vector<double> input_fluxes, std::vector<time_step_t> t_deltas_s);
 
         std::string get_formulation_type() override;
 

--- a/src/realizations/catchment/Tshirt_C_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_C_Realization.cpp
@@ -495,7 +495,13 @@ int Tshirt_C_Realization::run_formulation_for_timesteps(std::vector<double> inpu
     //aorc_forcing_data empty_forcing[num_timesteps];
     aorc_forcing_data empty_forcing[1];
 
-    double* input_as_array = &input_fluxes[0];
+    // Since the input_fluxes param values are in meters per second, this will need to do some conversions to what gets
+    // passed to Tshirt_C's run(), which expects meters per hour.
+    std::vector<double> input_meters_per_hour(input_fluxes.size());
+    for (int i = 0; i < input_fluxes.size(); ++i) {
+        input_meters_per_hour[i] = input_fluxes[i] * 3600;
+    }
+    double* input_as_array = &input_meters_per_hour[0];
 
     tshirt_c_result_fluxes output_fluxes_as_array[num_timesteps];
 

--- a/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
+++ b/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
@@ -298,7 +298,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1a) {
         Tokenizer tokenizer(line);
         result_vector.assign(tokenizer.begin(), tokenizer.end());
 
-        double input_storage = std::stod(result_vector[1]) / 1000;
+        double input_storage = std::stod(result_vector[1]) / 1000 / 3600;
 
         // Output the line essentially
         //copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
@@ -364,7 +364,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1b) {
     std::string actual_last = tshirt_c_real.get_output_line_for_timestep(timestep - 1);
     std::string outside_bounds = tshirt_c_real.get_output_line_for_timestep(timestep);
 
-    EXPECT_EQ(actual_last, "0.000000,0.000000,0.000000,0.000003,0.000233,0.000236");
+    EXPECT_EQ(actual_last, "0.000000,0.000000,0.000000,0.000049,0.000336,0.000385");
     ASSERT_EQ(outside_bounds, "");
 }
 
@@ -620,8 +620,10 @@ TEST_F(Tshirt_C_Realization_Test, TestSurfaceRunoffCalc1a) {
         // variable to convert them into cubic meters per time step.
         //input_storage *= c_impl_ex_catchment_area_km2;
 
-        // The run function now expects inputs in meters per timestep
+        // However, the data starts in mm/h, so first convert mm to m ...
         input_storage /= 1000;
+        // ... then convert m / h to m / s
+        input_storage /= 3600;
 
         // runoff is index 2
         double expected = std::stod(result_vector[2]);
@@ -696,8 +698,10 @@ TEST_F(Tshirt_C_Realization_Test, TestGiuhRunoffCalc1a) {
         // variable to convert them into cubic meters per time step.
         //input_storage *= c_impl_ex_catchment_area_km2;
 
-        // The run function now expects inputs in meters per timestep
+        // However, the data starts in mm/h, so first convert mm to m ...
         input_storage /= 1000;
+        // ... then convert m / h to m / s
+        input_storage /= 3600;
 
         // giuh runoff is index 3
         double expected = std::stod(result_vector[3]);
@@ -784,8 +788,10 @@ TEST_F(Tshirt_C_Realization_Test, TestLateralFlowCalc1a) {
         // variable to convert them into cubic meters per time step.
         //input_storage *= c_impl_ex_catchment_area_km2;
 
-        // The run function now expects inputs in meters per timestep
+        // However, the data starts in mm/h, so first convert mm to m ...
         input_storage /= 1000;
+        // ... then convert m / h to m / s
+        input_storage /= 3600;
 
         // lateral flow is index 4
         double expected = std::stod(result_vector[4]);
@@ -861,8 +867,10 @@ TEST_F(Tshirt_C_Realization_Test, TestBaseFlowCalc1a) {
         // variable to convert them into cubic meters per time step.
         //input_storage *= c_impl_ex_catchment_area_km2;
 
-        // The run function now expects inputs in meters per timestep
+        // However, the data starts in mm/h, so first convert mm to m ...
         input_storage /= 1000;
+        // ... then convert m / h to m / s
+        input_storage /= 3600;
 
         // base flow is index 5
         double expected = std::stod(result_vector[5]);
@@ -938,8 +946,10 @@ TEST_F(Tshirt_C_Realization_Test, TestTotalDischargeOutputCalc1a) {
         // variable to convert them into cubic meters per time step.
         //input_storage *= c_impl_ex_catchment_area_km2;
 
-        // The run function now expects inputs in meters per timestep
+        // However, the data starts in mm/h, so first convert mm to m ...
         input_storage /= 1000;
+        // ... then convert m / h to m / s
+        input_storage /= 3600;
 
         // output is index 5
         double expected = std::stod(result_vector[6]);

--- a/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
+++ b/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
@@ -249,7 +249,7 @@ TEST_F(Tshirt_C_Realization_Test, TestRun0) {
             params,
             nash_storage);
 
-    int result = tshirt_c_real.run_formulation_for_timestep(0.0);
+    int result = tshirt_c_real.run_formulation_for_timestep(0.0, 3600);
 
     // TODO: figure out how to test for bogus/mismatched nash_n and state nash vector size (without silent error)
 
@@ -304,7 +304,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1a) {
         //copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
         //cout << "\n";
 
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         timestep++;
     }
 
@@ -357,7 +357,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1b) {
         Tokenizer tokenizer(line);
         result_vector.assign(tokenizer.begin(), tokenizer.end());
         double input_storage = std::stod(result_vector[1]) / 1000;
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         timestep++;
     }
 
@@ -620,7 +620,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetValue1a) {
         Tokenizer tokenizer(line);
         result_vector.assign(tokenizer.begin(), tokenizer.end());
         double input_storage = std::stod(result_vector[1]);
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         values_vector.emplace_back(tshirt_c_real.get_latest_flux_surface_runoff());
     }
 
@@ -667,7 +667,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetValue1b) {
         Tokenizer tokenizer(line);
         result_vector.assign(tokenizer.begin(), tokenizer.end());
         double input_storage = std::stod(result_vector[1]);
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         values_vector.emplace_back(tshirt_c_real.get_latest_flux_total_discharge());
     }
 
@@ -733,7 +733,7 @@ TEST_F(Tshirt_C_Realization_Test, TestSurfaceRunoffCalc1a) {
         copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
         cout << "\n";
 
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
 
         double actual = tshirt_c_real.get_latest_flux_surface_runoff();
 
@@ -811,7 +811,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGiuhRunoffCalc1a) {
         copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
         cout << "\n";
 
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_giuh_runoff();
 
         // Note that, for non-zero values, having to work within a reasonable upper and lower bounds to allow for
@@ -901,7 +901,7 @@ TEST_F(Tshirt_C_Realization_Test, TestLateralFlowCalc1a) {
         copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
         cout << "\n";
 
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_lateral_flow();
 
         // Note that, for non-zero values, having to work within a reasonable upper and lower bounds to allow for
@@ -980,7 +980,7 @@ TEST_F(Tshirt_C_Realization_Test, TestBaseFlowCalc1a) {
         copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
         cout << "\n";
 
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_base_flow();
 
         // Note that, for non-zero values, having to work within a reasonable upper and lower bounds to allow for
@@ -1059,7 +1059,7 @@ TEST_F(Tshirt_C_Realization_Test, TestTotalDischargeOutputCalc1a) {
         copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
         cout << "\n";
 
-        tshirt_c_real.run_formulation_for_timestep(input_storage);
+        tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_total_discharge();
 
         // Note that, for non-zero values, having to work within a reasonable upper and lower bounds to allow for

--- a/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
+++ b/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
@@ -368,6 +368,104 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1b) {
     ASSERT_EQ(outside_bounds, "");
 }
 
+/**
+ * Test function for getting values for time step in formatted output string, for first and last time step, when reading
+ * from forcing data.
+ */
+TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep2a) {
+    int example_index = 0;
+
+    open_standalone_c_impl_data_stream();
+
+    setup_standalone_c_impl_example_case();
+
+    // init gw res as half full for test
+    double gw_storage_ratio = 0.5;
+
+    // init soil reservoir as 2/3 full
+    double soil_storage_ratio = 0.667;
+
+    std::vector<double> nash_storage(c_impl_ex_tshirt_params->nash_n);
+    for (int i = 0; i < c_impl_ex_tshirt_params->nash_n; i++) {
+        nash_storage[i] = 0.0;
+    }
+
+    std::vector<double> giuh_ordinates = giuh_ordinate_examples[example_index];
+
+    realization::Tshirt_C_Realization tshirt_c_real(
+            forcing_params_examples[example_index],
+            utils::StreamHandler(),
+            soil_storage_ratio,
+            gw_storage_ratio,
+            true,
+            "wat-88",
+            giuh_ordinates,
+            *c_impl_ex_tshirt_params,
+            nash_storage);
+
+    std::vector<std::string> result_vector;
+    string line;
+
+    for (int timestep = 0; timestep < 5; ++timestep) {
+        tshirt_c_real.get_response(timestep, 3600);
+    }
+
+    std::string actual_first = tshirt_c_real.get_output_line_for_timestep(0);
+    std::string actual_last = tshirt_c_real.get_output_line_for_timestep(4);
+
+    EXPECT_EQ(actual_first, "0.000000,0.000000,0.000000,0.000000,0.191086,0.191086");
+    ASSERT_EQ(actual_last, "0.000000,0.000000,0.000000,0.000242,0.145356,0.145598");
+}
+
+/**
+ * Test function for getting values for time step in formatted output string handles out-of-bounds case as expected,
+ * when reading from forcing data.
+ */
+TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep2b) {
+    int example_index = 0;
+
+    open_standalone_c_impl_data_stream();
+
+    setup_standalone_c_impl_example_case();
+
+    // init gw res as half full for test
+    double gw_storage_ratio = 0.5;
+
+    // init soil reservoir as 2/3 full
+    double soil_storage_ratio = 0.667;
+
+    std::vector<double> nash_storage(c_impl_ex_tshirt_params->nash_n);
+    for (int i = 0; i < c_impl_ex_tshirt_params->nash_n; i++) {
+        nash_storage[i] = 0.0;
+    }
+
+    std::vector<double> giuh_ordinates = giuh_ordinate_examples[example_index];
+
+    realization::Tshirt_C_Realization tshirt_c_real(
+            forcing_params_examples[example_index],
+            utils::StreamHandler(),
+            soil_storage_ratio,
+            gw_storage_ratio,
+            true,
+            "wat-88",
+            giuh_ordinates,
+            *c_impl_ex_tshirt_params,
+            nash_storage);
+
+    std::vector<std::string> result_vector;
+    string line;
+
+    for (int timestep = 0; timestep < 5; ++timestep) {
+        tshirt_c_real.get_response(timestep, 3600);
+    }
+
+    std::string actual_last = tshirt_c_real.get_output_line_for_timestep(4);
+    std::string outside_bounds = tshirt_c_real.get_output_line_for_timestep(5);
+
+    EXPECT_EQ(actual_last, "0.000000,0.000000,0.000000,0.000242,0.145356,0.145598");
+    ASSERT_EQ(outside_bounds, "");
+}
+
 /** Test function for getting number of output variables for realization type. */
 TEST_F(Tshirt_C_Realization_Test, TestGetOutputItemCount1a) {
     int example_index = 0;


### PR DESCRIPTION
The units for input data were not entirely consistent between the formulation and model code for the C-based Tshirt model.  This corrects that by having the formulation do a conversion before calling the model code.  It also updates unit tests as appropriate.