### PR TITLE
Submodule and Helper Build Setup for BMI Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ extern/pybind11/
 extern/libtorch-*.zip
 # Prototype Shared Library Example Build Directory
 extern/cfe/cmake_cfe_lib
+# Alt-modular build dir
+extern/alt-modular/cmake_am_libs

--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,11 @@ include/bmi.hpp
 
 temp/
 
-# Shared Library Example Build Directory
+# Certain items under extern/ #
+######################
+# pybind11 (for now)
+extern/pybind11/
+# libtorch source artifact
+extern/libtorch-*.zip
+# Prototype Shared Library Example Build Directory
 extern/cfe/cmake_cfe_lib

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "extern/alt-modular/alt-modular"]
 	path = extern/alt-modular/alt-modular
 	url = git@github.com:NOAA-OWP/alt-modular.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "test/googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest
+[submodule "extern/alt-modular/alt-modular"]
+	path = extern/alt-modular/alt-modular
+	url = git@github.com:NOAA-OWP/alt-modular.git

--- a/extern/alt-modular/CMakeLists.txt
+++ b/extern/alt-modular/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 # Uncomment this and rebuild artifacts to enable debugging
 set(CMAKE_BUILD_TYPE Debug)
 
-project(../alt-modular VERSION 1.0.0 DESCRIPTION "External BMI Models Shared Libraries")
+project(alt-modular VERSION 1.0.0 DESCRIPTION "External BMI Models Shared Libraries")
 
 #### Add variables for individual libraries that are used withing the *.pc.in files
 # CFE
@@ -15,25 +15,25 @@ set(TOPMODEL_LIB_DESC_CMAKE "External TOPMODEL Shared Library")
 
 if(WIN32)
     #add_library(cfemodel src/bmi_cfe.c src/cfe.c)
-    add_library(cfebmi ../alt-modular/alt-modular/Modules/cfe-bmi/src/bmi_cfe.c ../alt-modular/alt-modular/Modules/cfe-bmi/src/cfe.c)
-    add_library(topmodelbmi ../alt-modular/alt-modular/Modules/TOPMODEL/src/bmi_topmodel.c ../alt-modular/alt-modular/Modules/TOPMODEL/src/topmodel.c)
+    add_library(cfebmi alt-modular/Modules/CFE/src/bmi_cfe.c alt-modular/Modules/CFE/src/cfe.c)
+    add_library(topmodelbmi alt-modular/Modules/TOPMODEL/src/bmi_topmodel.c .alt-modular/Modules/TOPMODEL/src/topmodel.c)
 else()
     #add_library(cfemodel SHARED src/bmi_cfe.c src/cfe.c)
-    add_library(cfebmi SHARED ../alt-modular/alt-modular/Modules/cfe-bmi/src/bmi_cfe.c ../alt-modular/alt-modular/Modules/cfe-bmi/src/cfe.c)
-    add_library(topmodelbmi SHARED ../alt-modular/alt-modular/Modules/TOPMODEL/src/bmi_topmodel.c ../alt-modular/alt-modular/Modules/TOPMODEL/src/topmodel.c)
+    add_library(cfebmi SHARED alt-modular/Modules/CFE/src/bmi_cfe.c alt-modular/Modules/CFE/src/cfe.c)
+    add_library(topmodelbmi SHARED alt-modular/Modules/TOPMODEL/src/bmi_topmodel.c alt-modular/Modules/TOPMODEL/src/topmodel.c)
 endif()
 
 #target_include_directories(cfemodel PRIVATE include)
-target_include_directories(cfebmi PRIVATE ../alt-modular/alt-modular/Modules/cfe-bmi/include)
-target_include_directories(topmodelbmi PRIVATE ../alt-modular/alt-modular/Modules/TOPMODEL/include)
+target_include_directories(cfebmi PRIVATE alt-modular/Modules/CFE/include)
+target_include_directories(topmodelbmi PRIVATE alt-modular/Modules/TOPMODEL/include)
 
 #set_target_properties(cfemodel PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(cfebmi PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(topmodelbmi PROPERTIES VERSION ${PROJECT_VERSION})
 
 #set_target_properties(cfemodel PROPERTIES PUBLIC_HEADER include/bmi_cfe.h)
-set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER ../alt-modular/alt-modular/Modules/cfe-bmi/include/bmi_cfe.h)
-set_target_properties(topmodelbmi PROPERTIES PUBLIC_HEADER alt-modular/Modules/TOPMODEL/include/bmi_cfe.h)
+set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER alt-modular/Modules/CFE/include/bmi_cfe.h)
+set_target_properties(topmodelbmi PROPERTIES PUBLIC_HEADER alt-modular/Modules/TOPMODEL/include/bmi_topmodel.h)
 
 include(GNUInstallDirs)
 

--- a/extern/alt-modular/CMakeLists.txt
+++ b/extern/alt-modular/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Uncomment this and rebuild artifacts to enable debugging
+set(CMAKE_BUILD_TYPE Debug)
+
+project(../alt-modular VERSION 1.0.0 DESCRIPTION "External BMI Models Shared Libraries")
+
+#### Add variables for individual libraries that are used withing the *.pc.in files
+# CFE
+set(CFE_LIB_NAME_CMAKE cfebmi)
+set(CFE_LIB_DESC_CMAKE "External CFE Shared Library")
+# TOPMODEL
+set(TOPMODEL_LIB_NAME_CMAKE topmodelbmi)
+set(TOPMODEL_LIB_DESC_CMAKE "External TOPMODEL Shared Library")
+
+if(WIN32)
+    #add_library(cfemodel src/bmi_cfe.c src/cfe.c)
+    add_library(cfebmi ../alt-modular/alt-modular/Modules/cfe-bmi/src/bmi_cfe.c ../alt-modular/alt-modular/Modules/cfe-bmi/src/cfe.c)
+    add_library(topmodelbmi ../alt-modular/alt-modular/Modules/TOPMODEL/src/bmi_topmodel.c ../alt-modular/alt-modular/Modules/TOPMODEL/src/topmodel.c)
+else()
+    #add_library(cfemodel SHARED src/bmi_cfe.c src/cfe.c)
+    add_library(cfebmi SHARED ../alt-modular/alt-modular/Modules/cfe-bmi/src/bmi_cfe.c ../alt-modular/alt-modular/Modules/cfe-bmi/src/cfe.c)
+    add_library(topmodelbmi SHARED ../alt-modular/alt-modular/Modules/TOPMODEL/src/bmi_topmodel.c ../alt-modular/alt-modular/Modules/TOPMODEL/src/topmodel.c)
+endif()
+
+#target_include_directories(cfemodel PRIVATE include)
+target_include_directories(cfebmi PRIVATE ../alt-modular/alt-modular/Modules/cfe-bmi/include)
+target_include_directories(topmodelbmi PRIVATE ../alt-modular/alt-modular/Modules/TOPMODEL/include)
+
+#set_target_properties(cfemodel PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(cfebmi PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(topmodelbmi PROPERTIES VERSION ${PROJECT_VERSION})
+
+#set_target_properties(cfemodel PROPERTIES PUBLIC_HEADER include/bmi_cfe.h)
+set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER ../alt-modular/alt-modular/Modules/cfe-bmi/include/bmi_cfe.h)
+set_target_properties(topmodelbmi PROPERTIES PUBLIC_HEADER alt-modular/Modules/TOPMODEL/include/bmi_cfe.h)
+
+include(GNUInstallDirs)
+
+#install(TARGETS cfemodel
+#        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS cfebmi
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS topmodelbmi
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+#configure_file(cfemodel.pc.in cfemodel.pc @ONLY)
+configure_file(cfebmi.pc.in cfebmi.pc @ONLY)
+configure_file(topmodelbmi.pc.in topmodelbmi.pc @ONLY)
+
+#install(FILES ${CMAKE_BINARY_DIR}/cfemodel.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+install(FILES ${CMAKE_BINARY_DIR}/cfebmi.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+install(FILES ${CMAKE_BINARY_DIR}/topmodelbmi.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)

--- a/extern/alt-modular/README.md
+++ b/extern/alt-modular/README.md
@@ -47,5 +47,18 @@ To change the branch for everyone, run the following:
 
 ## Building Libraries
 
+First, cd into the outer directory containing the submodule:
 
