### PR TITLE
Network documentation

### DIFF
--- a/include/core/network.hpp
+++ b/include/core/network.hpp
@@ -138,7 +138,7 @@ namespace network {
         std::string get_id( Graph::vertex_descriptor idx);
 
         /**
-         * @brief Get the origination (upstream) ids of all vertices connecting to @p id
+         * @brief Get the origination (upstream) ids (immediate neighbors) of all vertices with an edge connecting to @p id
          * 
          * @param id 
          * @return std::vector<std::string> 
@@ -146,7 +146,7 @@ namespace network {
         std::vector<std::string> get_origination_ids(std::string id);
 
         /**
-         * @brief Get the destination (downstream) ids of all vertices @p id connects to
+         * @brief Get the destination (downstream) ids (immediate neighbors) of all vertices with an edge from @p id
          * 
          * @param id 
          * @return std::vector<std::string> 

--- a/include/core/network.hpp
+++ b/include/core/network.hpp
@@ -52,9 +52,12 @@ namespace network {
    * 
    */
   using IndexPair = std::pair< NetworkIndexT::const_iterator, NetworkIndexT::const_iterator>;
+
     /**
-     * @brief 
+     * @brief A lightweight, graph based index of hydrologic features.
      * 
+     * This class provides various iterators and access to hydrologic feature identities based on their topological relationships.
+     * It uses a boost::graph to model the relationship of features, and various iterators of the features based on traversal of this graph.
      */
     class Network {
       public:

--- a/include/core/network.hpp
+++ b/include/core/network.hpp
@@ -14,27 +14,106 @@
 #include <FeatureBuilder.hpp>
 
 namespace network {
+  /**
+   * @brief The structure defining graph vertex properties.
+   * 
+   * @var VertexProperty::id
+   * The string identifier of the vertex.
+   */
   struct VertexProperty{
     std::string id;
   };
-
+  /**
+   * @brief Type used to index network::NodeT types
+   * 
+   */
   typedef boost::property<boost::vertex_index_t, std::size_t> IndexT;
+  /**
+   * @brief Type used to label node properties in a network::Graph
+   * 
+   */
   typedef boost::property<boost::vertex_name_t, std::string, IndexT> NodeT;
+  /**
+   * @brief Parameterized graph storing network::NodeT vertices
+   * 
+   * Nodes are stored as boost::setS, edges as boost::vecS, with bidirectional edges
+   * 
+   */
   typedef boost::adjacency_list<boost::setS, boost::vecS, boost::bidirectionalS, NodeT> Graph;
+  /**
+   * @brief A vector of network::Graph vertex_descriptors
+   * 
+   */
   typedef std::vector< Graph::vertex_descriptor > NetworkIndexT;
-  //A type for holding a pair of NetworkIndexT iterators,  pair.first=begin,  pair.second=end
-  //These indicies should be const to the caller
+  /**
+   * @brief A type for holding a pair of network::NetworkIndexT iterators,  pair.first=begin,  pair.second=end
+   * 
+   * these indicies should be const to the caller
+   * 
+   */
   using IndexPair = std::pair< NetworkIndexT::const_iterator, NetworkIndexT::const_iterator>;
-
+    /**
+     * @brief 
+     * 
+     */
     class Network {
       public:
+        /**
+         * @brief Construct a new empty Network object
+         * 
+         */
         Network() {}
+
+        /**
+         * @brief Construct a new Network object from the features in fabric, assumes features have already been linked.
+         * 
+         * @param fabric a geojson::GeoJSON collection of features to add as nodes to the graph
+         */
         Network( geojson::GeoJSON fabric );
+
+        /**
+         * @brief Construct a new Network object from features in fabric, creating edges between feature properties defined by link_key
+         * 
+         * @param features a geojson::GeoJSON collection of features to add as nodes to the graph
+         * @param link_key the property to read from features to determie edge linking, i.e. 'toid'
+         */
         Network( geojson::GeoJSON features, std::string* link_key);
+
+        /**
+         * @brief Destroy the Network object
+         * 
+         */
         virtual ~Network(){}
 
+        /**
+         * @brief Iterator to the first graph vertex descriptor of the topologically ordered graph vertices
+         * 
+         * @return NetworkIndexT::const_reverse_iterator 
+         */
         NetworkIndexT::const_reverse_iterator begin();
+
+        /**
+         * @brief Iterator to the end of the topologically ordered graph vertices
+         * 
+         * @return NetworkIndexT::const_reverse_iterator 
+         */
         NetworkIndexT::const_reverse_iterator end();
+
+        /**
+         * @brief Provides a boost transform_iterator, filtered by @p type , to the topologically ordered graph vertex string id's
+         * 
+         * This function is useful when only interested in a single type of feature.
+         * It returns the a topologically ordered set of feature ids.  For example, to print all catchments
+         * in the network:
+         * @code {.cpp}
+         * for( auto catchment : network.filter('cat') ){
+         *    std::cout << catchment;
+         * }
+         * @endcode
+         * 
+         * @param type the type of feature to filter for, i.e. 'cat', 'nex'
+         * @return auto 
+         */
         auto filter(std::string type)
         {
           //todo need to worry about validating input???
@@ -44,37 +123,108 @@ namespace network {
                             | boost::adaptors::transformed([this](int const& i) { return get_id(i); })
                             | boost::adaptors::filtered([type](std::string const& s) { return s.substr(0,3) == type; });
         }
+
+        /**
+         * @brief Get the string id of a given graph vertex_descriptor @p idx
+         * 
+         * @param idx
+         * @return std::string
+         * 
+         * @throw std::invalid_argument if @p idx is not in the range of valid vertex descriptors [0, num_verticies)
+         */
         std::string get_id( Graph::vertex_descriptor idx);
+
+        /**
+         * @brief Get the origination (upstream) ids of all vertices connecting to @p id
+         * 
+         * @param id 
+         * @return std::vector<std::string> 
+         */
         std::vector<std::string> get_origination_ids(std::string id);
+
+        /**
+         * @brief Get the destination (downstream) ids of all vertices @p id connects to
+         * 
+         * @param id 
+         * @return std::vector<std::string> 
+         */
         std::vector<std::string> get_destination_ids(std::string id);
+
+        /**
+         * @brief The number of features in the network (number of vertices)
+         * 
+         * @return std::size_t 
+         */
         std::size_t size();
 
+        /**
+         * @brief An iterator pair (begin, end) of the network headwater features
+         * 
+         * @return IndexPair 
+         */
         IndexPair headwaters();
+
+        /**
+         * @brief An iterator pair (begin, end) of the network tailwater features
+         * 
+         * @return IndexPair 
+         */
         IndexPair tailwaters();
 
+        /**
+         * @brief Print a graphviz (text) representation of the network
+         * 
+         */
         void print_network(){
           boost::dynamic_properties dp;
           dp.property("node_id", get(boost::vertex_name, this->graph));
           boost::write_graphviz_dp(std::cout, graph, dp);
         }
+
       protected:
 
       private:
+
+        /**
+         * @brief Initializes the head/tailwater iterators after the underlying graph is constructed.
+         * 
+         */
         void init_indicies();
+
+        /**
+         * @brief Vector of topologically sorted features
+         * 
+         */
         NetworkIndexT topo_order;
-        //keep an index of headwater verticies
+
+        /**
+         * @brief Vector of headwater features
+         * 
+         */
         NetworkIndexT headwaters_idx;
-        //keep  an index of tailwater verticies
+        
+        /**
+         * @brief Vector of tailwater features
+         * 
+         */
         NetworkIndexT tailwaters_idx;
+
         //There are "classes" of tailwater to consider, "Free" "Coastal" "Internal" ect
         //Really the same is true for head waters in the "Free" and "Internal" sense where
         //there are interactions of boundary conditions
         //TODO Distributary network??? Has topological "wildcard"
         //Diffusive routing can assume DAG, Dynamic routing cannot
 
-        //Boost Graph
+        /**
+         * @brief The underlying boost::Graph 
+         * 
+         */
         Graph graph;
-        //Keep a mapping of identity to graph vertex descriptor
+
+        /**
+         * @brief Mapping of identity to graph vertex descriptor
+         * 
+         */
         std::unordered_map<std::string, Graph::vertex_descriptor> descriptor_map;
 
     };

--- a/src/core/network.cpp
+++ b/src/core/network.cpp
@@ -1,5 +1,6 @@
 #include "network.hpp"
 #include <boost/graph/topological_sort.hpp>
+#include <stdexcept>
 
 using namespace network;
 
@@ -121,6 +122,10 @@ IndexPair Network::tailwaters(){
 }
 
 std::string Network::get_id( Graph::vertex_descriptor idx){
+  if( idx < 0 || idx >= num_vertices(this->graph) )
+  {
+    throw std::invalid_argument( std::string("Network::get_id: No vertex descriptor "+std::to_string(idx)+" in network."));
+  }
   return get(boost::vertex_name, this->graph)[idx];
 }
 

--- a/test/core/NetworkTests.cpp
+++ b/test/core/NetworkTests.cpp
@@ -197,6 +197,44 @@ TEST_P(Network_Test1, TestNetworkTopologicalIndex)
   }
 }
 
+TEST_P(Network_Test1, TestNetwork_get_id)
+{
+  //Test valid vertex descriptors
+  ASSERT_TRUE( n.get_id(0) == "cat-0" );
+  ASSERT_TRUE( n.get_id(1) == "nex-0" );
+  ASSERT_TRUE( n.get_id(2) == "cat-1" );
+}
+
+TEST_P(Network_Test1, TestNetwork_get_id_1)
+{
+  //Test an invalid vertex descriptor
+  int idx = 100;
+  try {
+    n.get_id(idx);
+    FAIL();
+  } catch( std::invalid_argument const & ex ){
+    EXPECT_EQ(ex.what(), std::string("Network::get_id: No vertex descriptor "+std::to_string(idx)+" in network."));
+  }
+  catch(...){
+    FAIL() << "Expected std::invalid_argument";
+  }
+}
+
+TEST_P(Network_Test1, TestNetwork_get_id_2)
+{
+  //Test an invalid vertex descriptor on the edge of the valid range
+  int idx = 3;
+  try {
+    n.get_id(idx);
+    FAIL();
+  } catch( std::invalid_argument const & ex ){
+    EXPECT_EQ(ex.what(), std::string("Network::get_id: No vertex descriptor "+std::to_string(idx)+" in network."));
+  }
+  catch(...){
+    FAIL() << "Expected std::invalid_argument";
+  }
+}
+
 /*  A nice example of how to disable a test
 TEST_P(Network_Test1, DISABLED_TestInit1)
 {


### PR DESCRIPTION
This PR adds inline documentation for the `Network` class which serves as the underlying graph index of features for `HY_Features` objects.  While writing the documentation, a small flaw in the error handling of `get_id` was discovered, and a fix was added to this PR.

Closes #268 

## Additions

- Inline doxygen doc strings for the Network class.

## Removals

-

## Changes

-  `get_id` throws an exception if the requested vertex descriptor isn't in the valid range of possible descriptors.

## Testing

1.  Tests for the error handling of `get_id` were added to NetworkTest

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS