### PR TITLE
Fix Actions config after Boost change.

### DIFF
--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -24,8 +24,24 @@ jobs:
     - name: git submodule
       run: git submodule update --init --recursive -- test/googletest
 
+    - name: Cache Boost Dependency
+      id: cache-boost-dep
+      uses: actions/cache@v1
+      with:
+        path: boost_1_72_0
+        key: unix-boost-dep
+
+    - name: Get Boost Dependency
+      if: steps.cache-boost-dep.outputs.cache-hit != 'true'
+      run: |
+        curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+        tar xjf boost_1_72_0.tar.bz2
+
     - name: cmake_init_build
-      run: cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=OFF -S .
+      run: |
+        export BOOST_ROOT="$(pwd)/boost_1_72_0"
+        [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
+        cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=OFF -S .
     
     - name: build_tests
       run: cmake --build cmake_build --target test_unit
@@ -61,8 +77,24 @@ jobs:
       - name: build_cfe_build_shared_lib
         run: cmake --build extern/cfe/cmake_cfe_lib --target cfemodel
 
+      - name: Cache Boost Dependency
+        id: cache-boost-dep
+        uses: actions/cache@v1
+        with:
+          path: boost_1_72_0
+          key: unix-boost-dep
+
+      - name: Get Boost Dependency
+        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
+        run: |
+          curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+          tar xjf boost_1_72_0.tar.bz2
+
       - name: cmake_init_build
-        run: cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_C_LIB_NAME:STRING=cfemodel -DBMI_C_LIB_DIR:STRING=./extern/cfe/cmake_cfe_lib -S .
+        run: |
+          export BOOST_ROOT="$(pwd)/boost_1_72_0"
+          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
+          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_C_LIB_NAME:STRING=cfemodel -DBMI_C_LIB_DIR:STRING=./extern/cfe/cmake_cfe_lib -S .
 
       - name: build_bmi_c_tests
         run: cmake --build cmake_build --target test_bmi_c


### PR DESCRIPTION
Fixing Github Actions config after Github [removal of Boost from Actions images](https://github.com/actions/virtual-environments/issues/2667).

## Changes

- Actions running on Ubuntu have steps added for acquiring Boost manually
- Actions running on Ubuntu have CMake build init step adjusted to set path to Boost via env variable