-## Adding New Library Configuration
+    cd extern/alt-modular
+
+Before library files can be build, a CMake build system must be generated.  E.g.:
+
+    cmake -B cmake_am_libs -S .
+
+Note that when there is an existing directory, it may sometimes be necessary to clear it and regenerate, especially if any changes were made to the [CMakeLists.txt](CMakeLists.txt) file.
+
+After there is build system directory, the shared libraries can be built.  This is done with individual targets for each. For example, the CFE shared library file (i.e., the build config's `cfebmi` target) can be build using:
+
+    cmake --build cmake_am_libs --target cfebmi -- -j 2
+
+This will build a `cmake_am_libs/libcfebmi.<version>.<ext>` file, where the version is configured within the CMake config, and the extension depends on the local machine's operating system.    

--- a/extern/alt-modular/README.md
+++ b/extern/alt-modular/README.md
@@ -1,0 +1,51 @@
+# Alt-Modular Submodule
+
+## About
+
+This directory wraps the *alt-modular* Git submodule repo, which contains a number of independent model libraries each implementing BMI.  From here, shared library files for several of the *alt-modular* modules can be built for use in NGen.  These are configured with the [CMakeLists.txt](CMakeLists.txt) and other files in this outer directory.
+
+#### Extra Outer Directory
+
+Currently there are two directory layers beneath the top-level *extern/* directory.  This was done so that certain things used by NGen (i.e., a *CMakeLists.txt* file for building shared library files) can be placed alongside, but not within, the submodule.
+
+## Working with the Submodule
+
+Some simple explanations of several commands are included below.  To better understand what these things are doing, consult the [Git Submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 
+
+### Getting the Latest Changes
+
+There are two steps to getting upstream submodule changes fully 
+  1. fetching and locally checking out the changes from the remote
+  2. committing the new checkout revision for the submodule
+
+To fetch and check out the latest revision (for the [currently used branch](#viewing-the-current-branch)):
+
+    git submodule update --remote extern/alt-modular/alt-modular
+
+To commit the current submodule checkout revision to the NGen repo:
+
+    git add extern/alt-modular/alt-modular
+    git commit
+
+### Viewing the Current Branch
+
+The configured branch for the submodule will control exactly what revision gets checked out when new changes are retrieved, and as such may need to be viewed or [changed](#changing-the-branch).  
+
+The submodule's status, which includes the current branch, can be viewed with `git submodule status`:
+
+    git submodule status -- extern/alt-modular/alt-modular/
+
+This will show the **commit**, **submodule local path**, and **submodule branch**.  It can also be run without the extra arguments to show this for all NGen repo submodules.
+
+### Changing the Branch
+
+To change the branch for everyone, run the following:
+
+    git config -f .gitmodules "submodule.extern/alt-modular/alt-modular.branch" main
+
+# Usage
+
+## Building Libraries
+
+
+## Adding New Library Configuration

--- a/extern/alt-modular/README.md
+++ b/extern/alt-modular/README.md
@@ -51,13 +51,13 @@ First, cd into the outer directory containing the submodule:
 
     cd extern/alt-modular
 
-Before library files can be build, a CMake build system must be generated.  E.g.:
+Before library files can be built, a CMake build system must be generated.  E.g.:
 
     cmake -B cmake_am_libs -S .
 
 Note that when there is an existing directory, it may sometimes be necessary to clear it and regenerate, especially if any changes were made to the [CMakeLists.txt](CMakeLists.txt) file.
 
-After there is build system directory, the shared libraries can be built.  This is done with individual targets for each. For example, the CFE shared library file (i.e., the build config's `cfebmi` target) can be build using:
+After there is build system directory, the shared libraries can be built.  This is done with individual targets for each. For example, the CFE shared library file (i.e., the build config's `cfebmi` target) can be built using:
 
     cmake --build cmake_am_libs --target cfebmi -- -j 2
 

--- a/extern/alt-modular/cfebmi.pc.in
+++ b/extern/alt-modular/cfebmi.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @CFE_LIB_NAME_CMAKE@
+Description: @CFE_LIB_DESC_CMAKE@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lmylib
+Cflags: -I${includedir}

--- a/extern/alt-modular/topmodelbmi.pc.in
+++ b/extern/alt-modular/topmodelbmi.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @TOPMODEL_LIB_NAME_CMAKE@
+Description: @TOPMODEL_DESC_CMAKE@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lmylib
+Cflags: -I${includedir}


### PR DESCRIPTION
Submodule and helper build setup for OWP-maintained BMI models that are not contained directly within the NGen repo.  

This primarily sets up the `alt-modular` repo as a Git submodule, then creates a separated CMake config for building the shared libraries for CFE and TOPMODEL.  It also includes a bit of explanation in the helper README.  These are all under the `extern/alt-modular/` directory, with the submodule itself being at `extern/alt-modular/alt-modular/`.

Note that this requires pulling the submodule via Git's SSH functionality, which in turn requires a private key be set up for the user in Git for this.  Because of the current status and restrictions of `alt-modular`, it was either that or a Git Personal Access Token for HTTPS, and the SSH key seemed more standard.

