### PR TITLE
Remote Nexus Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 
 if(MPI_ACTIVE)
     find_package(MPI)
+    add_compile_definitions(NGEN_MPI_ACTIVE)
 endif()
 
 find_package(Boost 1.72.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ if(MPI_ACTIVE)
    set (CMAKE_CXX_COMPILER "mpicxx")
 endif()
 
-
 ########### Define project version and use via generated config header
 project(ngen VERSION 0.1.0)
 configure_file(include/NGenConfig.h.in include/NGenConfig.h)
@@ -70,7 +69,7 @@ endif()
 
 if(MPI_ACTIVE)
     find_package(MPI)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_FLAGS}")
+    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_FLAGS}")
     add_compile_definitions(NGEN_MPI_ACTIVE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ else()
     endif()
 endif()
 
+if(MPI_ACTIVE)
+    find_package(MPI)
+endif()
+
 find_package(Boost 1.72.0 REQUIRED)
 
 # Handle several steps for BMI C library logic and dependencies, at top level, if functionality is turned on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ endif()
 
 if(MPI_ACTIVE)
     find_package(MPI)
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_FLAGS}")
     add_compile_definitions(NGEN_MPI_ACTIVE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
+
+if(MPI_ACTIVE)
+   set (CMAKE_CXX_COMPILER "mpicxx")
+endif()
+
+
 ########### Define project version and use via generated config header
 project(ngen VERSION 0.1.0)
 configure_file(include/NGenConfig.h.in include/NGenConfig.h)
@@ -64,6 +70,7 @@ endif()
 
 if(MPI_ACTIVE)
     find_package(MPI)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_FLAGS}")
     add_compile_definitions(NGEN_MPI_ACTIVE)
 endif()
 

--- a/doc/MPI_REMOTE_NEXUS.md
+++ b/doc/MPI_REMOTE_NEXUS.md
@@ -1,0 +1,23 @@
+# MPI Remote Nexus
+
+* [Summary](#summary)
+
+## Summary
+
+This describes how to use the first iteration of the Remote Nexus Class with MPI.  
+
+The basic outline of steps needed to run the Remote Nexus Class with MPI is:
+  * Install MPI.
+  * Create the build directory including the option to activate MPI: 
+  
+      `cmake -DCMAKE_BUILD_TYPE=Debug -B cmake-build-debug -DMPI_ACTIVE:BOOL=ON -S .`  
+  
+  * Unit tests for the Remote Nexus Class can then be built and run from the main directory with the following two commands:
+  
+      `cmake --build cmake-build-debug --target test_remote_nexus`  <br />
+      
+      `mpirun -np 2 ./cmake-build-debug/test/test_remote_nexus`
+
+  * `mpirun -np 2` runs the test on 2 processors        
+  
+

--- a/include/core/nexus/HY_PointHydroNexus.hpp
+++ b/include/core/nexus/HY_PointHydroNexus.hpp
@@ -31,8 +31,6 @@ class HY_PointHydroNexus : public HY_HydroNexus
 
     protected:
 
-    private:
-
     typedef std::vector< std::pair<long,double> > id_flow_vector;
     typedef std::vector< std::pair<long,double> > id_request_vector;
 

--- a/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
@@ -18,6 +18,13 @@ class HY_PointHydroNexusRemoteDownstream : public HY_PointHydroNexus
 
         int get_world_rank();
 
+        double get_upstream_flow_value();
+
+        long get_catchment_id();
+
+        long get_time_step();
+
+
     private:
         int world_rank;
 
@@ -26,6 +33,7 @@ class HY_PointHydroNexusRemoteDownstream : public HY_PointHydroNexus
 
         double upstream_flow;
         long time_step; 
+        long upstream_catchment_id;
 
         // Create the datatype
         MPI_Datatype time_step_and_flow_type;
@@ -33,13 +41,11 @@ class HY_PointHydroNexusRemoteDownstream : public HY_PointHydroNexus
         struct time_step_and_flow_t
         {
             long time_step;
+            long catchment_id;
             double flow;
         };
 
         struct time_step_and_flow_t received;
-
-
-
 
 };
 

