### PR TITLE
Add build target for partitioner executable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,21 @@ if(LSTM_TORCH_LIB_ACTIVE)
            )
 endif()
 
+add_executable(partitionGenerator
+        src/partitionGenerator.cpp
+        )
+
+target_include_directories(partitionGenerator PUBLIC
+        "${PROJECT_BINARY_DIR}/include" # For generated config header file in binary tree
+
+        )
+
+
+target_link_libraries(partitionGenerator PUBLIC
+        core
+        geojson
+        )
+
 # For automated testing with Google Test
 if(PACKAGE_TESTS)
     enable_testing()


### PR DESCRIPTION
Adding CMake build target in top-level [CMakeLists.txt](https://github.com/NOAA-OWP/ngen/blob/master/CMakeLists.txt) for building the partitioner executable.