### PR TITLE
Don't always link pybind11 in catchment lib.

### DIFF
--- a/src/realizations/catchment/CMakeLists.txt
+++ b/src/realizations/catchment/CMakeLists.txt
@@ -17,7 +17,6 @@ target_include_directories(realizations_catchment PUBLIC
         ${PROJECT_SOURCE_DIR}/models/kernels
         ${PROJECT_SOURCE_DIR}/models/kernels/evapotranspiration
         ${PROJECT_SOURCE_DIR}/models/tshirt/include
-        ${PROJECT_SOURCE_DIR}/extern/pybind11/include
         )
         
 target_link_libraries(realizations_catchment PUBLIC
@@ -27,8 +26,12 @@ target_link_libraries(realizations_catchment PUBLIC
         NGen::models_tshirt
         NGen::geojson
         NGen::kernels_evapotranspiration
-        pybind11::embed
         )
+
+if(NGEN_ACTIVATE_PYTHON)
+   target_include_directories(realizations_catchment PUBLIC ${PROJECT_SOURCE_DIR}/extern/pybind11/include)
+   target_link_libraries(realizations_catchment PUBLIC pybind11::embed)
+endif()
 
 add_dependencies(realizations_catchment NGen::kernels_evapotranspiration)
 


### PR DESCRIPTION
Updates the CMake config for the _realizations_catchment_ library to avoid including and linking the external _pybind11_ dependency if the build variable to control whether Python functionality should be active is not set to `ON`/`true`.