--- a/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
@@ -1,0 +1,30 @@
+#ifndef HY_POINTHYDRONEXUSREMOTEDOWNSTREAM_H
+#define HY_POINTHYDRONEXUSREMOTEDOWNSTREAM_H
+
+#include <HY_PointHydroNexus.hpp>
+#include <mpi.h>
+
+
+class HY_PointHydroNexusRemoteDownstream : public HY_PointHydroNexus
+{
+    public:
+        HY_PointHydroNexusRemoteDownstream(int nexus_id_number, std::string nexus_id, int num_downstream);
+        virtual ~HY_PointHydroNexusRemoteDownstream();
+
+        /** get the request percentage of downstream flow through this nexus at timestep t. */
+        double get_downstream_flow(long catchment_id, time_step_t t, double percent_flow);
+
+        /** add flow to this nexus for timestep t. */
+        void add_upstream_flow(double val, long catchment_id, time_step_t t);
+
+        int get_world_rank();
+
+
+    private:
+        int world_rank;
+
+
+
+};
+
+#endif // HY_POINTHYDRONEXUSREMOTEDOWNSTREAM_H

--- a/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
@@ -1,6 +1,8 @@
 #ifndef HY_POINTHYDRONEXUSREMOTEDOWNSTREAM_H
 #define HY_POINTHYDRONEXUSREMOTEDOWNSTREAM_H
 
+#ifdef NGEN_MPI_ACTIVE
+
 #include <HY_PointHydroNexus.hpp>
 #include <mpi.h>
 
@@ -27,4 +29,5 @@ class HY_PointHydroNexusRemoteDownstream : public HY_PointHydroNexus
 
 };
 
+#endif // NGEN_MPI_ACTIVE
 #endif // HY_POINTHYDRONEXUSREMOTEDOWNSTREAM_H

--- a/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteDownstream.hpp
@@ -13,17 +13,31 @@ class HY_PointHydroNexusRemoteDownstream : public HY_PointHydroNexus
         HY_PointHydroNexusRemoteDownstream(int nexus_id_number, std::string nexus_id, int num_downstream);
         virtual ~HY_PointHydroNexusRemoteDownstream();
 
-        /** get the request percentage of downstream flow through this nexus at timestep t. */
-        double get_downstream_flow(long catchment_id, time_step_t t, double percent_flow);
-
         /** add flow to this nexus for timestep t. */
         void add_upstream_flow(double val, long catchment_id, time_step_t t);
 
         int get_world_rank();
 
-
     private:
         int world_rank;
+
+        //Determine this with a broadcast of the ranks at init?
+        int upstream_remote_nexus_rank = 0;
+
+        double upstream_flow;
+        long time_step; 
+
+        // Create the datatype
+        MPI_Datatype time_step_and_flow_type;
+
+        struct time_step_and_flow_t
+        {
+            long time_step;
+            double flow;
+        };
+
+        struct time_step_and_flow_t received;
+
 
 
 

--- a/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
@@ -13,9 +13,6 @@ class HY_PointHydroNexusRemoteUpstream : public HY_PointHydroNexus
         HY_PointHydroNexusRemoteUpstream(int nexus_id_number, std::string nexus_id, int num_downstream);
         virtual ~HY_PointHydroNexusRemoteUpstream();
 
-        /** get the request percentage of downstream flow through this nexus at timestep t. */
-        double get_downstream_flow(long catchment_id, time_step_t t, double percent_flow);
-
         /** add flow to this nexus for timestep t. */
         void add_upstream_flow(double val, long catchment_id, time_step_t t);
 
@@ -23,6 +20,20 @@ class HY_PointHydroNexusRemoteUpstream : public HY_PointHydroNexus
 
     private:
         int world_rank;
+
+        //Determine this with a broadcast of the ranks at init?
+        int downstream_remote_nexus_rank = 1;
+
+        // Create the MPI datatype
+        MPI_Datatype time_step_and_flow_type;
+
+        struct time_step_and_flow_t
+        {
+           long time_step;
+           double flow;
+        };
+
+        struct time_step_and_flow_t buffer;
 
 
 };

--- a/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
@@ -30,11 +30,11 @@ class HY_PointHydroNexusRemoteUpstream : public HY_PointHydroNexus
         struct time_step_and_flow_t
         {
            long time_step;
+           long catchment_id;
            double flow;
         };
 
         struct time_step_and_flow_t buffer;
-
 
 };
 

