### PR TITLE
Changed variable time_step to output_time_index to fix build failure

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -238,7 +238,7 @@ int main(int argc, char *argv[]) {
             catchment_outfiles[formulation_pair.first] << "Time Step," << "Time," << header_str <<std::endl;
         }
         std::string output_str = formulation_pair.second->get_output_line_for_timestep(output_time_index);
-        catchment_outfiles[formulation_pair.first] << time_step << "," << current_timestamp << "," << output_str << std::endl;
+        catchment_outfiles[formulation_pair.first] << output_time_index << "," << current_timestamp << "," << output_str << std::endl;
         response = response * boost::geometry::area(nexus_collection->get_feature(formulation_pair.first)->geometry<geojson::multipolygon_t>());
         std::cout << "\t\tThe modified response is: " << response << std::endl;
         //update the nexus with this flow


### PR DESCRIPTION
Changed variable time_step to output_time_index to fix build failure

Fixes #201. This currently fails the run ngen.cpp test that clones and builds master because master has the old variable, time_step. Merging this should fix the automatically running of ngen.cpp

https://github.com/NOAA-OWP/ngen/pull/209/checks?check_run_id=1444799411#step:3:578

## Testing

1. Passes all unit tests locally

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
