### PR TITLE
Some Post Milestone Fixes

### DIFF
--- a/data/example_realization_config_w_bmi_c__linux.json
+++ b/data/example_realization_config_w_bmi_c__linux.json
@@ -50,11 +50,10 @@
                     "params": {
                         "model_type_name": "bmi_c_cfe",
                         "library_file": "./extern/alt-modular/cmake_am_libs/libcfebmi.so",
-                        "forcing_file": "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv",
                         "init_config": "./data/bmi/c/cfe/cat_27_bmi_config.txt",
                         "main_output_variable": "Q_OUT",
                         "registration_function": "register_bmi_cfe",
-                        "variable_names_map" : {
+                        "variables_names_map" : {
                             "water_potential_evaporation_flux" : "potential_evapotranspiration",
                             "atmosphere_water__liquid_equivalent_precipitation_rate" : "precip_rate",
                             "atmosphere_air_water~vapor__relative_saturation" : "SPFH_2maboveground",
@@ -65,7 +64,7 @@
                             "land_surface_radiation~incoming~shortwave__energy_flux" : "DSWRF_surface",
                             "land_surface_air__pressure" : "PRES_surface"
                         },
-                        "uses_forcing_file": true
+                        "uses_forcing_file": false
                     }
                 }
             ],
@@ -84,7 +83,10 @@
                       1.0
                   ],
                   "storage": 1.0,
-                  "max_storage": 1000.0,
+                  "gw_storage": 1.0,
+                  "gw_max_storage": 1000.0,
+                  "nash_max_storage": 1000.0,
+                  "smax": 1000.0,
                   "a": 1.0,
                   "b": 10.0,
                   "Ks": 0.1,
@@ -146,7 +148,10 @@
                     1.0
                 ],
                 "storage": 1.0,
-                "max_storage": 1000.0,
+                  "gw_storage": 1.0,
+                  "gw_max_storage": 1000.0,
+                  "nash_max_storage": 1000.0,
+                  "smax": 1000.0,
                 "a": 1.0,
                 "b": 10.0,
                 "Ks": 0.1,

--- a/data/example_realization_config_w_bmi_c__macos.json
+++ b/data/example_realization_config_w_bmi_c__macos.json
@@ -49,12 +49,11 @@
                     "name": "bmi_c",
                     "params": {
                         "model_type_name": "bmi_c_cfe",
-                        "library_file": "../extern/alt-modular/cmake_am_libs/libcfebmi.dylib",
-                        "forcing_file": "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv",
+                        "library_file": "./extern/alt-modular/cmake_am_libs/libcfebmi.dylib",
                         "init_config": "./data/bmi/c/cfe/cat_27_bmi_config.txt",
                         "main_output_variable": "Q_OUT",
                         "registration_function": "register_bmi_cfe",
-                        "variable_names_map" : {
+                        "variables_names_map" : {
                             "water_potential_evaporation_flux" : "potential_evapotranspiration",
                             "atmosphere_water__liquid_equivalent_precipitation_rate" : "precip_rate",
                             "atmosphere_air_water~vapor__relative_saturation" : "SPFH_2maboveground",
@@ -65,7 +64,7 @@
                             "land_surface_radiation~incoming~shortwave__energy_flux" : "DSWRF_surface",
                             "land_surface_air__pressure" : "PRES_surface"
                         },
-                        "uses_forcing_file": true
+                        "uses_forcing_file": false
                     }
                 }
             ],
@@ -84,7 +83,10 @@
                       1.0
                   ],
                   "storage": 1.0,
-                  "max_storage": 1000.0,
+                  "gw_storage": 1.0,
+                  "gw_max_storage": 1000.0,
+                  "nash_max_storage": 1000.0,
+                  "smax": 1000.0,
                   "a": 1.0,
                   "b": 10.0,
                   "Ks": 0.1,
@@ -146,7 +148,10 @@
                     1.0
                 ],
                 "storage": 1.0,
-                "max_storage": 1000.0,
+                "gw_storage": 1.0,
+                "gw_max_storage": 1000.0,
+                "nash_max_storage": 1000.0,
+                "smax": 1000.0,
                 "a": 1.0,
                 "b": 10.0,
                 "Ks": 0.1,