--- a/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
@@ -1,0 +1,28 @@
+#ifndef HY_POINTHYDRONEXUSREMOTEUPSTREAM_H
+#define HY_POINTHYDRONEXUSREMOTEUPSTREAM_H
+
+#include <HY_PointHydroNexus.hpp>
+#include <mpi.h>
+
+
+class HY_PointHydroNexusRemoteUpstream : public HY_PointHydroNexus
+{
+    public:
+        HY_PointHydroNexusRemoteUpstream(int nexus_id_number, std::string nexus_id, int num_downstream);
+        virtual ~HY_PointHydroNexusRemoteUpstream();
+
+        /** get the request percentage of downstream flow through this nexus at timestep t. */
+        double get_downstream_flow(long catchment_id, time_step_t t, double percent_flow);
+
+        /** add flow to this nexus for timestep t. */
+        void add_upstream_flow(double val, long catchment_id, time_step_t t);
+
+        int get_world_rank();
+
+    private:
+        int world_rank;
+
+
+};
+
+#endif // HY_POINTHYDRONEXUSREMOTEUPSTREAM_H

--- a/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemoteUpstream.hpp
@@ -1,6 +1,8 @@
 #ifndef HY_POINTHYDRONEXUSREMOTEUPSTREAM_H
 #define HY_POINTHYDRONEXUSREMOTEUPSTREAM_H
 
+#ifdef NGEN_MPI_ACTIVE
+
 #include <HY_PointHydroNexus.hpp>
 #include <mpi.h>
 
@@ -25,4 +27,5 @@ class HY_PointHydroNexusRemoteUpstream : public HY_PointHydroNexus
 
 };
 
+#endif // NGEN_MPI_ACTIVE
 #endif // HY_POINTHYDRONEXUSREMOTEUPSTREAM_H

--- a/src/core/nexus/CMakeLists.txt
+++ b/src/core/nexus/CMakeLists.txt
@@ -16,3 +16,8 @@ find_package(Boost)
 target_link_libraries(core_nexus PUBLIC
         Boost::boost                # Headers-only Boost
         )
+
+if(MPI_ACTIVE)
+    add_compile_definitions(NGEN_MPI_ACTIVE)
+endif()
+

--- a/src/core/nexus/HY_PointHydroNexusRemoteDownstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteDownstream.cpp
@@ -1,5 +1,6 @@
 #include "HY_PointHydroNexusRemoteDownstream.hpp"
 
+#ifdef NGEN_MPI_ACTIVE
 
 HY_PointHydroNexusRemoteDownstream::HY_PointHydroNexusRemoteDownstream(int nexus_id_number, std::string nexus_id, int num_downstream) : HY_PointHydroNexus(nexus_id_number, nexus_id, num_downstream)
 {
@@ -108,3 +109,4 @@ int HY_PointHydroNexusRemoteDownstream::get_world_rank()
    return world_rank;
 }
 
+#endif // NGEN_MPI_ACTIVE

--- a/src/core/nexus/HY_PointHydroNexusRemoteDownstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteDownstream.cpp
@@ -1,0 +1,57 @@
+#include "HY_PointHydroNexusRemoteDownstream.hpp"
+
+
+HY_PointHydroNexusRemoteDownstream::HY_PointHydroNexusRemoteDownstream(int nexus_id_number, std::string nexus_id, int num_downstream) : HY_PointHydroNexus(nexus_id_number, nexus_id, num_downstream)
+{
+   MPI_Init(NULL, NULL);
+
+   MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+
+}
+
+HY_PointHydroNexusRemoteDownstream::~HY_PointHydroNexusRemoteDownstream()
+{
+    //dtor
+}
+
+double HY_PointHydroNexusRemoteDownstream::get_downstream_flow(long catchment_id, time_step_t t, double percent_flow)
+{
+   //double downstream_flow = HY_PointHydroNexus::get_downstream_flow(catchment_id, t, percent_flow);
+
+   double downstream_flow;
+
+   int upstream_remote_nexus_rank = 0;
+
+   //Need to update code for the possibility of multiple downstreams. Need to send this message to all downstreams.
+
+   //Send timestep(key to a dict to extract the info) and flow value as bytes with a custom type that packs these together
+   //Custom mpi type that is a pass structure
+
+   //Receive downstream_flow from Upstream Remote Nexus to this Downstream Remote Nexus
+   MPI_Recv(
+     /* data         = */ &downstream_flow, 
+     /* count        = */ 1, 
+     /* datatype     = */ MPI_DOUBLE, 
+     /* source       = */ upstream_remote_nexus_rank, 
+     /* tag          = */ 0, 
+     /* communicator = */ MPI_COMM_WORLD, 
+     /* status       = */ MPI_STATUS_IGNORE);
+
+   std::cout << "NexusRemoteDownstream downstream_flow: " << downstream_flow << std::endl; 
+
+   return downstream_flow;
+}
+
+void HY_PointHydroNexusRemoteDownstream::add_upstream_flow(double val, long catchment_id, time_step_t t)
+{
+  HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
+
+  return;
+
+}
+
+int HY_PointHydroNexusRemoteDownstream::get_world_rank()
+{
+   return world_rank;
+}
+

