### PR TITLE
Update BMI C Formulation to Properly Handle Input Variables

### DIFF
--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -70,10 +70,11 @@ There are some special config parameters which are not *always* required in BMI 
   * Required for C-based BMI model formulations
 
 ### Optional Parameters
-* `other_input_variables`
-  * this may be provided to set certain model variables more directly after its `initialize` function
-  * JSON structure should be one or more nested JSON nodes, keyed by the variable name, and with the variable values contained as a list
-  * e.g.,  `"other_input_variables": {"ex_var_1": [0, 1, 2]}`
+* `variables_names_map`
+  * can specify a mapping of model variable names (input or output) to supported standard names
+  * supported standard names are listed in the [include/utilities/Constants.h](../include/utilities/Constants.h) file
+  * this can be useful in particular for informing the framework how to provide the input a model needs for execution
+  * e.g.,  `"variables_names_map": {"model_variable_name": "standard_variable_name"}`
 * `output_variables`
   * can specify the particular set and order of output variables to include in the realization's `get_output_line_for_timestep()` (and similar) function
   * JSON structure should be a list of strings

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -145,6 +145,45 @@ class Forcing
     }
 
     /**
+     * Get the current value of a forcing param identified by its name.
+     *
+     * @param name The name of the forcing param for which the current value is desired.
+     * @return The particular param's current value.
+     */
+    inline double get_value_for_param_name(const std::string& name) {
+        if (name == AORC_FIELD_NAME_PRECIP_RATE) {
+            return get_current_hourly_precipitation_meters_per_second();
+        }
+        if (name == AORC_FIELD_NAME_SOLAR_SHORTWAVE) {
+            return get_AORC_DSWRF_surface_W_per_meters_squared();
+        }
+        if (name == AORC_FIELD_NAME_SOLAR_LONGWAVE) {
+            return get_AORC_DLWRF_surface_W_per_meters_squared();
+        }
+        if (name == AORC_FIELD_NAME_PRESSURE_SURFACE) {
+            return get_AORC_PRES_surface_Pa();
+        }
+        if (name == AORC_FIELD_NAME_TEMP_2M_AG) {
+            return get_AORC_TMP_2maboveground_K();
+        }
+        if (name == AORC_FIELD_NAME_APCP_SURFACE) {
+            return get_AORC_APCP_surface_kg_per_meters_squared();
+        }
+        if (name == AORC_FIELD_NAME_WIND_U_10M_AG) {
+            return get_AORC_UGRD_10maboveground_meters_per_second();
+        }
+        if (name == AORC_FIELD_NAME_WIND_V_10M_AG) {
+            return get_AORC_VGRD_10maboveground_meters_per_second();
+        }
+        if (name == AORC_FIELD_NAME_SPEC_HUMID_2M_AG) {
+            return get_AORC_SPFH_2maboveground_kg_per_kg();
+        }
+        else {
+            throw std::runtime_error("Cannot get forcing value for unrecognized parameter name '" + name + "'.");
+        }
+    }
+
+    /**
      * @brief Checks forcing vector index bounds and adjusts index if out of vector bounds
      * /// \todo: Bounds checking is based on precipitation vector. Consider potential for vectors of different sizes and indices.
      */

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -13,6 +13,18 @@
 #include <time.h>
 #include <memory>
 
