### PR TITLE
Update dockerfiles to new Boost archive location

### DIFF
--- a/docker/CENTOS_4.8.5_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_4.8.5_NGEN_RUN.dockerfile
@@ -19,7 +19,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/CENTOS_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_NGEN_RUN.dockerfile
@@ -12,7 +12,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/CENTOS_TEST.dockerfile
+++ b/docker/CENTOS_TEST.dockerfile
@@ -11,7 +11,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/CENTOS_latest_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_latest_NGEN_RUN.dockerfile
@@ -13,7 +13,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/RHEL_TEST.dockerfile
+++ b/docker/RHEL_TEST.dockerfile
@@ -10,7 +10,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 


### PR DESCRIPTION
Fixing boost location for builds
 
## Additions
fix for #243 

-

## Removals

-

## Changes
Dockerfiles updated to fix GitHub Actions runs
-

## Testing

1. build docker files

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