--- a/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
@@ -13,6 +13,16 @@ HY_PointHydroNexusRemoteUpstream::HY_PointHydroNexusRemoteUpstream(int nexus_id_
 
    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
 
+   int count = 2;
+   const int array_of_blocklengths[2] = { 1, 1 };
+   const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) };
+   const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE };
+
+   MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, &time_step_and_flow_type);
+
+   MPI_Type_commit(&time_step_and_flow_type);
+
+
 }
 
 HY_PointHydroNexusRemoteUpstream::~HY_PointHydroNexusRemoteUpstream()
@@ -20,25 +30,6 @@ HY_PointHydroNexusRemoteUpstream::~HY_PointHydroNexusRemoteUpstream()
     //dtor
 }
 
-double HY_PointHydroNexusRemoteUpstream::get_downstream_flow(long catchment_id, time_step_t t, double percent_flow)
-{
-   double downstream_flow = HY_PointHydroNexus::get_downstream_flow(catchment_id, t, percent_flow);
-
-   //Determine this with a broadcast of the ranks at init?
-   int downstream_remote_nexus_rank = 1;
-
-   //Send downstream_flow from this Upstream Remote Nexus to the Downstream Remote Nexus
-   MPI_Send(
-     /* data         = */ &downstream_flow, 
-     /* count        = */ 1, 
-     /* datatype     = */ MPI_DOUBLE, 
-     /* destination  = */ downstream_remote_nexus_rank, 
-     /* tag          = */ 0, 
-     /* communicator = */ MPI_COMM_WORLD);
-
-   //Return downstream_flow or 0.0 since it was passed to the downstream remote nexus?
-   return downstream_flow;
-}
 
 void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchment_id, time_step_t t)
 {
@@ -48,38 +39,30 @@ void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchm
    //HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
 
 
-   //Determine this with a broadcast of the ranks at init?
-   int downstream_remote_nexus_rank = 1;
 
    // Create the datatype
-   MPI_Datatype time_step_and_flow_type;
+   //MPI_Datatype time_step_and_flow_type;
 
-
+   /*   
    int count = 2;
    const int array_of_blocklengths[2] = { 1, 1 };
    const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) };
    const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE }; 
 
-   /*
-   int MPI_Type_create_struct(int count = 2,
-                              const int array_of_blocklengths[2] = { 1, 1 },
-                              const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) },
-                              const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE },
-                              &time_step_and_flow_type); 
-   */
-
    MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, &time_step_and_flow_type);
 
    MPI_Type_commit(&time_step_and_flow_type);
-
-   struct time_step_and_flow_t
-   {
-       long time_step;
-       double flow;
-   }; 
+   */
 
 
-   struct time_step_and_flow_t buffer;
+   //struct time_step_and_flow_t
+   //{
+   //    long time_step;
+   //   double flow;
+   //}; 
+
+
+   //struct time_step_and_flow_t buffer;
 
    buffer.time_step = t;
    buffer.flow = val;
@@ -92,8 +75,6 @@ void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchm
      /* destination  = */ downstream_remote_nexus_rank, 
      /* tag          = */ 0, 
      /* communicator = */ MPI_COMM_WORLD);
-
-
 
 
    return;