+// Recognized Forcing Value Names (in particular for use when configuring BMI input variables)
+// TODO: perhaps create way to configure a mapping of these to something different
+#define AORC_FIELD_NAME_PRECIP_RATE "precip_rate"
+#define AORC_FIELD_NAME_SOLAR_SHORTWAVE "DSWRF_surface"
+#define AORC_FIELD_NAME_SOLAR_LONGWAVE "DLWRF_surface"
+#define AORC_FIELD_NAME_PRESSURE_SURFACE "PRES_surface"
+#define AORC_FIELD_NAME_TEMP_2M_AG "TMP_2maboveground"
+#define AORC_FIELD_NAME_APCP_SURFACE "APCP_surface"
+#define AORC_FIELD_NAME_WIND_U_10M_AG "UGRD_10maboveground"
+#define AORC_FIELD_NAME_WIND_V_10M_AG "VGRD_10maboveground"
+#define AORC_FIELD_NAME_SPEC_HUMID_2M_AG "SPFH_2maboveground"
+
 using namespace std;
 
 /**
@@ -67,6 +79,26 @@ class Forcing
     public:
 
     typedef struct tm time_type;
+    
+    /**
+     * Get supported standard names for forcing fields.
+     *
+     * @return
+     */
+    static std::shared_ptr<set<std::string>> get_forcing_field_names() {
+        std::shared_ptr<set<std::string>> field_names = std::make_shared<set<std::string>>();
+        field_names->insert(AORC_FIELD_NAME_PRECIP_RATE);
+        field_names->insert(AORC_FIELD_NAME_SOLAR_SHORTWAVE);
+        field_names->insert(AORC_FIELD_NAME_SOLAR_LONGWAVE);
+        field_names->insert(AORC_FIELD_NAME_PRESSURE_SURFACE);
+        field_names->insert(AORC_FIELD_NAME_TEMP_2M_AG);
+        field_names->insert(AORC_FIELD_NAME_APCP_SURFACE);
+        field_names->insert(AORC_FIELD_NAME_WIND_U_10M_AG);
+        field_names->insert(AORC_FIELD_NAME_WIND_V_10M_AG);
+        field_names->insert(AORC_FIELD_NAME_SPEC_HUMID_2M_AG);
+        return field_names;
+    }
+
 
     /**
      * Default Constructor building an empty Forcing object

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -145,6 +145,20 @@ class Forcing
     }
 
     /**
+     * Placeholder implementation for function to return the given param adjusted to be in the supplied units.
+     *
+     * At present this just returns the param's internal value.
+     *
+     * @param name The name of the desired parameter.
+     * @param units_str A string represented the units for conversion, using standard abbreviations.
+     * @return For now, just the param value, but in the future, the value converted.
+     */
+    inline double get_converted_value_for_param_in_units(const std::string& name, const std::string& units_str) {
+        // TODO: this is just a placeholder implementation that needs to be replaced with real convertion logic
+        return get_value_for_param_name(name);
+    }
+
+    /**
      * Get the current value of a forcing param identified by its name.
      *
      * @param name The name of the forcing param for which the current value is desired.

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -293,6 +293,20 @@ class Forcing
     };
 
     /**
+     * Get the time step size, based on epoch vector, assuming the last ts is equal to the next to last.
+     *
+     * @return
+     */
+    time_t get_time_step_size() {
+        check_forcing_vector_index_bounds();
+        // When at the last index, make an assumption the length is the same as the next-to-last
+        if (time_epoch_vector.size() - 1 == forcing_vector_index)
+            return time_epoch_vector.at(forcing_vector_index) - time_epoch_vector.at(forcing_vector_index - 1);
+        else
+            return time_epoch_vector.at(forcing_vector_index + 1) - time_epoch_vector.at(forcing_vector_index);
+    }
+
+    /**
      * @brief Accessor to AORC data struct
      * @return AORC_data
      */

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -85,8 +85,8 @@ class Forcing
      *
      * @return
      */