--- a/extern/alt-modular/CMakeLists.txt
+++ b/extern/alt-modular/CMakeLists.txt
@@ -13,6 +13,9 @@ set(CFE_LIB_DESC_CMAKE "External CFE Shared Library")
 set(TOPMODEL_LIB_NAME_CMAKE topmodelbmi)
 set(TOPMODEL_LIB_DESC_CMAKE "External TOPMODEL Shared Library")
 
+# Make sure these are compiled with this directive
+add_compile_definitions(BMI_ACTIVE)
+
 if(WIN32)
     #add_library(cfemodel src/bmi_cfe.c src/cfe.c)
     add_library(cfebmi alt-modular/Modules/CFE/src/bmi_cfe.c alt-modular/Modules/CFE/src/cfe.c)

--- a/extern/alt-modular/README.md
+++ b/extern/alt-modular/README.md
@@ -10,7 +10,7 @@ Currently there are two directory layers beneath the top-level *extern/* directo
 
 ## Working with the Submodule
 
-Some simple explanations of several commands are included below.  To better understand what these things are doing, consult the [Git Submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 
+Some simple explanations of several command actions are included below.  To better understand what these things are doing, consult the [Git Submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 
 
 ### Getting the Latest Changes
 
@@ -20,28 +20,28 @@ There are two steps to getting upstream submodule changes fully
 
 To fetch and check out the latest revision (for the [currently used branch](#viewing-the-current-branch)):
 
-    git submodule update --remote extern/alt-modular/alt-modular
+    git submodule update --init --remote -- extern/alt-modular/alt-modular
 
 To commit the current submodule checkout revision to the NGen repo:
 
     git add extern/alt-modular/alt-modular
     git commit
 
-### Viewing the Current Branch
+### Viewing the Commit Hash
 
-The configured branch for the submodule will control exactly what revision gets checked out when new changes are retrieved, and as such may need to be viewed or [changed](#changing-the-branch).  
-
-The submodule's status, which includes the current branch, can be viewed with `git submodule status`:
+Git submodule configurations include the specific commit to be checked out (or an implicit default).  The current commit can be view with `git submodule status`:
 
     git submodule status -- extern/alt-modular/alt-modular/
 
-This will show the **commit**, **submodule local path**, and **submodule branch**.  It can also be run without the extra arguments to show this for all NGen repo submodules.
+This will show the **commit**, **submodule local path**, and the git description for the **commit**.  The specific configuration, including the configured branch, is set in the _.gitmodules_ file in the NGen project root.
 
-### Changing the Branch
+### Changing the Commit Branch
 
-To change the branch for everyone, run the following:
+The latest commit in the configured branch can be brought in as described here.  If it is ever necessary to change to a different branch, the following will do so:
 
-    git config -f .gitmodules "submodule.extern/alt-modular/alt-modular.branch" main
+    git config -f .gitmodules "submodule.extern/alt-modular/alt-modular.branch" <branchName>
+
+Note that this will be done in the NGen repo configuration, so it can then be committed and push to remotes.  It is also possible to do something similar in just the local clone of a repo, by configuring `.git/config` instead of `.gitmodules`.  See the Git documentation for more on how that works if needed.
 
 # Usage
 

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <iostream>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include "CSV_Reader.h"
 #include <ctime>
 #include <time.h>
@@ -493,7 +494,7 @@ class Forcing
                     string precip_str = vec[5];
 
                     //Convert from string to double and from mm/hr to m/s
-                    double precip = atof(precip_str.c_str()) / (1000 * 3600);
+                    double precip = boost::lexical_cast<double>(precip_str) / (1000 * 3600);
 
                     //Add precip to vector
                     precipitation_rate_meters_per_second_vector.push_back(precip);
@@ -568,20 +569,21 @@ class Forcing
                     AORC_data AORC;
 
                     //Convert from strings to doubles and add to AORC struct
-                    AORC.APCP_surface_kg_per_meters_squared = atof(APCP_surface_str.c_str());
-                    AORC.DLWRF_surface_W_per_meters_squared = atof(DLWRF_surface_str.c_str());
-                    AORC.DSWRF_surface_W_per_meters_squared = atof(DSWRF_surface_str.c_str());
-                    AORC.PRES_surface_Pa = atof(PRES_surface_str.c_str());
-                    AORC.SPFH_2maboveground_kg_per_kg = atof(SPFH_2maboveground_str.c_str());
-                    AORC.TMP_2maboveground_K = atof(TMP_2maboveground_str.c_str());
-                    AORC.UGRD_10maboveground_meters_per_second = atof(UGRD_10maboveground_str.c_str());
-                    AORC.VGRD_10maboveground_meters_per_second = atof(VGRD_10maboveground_str.c_str());
-                  
+                    AORC.APCP_surface_kg_per_meters_squared = boost::lexical_cast<double>(APCP_surface_str);
+                    AORC.DLWRF_surface_W_per_meters_squared = boost::lexical_cast<double>(DLWRF_surface_str);
+                    AORC.DSWRF_surface_W_per_meters_squared = boost::lexical_cast<double>(DSWRF_surface_str);
+                    AORC.PRES_surface_Pa = boost::lexical_cast<double>(PRES_surface_str);
+                    AORC.SPFH_2maboveground_kg_per_kg = boost::lexical_cast<double>(SPFH_2maboveground_str);
+                    AORC.TMP_2maboveground_K = boost::lexical_cast<double>(TMP_2maboveground_str);
+                    AORC.UGRD_10maboveground_meters_per_second = boost::lexical_cast<double>(UGRD_10maboveground_str);
+                    AORC.VGRD_10maboveground_meters_per_second = boost::lexical_cast<double>(VGRD_10maboveground_str);
+
+
                     //Add AORC struct to AORC vector
                     AORC_vector.push_back(AORC);
             
                     //Convert precip_rate from string to double
-                    double precip_rate = atof(precip_rate_str.c_str());
+                    double precip_rate = boost::lexical_cast<double>(precip_rate_str);
 
                     //Add data to vectors
                     precipitation_rate_meters_per_second_vector.push_back(precip_rate);

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -395,7 +395,7 @@ namespace realization {
             // Note that this must be present if bmi_using_forcing_file is true
             if (properties.find(BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE) != properties.end())
                 set_forcing_file_path(properties.at(BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE).as_string());
-            else if (!is_bmi_using_forcing_file())
+            else if (is_bmi_using_forcing_file())
                 throw std::runtime_error("Can't create BMI formulation: using_forcing_file true but no file path set");
 
             if (properties.find(BMI_REALIZATION_CFG_PARAM_OPT__ALLOW_EXCEED_END) != properties.end()) {

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -66,7 +66,7 @@ namespace realization {
           return *key;
         }
 
-        throw std::runtime_error("No valid formulation was described in the passed in tree.");
+        throw std::runtime_error("No valid formulation for " + *key + " was described in the passed in tree.");
     }
 }
 

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -209,7 +209,13 @@ namespace realization {
                 utils::StreamHandler output_stream
             ) {
                 auto params = formulation.get_child("params");
-                std::string formulation_type_key =  get_formulation_key(formulation);
+                std::string formulation_type_key;
+                try {
+                    formulation_type_key = get_formulation_key(formulation);
+                }
+                catch(std::exception& e) {
+                    throw std::runtime_error("Catchment " + identifier + " failed initialization: " + e.what());
+                }
 
                 boost::property_tree::ptree formulation_config = formulation.get_child("params");
 

--- a/include/utilities/FileStreamHandler.hpp
+++ b/include/utilities/FileStreamHandler.hpp
@@ -10,7 +10,7 @@ namespace utils
       public:
             FileStreamHandler(const char* path) : StreamHandler()
             {
-                auto stream = std::make_shared<std::ofstream>(std::ofstream());
+                auto stream = std::make_shared<std::ofstream>();
                 stream->open(path, std::ios::trunc);
                 output_stream = stream;
             }

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[]) {
                              r_c->get_output_line_for_timestep(output_time_index)+"\n";
         r_c->write_output(output);
         //TODO put this somewhere else.  For now, just trying to ensure we get m^3/s into nexus output
-        response = response * boost::geometry::area(catchment_collection->get_feature(id)->geometry<geojson::multipolygon_t>());
+        response *= (catchment_collection->get_feature(id)->get_property("areasqkm").as_real_number() * 1000000);
         //update the nexus with this flow
         for(auto& nexus : features.destination_nexuses(id))
         {

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -90,7 +90,9 @@ inline void Bmi_C_Formulation::get_forcing_data_ts_contributions(time_step_t t_d
         // TODO: should we include <typeinfo> and use typeid(this).name() to print class?
         //  (Also, should there be a directive-controlled option for that?)
         throw std::runtime_error("Bmi_C_Formulation for model '" + get_model_type_name() +
-                                 "' cannot get contributions for model time step before current forcing time step");
+                                 "' can't get contributions for model time step " + to_string(t_delta) + " starting at "
+                                 + to_string(model_epoch_time_s) + ", as current forcing time step doesn't start until "
+                                 + to_string(forcing.get_time_epoch()));
     }
 
     model_ts_start_offset = model_epoch_time_s - forcing.get_time_epoch();

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -87,7 +87,10 @@ inline void Bmi_C_Formulation::get_forcing_data_ts_contributions(time_step_t t_d
     // Though this is a problem at the moment, because we can't go through forcings in reverse order
     if (model_epoch_time_s < forcing.get_time_epoch()) {
         // TODO: think if there is a better way to address this
-        throw std::runtime_error("Cannot get contributions for model time step before current forcing time step");
+        // TODO: should we include <typeinfo> and use typeid(this).name() to print class?
+        //  (Also, should there be a directive-controlled option for that?)
+        throw std::runtime_error("Bmi_C_Formulation for model '" + get_model_type_name() +
+                                 "' cannot get contributions for model time step before current forcing time step");
     }
 
     model_ts_start_offset = model_epoch_time_s - forcing.get_time_epoch();

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -86,13 +86,17 @@ inline void Bmi_C_Formulation::get_forcing_data_ts_contributions(time_step_t t_d
 
     while (contribution_seconds_remaining > 0) {
         // If model ts, after having start time shifted forward within forcing step (if needed), goes beyond forcing ts
-        if ((time_t)contribution_seconds_remaining + model_ts_start_offset >= forcing.get_time_step_size()) {
-            increment_to_next_forcing_ts = true;
-            model_ts_seconds_contained_in_forcing_ts = forcing.get_time_step_size() - model_ts_start_offset;
+        if ((time_t) contribution_seconds_remaining + model_ts_start_offset < forcing.get_time_step_size()) {
+            increment_to_next_forcing_ts = false;
+            model_ts_seconds_contained_in_forcing_ts = (time_t) contribution_seconds_remaining;
+        }
+        else if (get_bmi_model()->GetEndTime() <= (get_bmi_model()->GetCurrentTime() + (double)(2 * forcing.get_time_step_size()))) {
+            increment_to_next_forcing_ts = false;
+            model_ts_seconds_contained_in_forcing_ts = (time_t) contribution_seconds_remaining;
         }
         else {
-            increment_to_next_forcing_ts = false;
-            model_ts_seconds_contained_in_forcing_ts = (time_t)contribution_seconds_remaining;
+            increment_to_next_forcing_ts = true;
+            model_ts_seconds_contained_in_forcing_ts = forcing.get_time_step_size() - model_ts_start_offset;
         }
 
         // Get the contributions from this forcing ts for all the forcing params needed.


### PR DESCRIPTION
Several fixes made directly to environment during final preparations for milestone test, which now need to be included upstream.  

- Additional details in BMI modules helper build README file.
- Fixes to some relative paths and certain included parameters for several example realization configs.
- Fix of bug in logic for determining from realization config whether a BMI model should use its forcing file directly (issue #254).
- Updating to latest _alt-modular_ checkout.
- Adjust logic in _Bmi_C_Formulation_ to better handle iterating through forcing records, especially near the end of available data, to avoid misleading warnings.