--- a/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
@@ -1,0 +1,52 @@
+#include "HY_PointHydroNexusRemoteUpstream.hpp"
+
+//Can allow multiple upstreams to be on different ranks / multiple processors.
+//Downstream is always local
+//Everything that extracts water from a nexus needs to be colocal / on the same processor.
+
+
+HY_PointHydroNexusRemoteUpstream::HY_PointHydroNexusRemoteUpstream(int nexus_id_number, std::string nexus_id, int num_downstream) : HY_PointHydroNexus(nexus_id_number, nexus_id, num_downstream)
+{
+   MPI_Init(NULL, NULL);
+
+   MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+
+}
+
+HY_PointHydroNexusRemoteUpstream::~HY_PointHydroNexusRemoteUpstream()
+{
+    //dtor
+}
+
+double HY_PointHydroNexusRemoteUpstream::get_downstream_flow(long catchment_id, time_step_t t, double percent_flow)
+{
+   double downstream_flow = HY_PointHydroNexus::get_downstream_flow(catchment_id, t, percent_flow);
+
+   //Determine this with a broadcast of the ranks at init?
+   int downstream_remote_nexus_rank = 1;
+
+   //Send downstream_flow from this Upstream Remote Nexus to the Downstream Remote Nexus
+   MPI_Send(
+     /* data         = */ &downstream_flow, 
+     /* count        = */ 1, 
+     /* datatype     = */ MPI_DOUBLE, 
+     /* destination  = */ downstream_remote_nexus_rank, 
+     /* tag          = */ 0, 
+     /* communicator = */ MPI_COMM_WORLD);
+
+   //Return downstream_flow or 0.0 since it was passed to the downstream remote nexus?
+   return downstream_flow;
+}
+
+void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchment_id, time_step_t t)
+{
+   HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
+
+   return;
+
+}
+
+int HY_PointHydroNexusRemoteUpstream::get_world_rank()
+{
+   return world_rank;
+}

--- a/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
@@ -40,7 +40,59 @@ double HY_PointHydroNexusRemoteUpstream::get_downstream_flow(long catchment_id, 
 
 void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchment_id, time_step_t t)
 {
-   HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
+   //Don't call below on the updstream nexus because don't want to add to the total here.
+   //This upstream nexus is only to pass the flow to the downstream nexus, which will
+   //do the accounting.
+   //HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
+
+
+   //Determine this with a broadcast of the ranks at init?
+   int downstream_remote_nexus_rank = 1;
+
+   // Create the datatype
+   MPI_Datatype time_step_and_flow_type;
+
+
+   int count = 2;
+   const int array_of_blocklengths[2] = { 1, 1 };
+   const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) };
+   const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE }; 
+
+   /*
+   int MPI_Type_create_struct(int count = 2,
+                              const int array_of_blocklengths[2] = { 1, 1 },
+                              const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) },
+                              const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE },
+                              &time_step_and_flow_type); 
+   */
+
+   MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, &time_step_and_flow_type);
+
+   MPI_Type_commit(&time_step_and_flow_type);
+
+   struct time_step_and_flow_t
+   {
+       long time_step;
+       double flow;
+   }; 
+
+
+   struct time_step_and_flow_t buffer;
+
+   buffer.time_step = t;
+   buffer.flow = val;
+
+   //Send downstream_flow from this Upstream Remote Nexus to the Downstream Remote Nexus
+   MPI_Send(
+     /* data         = */ &buffer, 
+     /* count        = */ 1, 
+     /* datatype     = */ time_step_and_flow_type, 
+     /* destination  = */ downstream_remote_nexus_rank, 
+     /* tag          = */ 0, 
+     /* communicator = */ MPI_COMM_WORLD);
+
+
+
 
    return;
 

--- a/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
@@ -2,6 +2,7 @@
 
 #ifdef NGEN_MPI_ACTIVE
 
+//TODO:
 //Can allow multiple upstreams to be on different ranks / multiple processors.
 //Downstream is always local
 //Everything that extracts water from a nexus needs to be colocal / on the same processor.
@@ -9,19 +10,14 @@
 
 HY_PointHydroNexusRemoteUpstream::HY_PointHydroNexusRemoteUpstream(int nexus_id_number, std::string nexus_id, int num_downstream) : HY_PointHydroNexus(nexus_id_number, nexus_id, num_downstream)
 {
-   MPI_Init(NULL, NULL);
-
-   MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
-
-   int count = 2;
-   const int array_of_blocklengths[2] = { 1, 1 };
-   const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) };
-   const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE };
+   int count = 3;
+   const int array_of_blocklengths[3] = { 1, 1, 1 };
+   const MPI_Aint array_of_displacements[3] = { 0, sizeof(long), sizeof(long) + sizeof(long)};
+   const MPI_Datatype array_of_types[3] = { MPI_LONG, MPI_LONG, MPI_DOUBLE };
 
    MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, &time_step_and_flow_type);
 
    MPI_Type_commit(&time_step_and_flow_type);