-    static std::shared_ptr<set<std::string>> get_forcing_field_names() {
-        std::shared_ptr<set<std::string>> field_names = std::make_shared<set<std::string>>();
+    static std::shared_ptr<std::set<std::string>> get_forcing_field_names() {
+        std::shared_ptr<std::set<std::string>> field_names = std::make_shared<std::set<std::string>>();
         field_names->insert(AORC_FIELD_NAME_PRECIP_RATE);
         field_names->insert(AORC_FIELD_NAME_SOLAR_SHORTWAVE);
         field_names->insert(AORC_FIELD_NAME_SOLAR_LONGWAVE);

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -406,6 +406,34 @@ class Forcing
         return AORC_vector.at(forcing_vector_index).VGRD_10maboveground_meters_per_second;
     };
 
+    /**
+     * Get whether a param's value is an aggregate sum over the entire time step.
+     *
+     * Certain params, like rain fall, are aggregated sums over an entire time step.  Others, such as pressure, are not
+     * such sums and instead something else like an instantaneous reading or an average value over the time step.
+     *
+     * It may be the case that forcing data is needed for some discretization different than the forcing time step.
+     * These values can be calculated (or at least approximated), but doing so requires knowing which values are summed
+     * versus not.
+     *
+     * @param name The name of the forcing param for which the current value is desired.
+     * @return Whether the param's value is an aggregate sum.
+     */
+    inline bool is_param_sum_over_time_step(const std::string& name) {
+        if (name == AORC_FIELD_NAME_PRECIP_RATE) {
+            return true;
+        }
+        if (name == AORC_FIELD_NAME_SOLAR_SHORTWAVE) {
+            return true;
+        }
+        if (name == AORC_FIELD_NAME_SOLAR_LONGWAVE) {
+            return true;
+        }
+        if (name == AORC_FIELD_NAME_APCP_SURFACE) {
+            return true;
+        }
+        return false;
+    }
 
     private:
 

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -2,6 +2,7 @@
 #define FORCING_H
 
 #include <vector>
+#include <set>
 #include <cmath>
 #include <algorithm>
 #include <string>

--- a/include/realizations/catchment/Bmi_C_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_C_Formulation.hpp
@@ -98,6 +98,16 @@ namespace realization {
         std::shared_ptr<models::bmi::Bmi_C_Adapter> construct_model(const geojson::PropertyMap& properties) override;
 
         /**
+         * Determine and set the offset time of the model in seconds, compared to forcing data.
+         *
+         * BMI models frequently have their model start time be set to 0.  As such, to know what the forcing time is
+         * compared to the model time, an offset value is needed.  This becomes important in situations when the size of
+         * the time steps for forcing data versus model execution are not equal.  This method will determine and set
+         * this value.
+         */
+        void determine_model_time_offset() override;
+
+        /**
          * Get model input values from forcing data, accounting for model and forcing time steps not aligning.
          *
          * Get values to use to set model input variables, sourced from forcing data.  Account for if model time step

--- a/include/realizations/catchment/Bmi_C_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_C_Formulation.hpp
@@ -172,6 +172,7 @@ namespace realization {
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_C_Formulation_Test;
+        friend class ::Bmi_C_Cfe_IT;
 
     private:
 

--- a/include/realizations/catchment/Bmi_C_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_C_Formulation.hpp
@@ -188,6 +188,15 @@ namespace realization {
          */
         bool is_model_initialized() override;
 
+        /**
+         * Set BMI input variable values for the model appropriately prior to calling its `BMI `update()``.
+         *
+         * @param model_initial_time The model's time prior to the update, in its internal units and representation.
+         * @param t_delta The size of the time step over which the formulation is going to update the model, which might
+         *                be different than the model's internal time step.
+         */
+        void set_model_inputs_prior_to_update(const double &model_initial_time, time_step_t t_delta) override;
+
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_C_Formulation_Test;

--- a/include/realizations/catchment/Bmi_C_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_C_Formulation.hpp
@@ -98,6 +98,25 @@ namespace realization {
         std::shared_ptr<models::bmi::Bmi_C_Adapter> construct_model(const geojson::PropertyMap& properties) override;
 
         /**
+         * Get model input values from forcing data, accounting for model and forcing time steps not aligning.
+         *
+         * Get values to use to set model input variables, sourced from forcing data.  Account for if model time step
+         * (MTS) does not align with forcing time step (FTS), either due to MTS starting after the start of FTS, MTS
+         * extending beyond the end of FTS, or both.
+         *
+         * @param t_delta The size of the model's time step in seconds.
+         * @param model_initial_time The model's current time in its internal units and representation.
+         * @param params An ordered collection of desired forcing param names from which data for inputs is needed.
+         * @param param_units An ordered collection units of strings representing the BMI model's expected units for the
+         *                    corresponding input, so that value conversions of the proportional contributions are done.
+         * @param summed_contributions A referenced ordered collection that will contain the returned summed contributions.
+         */
+        inline void get_forcing_data_ts_contributions(time_step_t t_delta, const double &model_initial_time,
+                                                      const std::vector<std::string> &params,
+                                                      const std::vector<std::string> &param_units,
+                                                      std::vector<double> &summed_contributions);
+
+        /**
          * Get a value, converted to specified type, for an output variable at a time step.
          *
          * Function gets the value for a provided output variable at a provided time step index, and returns the value

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -140,6 +140,10 @@ namespace realization {
             return forcing_file_path;
         }
 
+        const time_t &get_bmi_model_start_time_forcing_offset_s() const {
+            return bmi_model_start_time_forcing_offset_s;
+        }
+
         /**
          * Get the name of the specific type of the backing model object.
          *
@@ -295,6 +299,10 @@ namespace realization {
             bmi_model = model;
         }
 
+        void set_bmi_model_start_time_forcing_offset_s(const time_t &offset_s) {
+            bmi_model_start_time_forcing_offset_s = offset_s;
+        }
+
         void set_bmi_model_time_step_fixed(bool is_fix_time_step) {
             bmi_model_time_step_fixed = is_fix_time_step;
         }
@@ -369,6 +377,11 @@ namespace realization {
         std::shared_ptr<M> bmi_model;
         /** Whether backing model has fixed time step size. */
         bool bmi_model_time_step_fixed = true;
+        /**
+         * The offset, converted to seconds, from the model's start time to the start time of the initial forcing time
+         * step.
+         */
+        time_t bmi_model_start_time_forcing_offset_s;
         std::string bmi_main_output_var;
         /** A configured mapping of BMI model variable names to standard names for use inside the framework. */
         std::map<std::string, std::string> bmi_var_names_map;

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -115,6 +115,16 @@ namespace realization {
          */
         virtual std::shared_ptr<M> construct_model(const geojson::PropertyMap& properties) = 0;
 
+        /**
+         * Determine and set the offset time of the model in seconds, compared to forcing data.
+         *
+         * BMI models frequently have their model start time be set to 0.  As such, to know what the forcing time is
+         * compared to the model time, an offset value is needed.  This becomes important in situations when the size of
+         * the time steps for forcing data versus model execution are not equal.  This method will determine and set
+         * this value.
+         */
+        virtual void determine_model_time_offset() = 0;
+
         const bool &get_allow_model_exceed_end_time() const {
             return allow_model_exceed_end_time;
         }
@@ -220,6 +230,10 @@ namespace realization {
             // Do this next, since after checking whether other input variables are present in the properties, we can
             // now construct the adapter and init the model
             set_bmi_model(construct_model(properties));
+
+            // Make sure that this is able to interpret model time and convert to real time, since BMI model time is
+            // usually starting at 0 and just counting up
+            determine_model_time_offset();
 
             // Output variable subset and order, if present
             auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -23,6 +23,7 @@
 // Forward declaration to provide access to protected items in testing
 class Bmi_Formulation_Test;
 class Bmi_C_Formulation_Test;
+class Bmi_C_Cfe_IT;
 
 namespace realization {
 

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -322,6 +322,15 @@ namespace realization {
         }
 
         /**
+         * Set BMI input variable values for the model appropriately prior to calling its `BMI `update()``.
+         *
+         * @param model_initial_time The model's time prior to the update, in its internal units and representation.
+         * @param t_delta The size of the time step over which the formulation is going to update the model, which might
+         *                be different than the model's internal time step.
+         */
+        virtual void set_model_inputs_prior_to_update(const double &model_initial_time, time_step_t t_delta) = 0;
+
+        /**
          * Set the name of the specific type of the backing model object.
          *
          * @param type_name The name of the backing model object's type.

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -20,6 +20,12 @@
 #define BMI_REALIZATION_CFG_PARAM_OPT__FIXED_TIME_STEP "fixed_time_step"
 #define BMI_REALIZATION_CFG_PARAM_OPT__LIB_FILE "library_file"
 
+// Supported Standard Names for BMI variables
+//
+// Taken from the CSDMS Standard Names list
+// TODO: need to add these in for anything BMI model input or output variables we need to know how to recognize
+#define CSDMS_STD_NAME_RAIN_RATE "atmosphere_water__rainfall_volume_flux"
+
 // Forward declaration to provide access to protected items in testing
 class Bmi_Formulation_Test;
 class Bmi_C_Formulation_Test;

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -178,6 +178,7 @@ double Bmi_C_Formulation::get_response(time_step_t t_index, time_step_t t_delta)
         throw std::invalid_argument("Getting response of previous time step in BMI C formulation is not allowed.");
     }
 
+    // The time step delta size, expressed in the units internally used by the model
     double t_delta_model_units;
     if (next_time_step_index <= t_index) {
         t_delta_model_units = get_bmi_model()->convert_seconds_to_model_time(t_delta);
@@ -193,10 +194,12 @@ double Bmi_C_Formulation::get_response(time_step_t t_index, time_step_t t_delta)
     }
 
     while (next_time_step_index <= t_index) {
+        double model_initial_time = get_bmi_model()->GetCurrentTime();
+        set_model_inputs_prior_to_update(model_initial_time, t_delta);
         if (t_delta_model_units == get_bmi_model()->GetTimeStep())
             get_bmi_model()->Update();
         else
-            get_bmi_model()->UpdateUntil(get_bmi_model()->GetCurrentTime() + t_delta_model_units);
+            get_bmi_model()->UpdateUntil(model_initial_time + t_delta_model_units);
         // TODO: again, consider whether we should store any historic response, ts_delta, or other var values
         next_time_step_index++;
     }

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -35,6 +35,20 @@ std::shared_ptr<Bmi_C_Adapter> Bmi_C_Formulation::construct_model(const geojson:
 }
 
 /**
+ * Determine and set the offset time of the model in seconds, compared to forcing data.
+ *
+ * BMI models frequently have their model start time be set to 0.  As such, to know what the forcing time is
+ * compared to the model time, an offset value is needed.  This becomes important in situations when the size of
+ * the time steps for forcing data versus model execution are not equal.  This method will determine and set
+ * this value.
+ */
+void Bmi_C_Formulation::determine_model_time_offset() {
+    set_bmi_model_start_time_forcing_offset_s(forcing.get_time_epoch() -
+                                              (time_t) get_bmi_model()->convert_model_time_to_seconds(
+                                                      get_bmi_model()->GetStartTime()));
+}
+
+/**
  * Get model input values from forcing data, accounting for model and forcing time steps not aligning.
  *
  * Get values to use to set model input variables, sourced from forcing data.  Account for if model time step

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -11,46 +11,27 @@ std::string Bmi_C_Formulation::get_formulation_type() {
 }
 
 /**
- * Construct model and its shared pointer, potentially supplying input variable values from config.
+ * Construct model and its shared pointer.
  *
- * Construct a model (and a shared pointer to it), checking whether additional input variable values are present in the
- * configuration properties and need to be used during model construction.
- *
- * @param properties Configuration properties for the formulation, potentially containing values for input variables
- * @return A shared pointer to a newly constructed model adapter object
+ * @param properties Configuration properties for the formulation.
+ * @return A shared pointer to a newly constructed model adapter object.
  */
 std::shared_ptr<Bmi_C_Adapter> Bmi_C_Formulation::construct_model(const geojson::PropertyMap& properties) {
-    // First examine properties to see if other input variable values are provided
     auto library_file_iter = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__LIB_FILE);
     if (library_file_iter == properties.end()) {
         throw std::runtime_error("BMI C formulation requires path to library file, but none provided in config");
     }
     std::string lib_file = library_file_iter->second.as_string();
 
-    auto other_in_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OTHER_IN_VARS);
-    if (other_in_var_it != properties.end()) {
-        return std::make_shared<Bmi_C_Adapter>(
-                Bmi_C_Adapter(
-                        lib_file,
-                        get_bmi_init_config(),
-                        get_forcing_file_path(),
-                        is_bmi_using_forcing_file(),
-                        get_allow_model_exceed_end_time(),
-                        is_bmi_model_time_step_fixed(),
-                        other_in_var_it->second,
-                        output));
-    }
-    else {
-        return std::make_shared<Bmi_C_Adapter>(
-                Bmi_C_Adapter(
-                        lib_file,
-                        get_bmi_init_config(),
-                        get_forcing_file_path(),
-                        is_bmi_using_forcing_file(),
-                        get_allow_model_exceed_end_time(),
-                        is_bmi_model_time_step_fixed(),
-                        output));
-    }
+    return std::make_shared<Bmi_C_Adapter>(
+            Bmi_C_Adapter(
+                    lib_file,
+                    get_bmi_init_config(),
+                    get_forcing_file_path(),
+                    is_bmi_using_forcing_file(),
+                    get_allow_model_exceed_end_time(),
+                    is_bmi_model_time_step_fixed(),
+                    output));
 }
 
 /**

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -193,7 +193,7 @@ void Bmi_C_Formulation_Test::SetUp() {
     /* Set up the derived example details */
     for (int i = 0; i < EX_COUNT; i++) {
         std::shared_ptr<forcing_params> params = std::make_shared<forcing_params>(
-                forcing_params(forcing_file[i], "2015-12-01 00:00:00", "2015-12-01 23:00:00"));
+                forcing_params(forcing_file[i], "2015-12-01 00:00:00", "2015-12-30 23:00:00"));
         std::string variables_line = (i == 1) ? variables_with_rain_rate : "";
         forcing_params_examples[i] = params;
         config_json[i] = "{"

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -291,6 +291,15 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_1_b) {
     ASSERT_EQ(output, "0.003153,0.004346,0.000449,0.001001,0.001424,0.002874");
 }
 
+TEST_F(Bmi_C_Formulation_Test, determine_model_time_offset_1_a) {
+    // TODO: implement tests
+    ASSERT_TRUE(false);
+}
+
+TEST_F(Bmi_C_Formulation_Test, get_forcing_data_ts_contributions_1_a) {
+    // TODO: implement tests
+    ASSERT_TRUE(false);
+}
 
 
 #endif  // NGEN_BMI_C_LIB_TESTS_ACTIVE

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -41,6 +41,15 @@ protected:
         formulation.determine_model_time_offset();
     }
 
+    static void call_friend_get_forcing_data_ts_contributions(Bmi_C_Formulation& formulation,
+                                                              time_step_t t_delta, const double &model_initial_time,
+                                                              const std::vector<std::string> &params,
+                                                              const std::vector<std::string> &param_units,
+                                                              std::vector<double> &contributions)
+    {
+        formulation.get_forcing_data_ts_contributions(t_delta, model_initial_time, params, param_units, contributions);
+    }
+
     static std::string get_friend_bmi_init_config(const Bmi_C_Formulation& formulation) {
         return formulation.get_bmi_init_config();
     }
@@ -56,12 +65,20 @@ protected:
         return formulation.get_bmi_model_start_time_forcing_offset_s();
     }
 
+    static double get_friend_forcing_param_value(Bmi_C_Formulation& formulation, const std::string& param_name) {
+        return formulation.forcing.get_value_for_param_name(param_name);
+    }
+
     static std::string get_friend_forcing_file_path(const Bmi_C_Formulation& formulation) {
         return formulation.get_forcing_file_path();
     }
 
     static time_t get_friend_forcing_start_time(Bmi_C_Formulation& formulation) {
         return formulation.forcing.get_time_epoch();
+    }
+
+    static time_t get_friend_forcing_time_step_size(Bmi_C_Formulation& formulation) {
+        return formulation.forcing.get_time_step_size();
     }
 
     static bool get_friend_is_bmi_using_forcing_file(const Bmi_C_Formulation& formulation) {


### PR DESCRIPTION
Updating the BMI C formulation class to be able to handle setting the publicized _input_ variables of the backing BMI model as needed before model updates.

## Additions

- Macro constants and new functions in _Forcing_ class to make it easy to get the known available forcing data fields and get the current value for a field. 
- Members to keep track of and allow access to whether forcing data fields in _Forcing_ are an aggregate sum over a time step (e.g., rain fall), as opposed to an instantaneous reading or average amount (e.g., pressure).
- Stub pass-thru function in _Forcing_ class as a placeholder for eventual function that converts forcing value to other units.
- Function in _Forcing_ class to get the size of the current forcing data time step (needed when a model's time steps do not align).
- Configuration support in _Bmi_Formulation_ class for accepting a mapping of model input variable names to recognized forcing field names, along with updated documentation.
- Primary and helper functions for reading, interpreting, acquiring values for, and setting BMI model input variables, including the ability to get values correctly when needed input applies to only part of a forcing time step and/or multiple forcing time steps.

## Changes

- Modified BMI C formulation to call new function for setting BMI input variables with `get_response` function, just prior to executing BMI model `update`.

## Testing

- Several automated unit tests for new functionality.

## Todos

- A stub function was created for unit conversions for source forcing values, but right now no conversions are performed; eventually there will need to be something that can handle conversions based on the expected units the BMI model publicizes.  
