### PR TITLE
Fix RHEL build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,8 @@ extern/libtorch-*.zip
 extern/cfe/cmake_cfe_lib
 # Alt-modular build dir
 extern/alt-modular/cmake_am_libs
+
+# NGen build-related items
+.venv
+boost_*
+include/NGenConfig.h

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "test/googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest
+	ignore = dirty # So the generated folder doesn't show up in git status
 [submodule "extern/alt-modular/alt-modular"]
 	path = extern/alt-modular/alt-modular
 	url = git@github.com:NOAA-OWP/alt-modular.git


### PR DESCRIPTION
Nothing but chainging the Python version to make the build work in the Docker image in the GitHub action.

## Additions

-

## Removals

-

## Changes

Python version from 3.6.12 to 3.6.8

## Testing

1. Builds/tests pass.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X ] PR has an informative and human-readable title
- [ X] Changes are limited to a single goal (no scope creep)
- [ X] Code can be automatically merged (no conflicts)
- [X ] Code follows project standards (link if applicable)
- [X ] Passes all existing automated tests
- [X ] Any _change_ in functionality is tested
- [X ] New functions are documented (with a description, list of inputs, and expected output)
- [X ] Placeholder code is flagged / future todos are captured in comments
- [X ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ X] Linux