-
 }
 
 HY_PointHydroNexusRemoteUpstream::~HY_PointHydroNexusRemoteUpstream()
@@ -38,6 +34,7 @@ void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchm
    //HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
 
    buffer.time_step = t;
+   buffer.catchment_id = catchment_id;
    buffer.flow = val;
 
    //Send downstream_flow from this Upstream Remote Nexus to the Downstream Remote Nexus

--- a/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
@@ -1,5 +1,7 @@
 #include "HY_PointHydroNexusRemoteUpstream.hpp"
 
+#ifdef NGEN_MPI_ACTIVE
+
 //Can allow multiple upstreams to be on different ranks / multiple processors.
 //Downstream is always local
 //Everything that extracts water from a nexus needs to be colocal / on the same processor.
@@ -102,3 +104,5 @@ int HY_PointHydroNexusRemoteUpstream::get_world_rank()
 {
    return world_rank;
 }
+
+#endif // NGEN_MPI_ACTIVE

--- a/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemoteUpstream.cpp
@@ -22,7 +22,6 @@ HY_PointHydroNexusRemoteUpstream::HY_PointHydroNexusRemoteUpstream(int nexus_id_
 
    MPI_Type_commit(&time_step_and_flow_type);
 
-
 }
 
 HY_PointHydroNexusRemoteUpstream::~HY_PointHydroNexusRemoteUpstream()
@@ -38,32 +37,6 @@ void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchm
    //do the accounting.
    //HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
 
-
-
-   // Create the datatype
-   //MPI_Datatype time_step_and_flow_type;
-
-   /*   
-   int count = 2;
-   const int array_of_blocklengths[2] = { 1, 1 };
-   const MPI_Aint array_of_displacements[2] = { 0, sizeof(long) };
-   const MPI_Datatype array_of_types[2] = { MPI_LONG, MPI_DOUBLE }; 
-
-   MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, &time_step_and_flow_type);
-
-   MPI_Type_commit(&time_step_and_flow_type);
-   */
-
-
-   //struct time_step_and_flow_t
-   //{
-   //    long time_step;
-   //   double flow;
-   //}; 
-
-
-   //struct time_step_and_flow_t buffer;
-
    buffer.time_step = t;
    buffer.flow = val;
 
@@ -76,9 +49,7 @@ void HY_PointHydroNexusRemoteUpstream::add_upstream_flow(double val, long catchm
      /* tag          = */ 0, 
      /* communicator = */ MPI_COMM_WORLD);
 
-
    return;
-
 }
 
 int HY_PointHydroNexusRemoteUpstream::get_world_rank()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,11 @@ add_subdirectory(googletest)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(${PROJ_ROOT_INCLUDE_DIR})
 
+if(MPI_ACTIVE)
+    find_package(MPI)
+    add_compile_definitions(NGEN_MPI_TESTS_ACTIVE)
+endif()
+
 if(BMI_C_LIB_ACTIVE)
     add_compile_definitions(NGEN_BMI_C_LIB_TESTS_ACTIVE)
 endif()
@@ -82,6 +87,15 @@ add_automated_test(
         test_giuh
         core/catchment/giuh/GIUH_Test.cpp
 )
