### PR TITLE
don't create formulations that aren't linked to hydrofabric, closes #236

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -127,6 +127,13 @@ namespace realization {
 
                 if (possible_catchment_configs) {
                     for (std::pair<std::string, boost::property_tree::ptree> catchment_config : *possible_catchment_configs) {
+                      if( fabric->find(catchment_config.first) == -1 )
+                      {
+                        std::cout<<"WARNING Formulation_Manager::read: Cannot create formulation for catchment "
+                                 <<catchment_config.first
+                                 <<" that isn't identified in the hydrofabric or requested subset"<<std::endl;
+                        continue;
+                      }
                       auto formulations = catchment_config.second.get_child_optional("formulations");
                       if( !formulations ) {
                         throw std::runtime_error("ERROR: No formulations defined for "+catchment_config.first+".");


### PR DESCRIPTION
Better align hydrofabric (and subsets) with formulation manager.  This fix ensures the manager doesn't attempt to construct formulations for features that aren't explicitly in the fabric provided. Closes #236 

## Changes

- Skip construction of formulations described in the realization configuration if they don't have a corresponding catchment key in the hydro fabric.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. Fixed all tests related to formulation manager, added test for creating formulations from config with keys not in hydrofabric

### Target Environment support

- [x] Linux
- [x] MacOS