+
+
+if(MPI_ACTIVE)
+   add_automated_test(
+           test_remote_nexus
+           core/nexus/NexusRemoteTests.cpp
+   )
+endif()
+
 
 add_automated_test(
         test_bmi_c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(${PROJ_ROOT_INCLUDE_DIR})
 
 if(MPI_ACTIVE)
-    find_package(MPI)
+    #find_package(MPI)
     add_compile_definitions(NGEN_MPI_TESTS_ACTIVE)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,6 @@ include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 include_directories(${PROJ_ROOT_INCLUDE_DIR})
 
 if(MPI_ACTIVE)
-    #find_package(MPI)
     add_compile_definitions(NGEN_MPI_TESTS_ACTIVE)
 endif()
 

--- a/test/core/nexus/NexusRemoteTests.cpp
+++ b/test/core/nexus/NexusRemoteTests.cpp
@@ -1,0 +1,101 @@
+#ifdef NGEN_MPI_TESTS_ACTIVE
+
+#include "gtest/gtest.h"
+#include "HY_PointHydroNexusRemoteUpstream.hpp"
+#include "HY_PointHydroNexusRemoteDownstream.hpp"
+
+
+#include <vector>
+#include <memory>
+
+class Nexus_Remote_Test : public ::testing::Test {
+
+protected:
+
+    Nexus_Remote_Test()
+    {
+
+    }
+
+    ~Nexus_Remote_Test() override {
+
+    }
+
+    void SetUp() override;
+
+    void TearDown() override;
+
+    std::shared_ptr<HY_PointHydroNexusRemoteUpstream> upstream_remote_nexus;
+    std::shared_ptr<HY_PointHydroNexusRemoteDownstream> downstream_remote_nexus;
+};
+
+void Nexus_Remote_Test::SetUp() {
+   int nexus_id_number = 26;
+   std::string nexus_id = "nex-26";
+   int num_downstream = 1;
+   
+   MPI_Init(NULL, NULL);
+
+   upstream_remote_nexus = std::make_shared<HY_PointHydroNexusRemoteUpstream>(nexus_id_number, nexus_id, num_downstream);
+
+   downstream_remote_nexus = std::make_shared<HY_PointHydroNexusRemoteDownstream>(nexus_id_number, nexus_id, num_downstream);
+
+}
+
+void Nexus_Remote_Test::TearDown() {
+
+}
+
+//Test sending data with MPI from an upstream remote nexus
+//to a downstream remote nexus.
+TEST_F(Nexus_Remote_Test, TestInit0)
+{
+   int send_catchment_id = 27;
+   double send_flow = 1.2;
+   long send_time_step = 3;
+   
+   int receive_catchment_id = 0;
+   double receive_flow = 0.0;
+   long receive_time_step = 0;
+
+   // Find out rank, size
+   int world_rank;
+   MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+
+   // If the world_rank is 0, then call HY_PointHydroNexusRemoteUpstream to send 
+   // data to downstream remote nexus.
+   if (world_rank == 0) 
+   {
+      upstream_remote_nexus->add_upstream_flow(send_flow, send_catchment_id, send_time_step);
+   }
+
+   // Else if the world_rank is 1, then call HY_PointHydroNexusRemoteDownstream to receive data
+   // from the upstream remote nexus.
+   else if (world_rank == 1) 
+   {
+      downstream_remote_nexus->add_upstream_flow(NULL, NULL, NULL);
+
+      receive_catchment_id = downstream_remote_nexus->get_catchment_id();
+      receive_flow = downstream_remote_nexus->get_upstream_flow_value();
+      receive_time_step = downstream_remote_nexus->get_time_step();
+
+      std::cout << "Received: \nCatchment ID " << receive_catchment_id << " \nFlow " 
+      << receive_flow << " \nTime Step " << receive_time_step << std::endl;
+
+      //Assert equal for the send and receive values 
+      EXPECT_DOUBLE_EQ(send_flow, receive_flow);
+
+      EXPECT_EQ(send_catchment_id, receive_catchment_id);
+
+      EXPECT_EQ(send_time_step, receive_time_step);
+
+   }
+
+   MPI_Finalize();
+
+   ASSERT_TRUE(true);
+
+}
+
+#endif  // NGEN_MPI_TESTS_ACTIVE
+


### PR DESCRIPTION
A Remote Nexus Class with and Upstream and Downstream implementation that is a subclass of HY_PointHydroNexus that can send flow, timestep, and catchment ID data using MPI from the Upstream Remote Nexus to the Downstream Remote Nexus. This includes documentation for building with this MPI option and class activated. This MPI option and class is not activated by default, so that the general user would not need to have MPI installed on their system. This also includes a unit test that can test the class with its MPI communication over 2 processors.

Addresses but does not complete #224

## Additions
-Remote Nexus Upstream and Downstream Classes
-Corresponding Unit Test
-Corresponding Documentation
-CMake MPI compiler build options


## Testing

1. Included Unit Test successfully runs
2. Also tested default build without MPI and MPI library not loaded to ensure that the default option works.


## Todos
Further iteration on this class needed as functionality is extended.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
