### PR TITLE
Noah-mp BMI shared library build file with netcdf dependency link

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -1,0 +1,131 @@
+#[==[
+Provides the following variables:
+
+  * `NetCDF_FOUND`: Whether NetCDF was found or not.
+  * `NetCDF_INCLUDE_DIRS`: Include directories necessary to use NetCDF.
+  * `NetCDF_LIBRARIES`: Libraries necessary to use NetCDF.
+  * `NetCDF_VERSION`: The version of NetCDF found.
+  * `NetCDF::NetCDF`: A target to use with `target_link_libraries`.
+  * `NetCDF_HAS_PARALLEL`: Whether or not NetCDF was found with parallel IO support.
+#]==]
+
+function(FindNetCDF_get_is_parallel_aware include_dir)
+  file(STRINGS "${include_dir}/netcdf_meta.h" _netcdf_lines
+    REGEX "#define[ \t]+NC_HAS_PARALLEL[ \t]")
+  string(REGEX REPLACE ".*NC_HAS_PARALLEL[ \t]*([0-1]+).*" "\\1" _netcdf_has_parallel "${_netcdf_lines}")
+  if (_netcdf_has_parallel)
+    set(NetCDF_HAS_PARALLEL TRUE PARENT_SCOPE)
+  else()
+    set(NetCDF_HAS_PARALLEL FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Try to find a CMake-built NetCDF.
+find_package(netCDF CONFIG QUIET)
+if (netCDF_FOUND)
+  # Forward the variables in a consistent way.
+  set(NetCDF_FOUND "${netCDF_FOUND}")
+  set(NetCDF_INCLUDE_DIRS "${netCDF_INCLUDE_DIR}")
+  set(NetCDF_LIBRARIES "${netCDF_LIBRARIES}")
+  set(NetCDF_VERSION "${NetCDFVersion}")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(NetCDF
+    REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+    VERSION_VAR NetCDF_VERSION)
+
+  if (NOT TARGET NetCDF::NetCDF)
+    add_library(NetCDF::NetCDF INTERFACE IMPORTED)
+    if (TARGET "netCDF::netcdf")
+      # 4.7.3
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "netCDF::netcdf")
+    elseif (TARGET "netcdf")
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "netcdf")
+    else ()
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${netCDF_LIBRARIES}")
+    endif ()
+  endif ()
+
+  FindNetCDF_get_is_parallel_aware("${NetCDF_INCLUDE_DIRS}")
+  # Skip the rest of the logic in this file.
+  return ()
+endif ()
+
+find_package(PkgConfig QUIET)
+if (PkgConfig_FOUND)
+  pkg_check_modules(_NetCDF QUIET netcdf IMPORTED_TARGET)
+  if (_NetCDF_FOUND)
+    # Forward the variables in a consistent way.
+    set(NetCDF_FOUND "${_NetCDF_FOUND}")
+    set(NetCDF_INCLUDE_DIRS "${_NetCDF_INCLUDE_DIRS}")
+    set(NetCDF_LIBRARIES "${_NetCDF_LIBRARIES}")
+    set(NetCDF_VERSION "${_NetCDF_VERSION}")
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(NetCDF
+      REQUIRED_VARS NetCDF_LIBRARIES
+      # This is not required because system-default include paths are not
+      # reported by `FindPkgConfig`, so this might be empty. Assume that if we
+      # have a library, the include directories are fine (if any) since
+      # PkgConfig reported that the package was found.
+      # NetCDF_INCLUDE_DIRS
+      VERSION_VAR NetCDF_VERSION)
+
+    if (NOT TARGET NetCDF::NetCDF)
+      add_library(NetCDF::NetCDF INTERFACE IMPORTED)
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_LINK_LIBRARIES "PkgConfig::_NetCDF")
+    endif ()
+
+    FindNetCDF_get_is_parallel_aware("${_NetCDF_INCLUDEDIR}")
+    # Skip the rest of the logic in this file.
+    return ()
+  endif ()
+endif ()
+
+find_path(NetCDF_INCLUDE_DIR
+  NAMES netcdf.h
+  DOC "netcdf include directories")
+mark_as_advanced(NetCDF_INCLUDE_DIR)
+
+find_library(NetCDF_LIBRARY
+  NAMES netcdf
+  DOC "netcdf library")
+mark_as_advanced(NetCDF_LIBRARY)
+
+if (NetCDF_INCLUDE_DIR)
+  file(STRINGS "${NetCDF_INCLUDE_DIR}/netcdf_meta.h" _netcdf_version_lines
+    REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+  string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_version_lines}")
+  string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_version_lines}")
+  string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_version_lines}")
+  string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_version_lines}")
+  set(NetCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+  unset(_netcdf_version_major)
+  unset(_netcdf_version_minor)
+  unset(_netcdf_version_patch)
+  unset(_netcdf_version_note)
+  unset(_netcdf_version_lines)
+
+  FindNetCDF_get_is_parallel_aware("${NetCDF_INCLUDE_DIR}")
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NetCDF
+  REQUIRED_VARS NetCDF_LIBRARY NetCDF_INCLUDE_DIR
+  VERSION_VAR NetCDF_VERSION)
+
+if (NetCDF_FOUND)
+  set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIR}")
+  set(NetCDF_LIBRARIES "${NetCDF_LIBRARY}")
+
+  if (NOT TARGET NetCDF::NetCDF)
+    add_library(NetCDF::NetCDF UNKNOWN IMPORTED)
+    set_target_properties(NetCDF::NetCDF PROPERTIES
+      IMPORTED_LOCATION "${NetCDF_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_INCLUDE_DIR}")
+  endif ()
+endif ()

--- a/extern/noah-mp-modular/CMakeLists.txt
+++ b/extern/noah-mp-modular/CMakeLists.txt
@@ -21,22 +21,21 @@ set(SURFACE_LIB_DESC_CMAKE "External Noah-MP Surface Shared Library")
 # Make sure these are compiled with this directive
 add_compile_definitions(BMI_ACTIVE)
 
-find_package (netCDF COMPONENTS F90 CONFIG)
-if(netCDF_FOUND)
-  message("Found netCDF config package")
+#Use ../../../FindNetCDF.cmake, which looks for config package, pkgconfig, and standard file locations
+#in that order
+find_package (NetCDF COMPONENTS F90)
+set(netCDF_INCLUDE_DIR ${NetCDF_INCLUDE_DIRS} CACHE PATH "NetCDF Include Directory" )
+set(netCDF_C_LIB ${NetCDF_LIBRARIES} CACHE PATH 
+"The path to the C shared object library file, libnetcdf.so or the library name if it can be found by the linker, i.e. netcdf" )
+if(NetCDF_FOUND)
+  #This provides a little diagnostic output, but most importantly, gives cache varabiles
+  #for each piece of the netcdf puzzle that a user might need to directly override
+  #if netcdf isn't configured correctly or cannot be found using the known methods.
+  message("Found netCDF package")
+  message("NetCDF inc: " ${NetCDF_INCLUDE_DIR})
+  message("NetCDF lib: " ${NetCDF_LIBRARIES})
 else()
-  # Try the VTK like FindNetCDF.cmake
-  find_package(NetCDF COMPONENTS F90 MODULE)
-  if(NetCDF_FOUND)
-    message("Found netCDF package")
-    set(netCDF_INCLUDE_DIR ${NetCDF_INCLUDE_DIRS} CACHE PATH "NetCDF Include Directory" )
-    message("NetCDF inc: " ${NetCDF_INCLUDE_DIR})
-    set(netCDF_C_LIB ${NetCDF_LIBRARIES} CACHE PATH 
-    "The path to the C shared object library file, libnetcdf.so or the library name if it can be found by the linker, i.e. netcdf" )
-    message("NetCDF lib: " ${NetCDF_LIBRARIES})
-  else()
-      message(SEND_ERROR "Cound not find NetCDF package")
-  endif()
+  message(SEND_ERROR "Could not find NetCDF, install the depdency or\n 1) Set the NetCDF_DIR to a source build\n 2) set the netCDF* cache variables as appropriate")
 endif()
 # Ensure we can find the netcdf.mod file, leave a cache var that can be set if we can't
 find_path(_netCDF_MOD_PATH "netcdf.mod" ${netCDF_INCLUDE_DIR} REQUIRED NO_CACHE)

--- a/extern/noah-mp-modular/CMakeLists.txt
+++ b/extern/noah-mp-modular/CMakeLists.txt
@@ -20,10 +20,11 @@ set(SURFACE_LIB_DESC_CMAKE "External Noah-MP Surface Shared Library")
 
 # Make sure these are compiled with this directive
 add_compile_definitions(BMI_ACTIVE)
-find_package (NetCDF REQUIRED COMPONENTS F90)
-if(NOT netCDF_LIBRARIES)
-message( SEND_ERROR "No netcdf library targets found")
-else()
+find_package (netCDF REQUIRED COMPONENTS F90 CONFIG)
+# For some reason the netcdf config.cmake doesn't set the netcdff lib correctly in
+# ${netCDF_Libararies}, so it only links the C lib (netcdf) and not the fortran lib (netcdff)
+# So find that library explicitly and make sure we link with it.
+find_library(netCDF_FORTRAN netcdff REQUIRED)
 
 set(MODEL_SOURCE_DIR noah-mp-modular/modules/surface_bmi/src/)
 set(BMI_SOURCE_DIR noah-mp-modular/modules/surface_bmi/bmi/)
@@ -38,9 +39,8 @@ list(APPEND MODEL_SOURCES noah-mp-modular/modules/surface_bmi/driver/noahmp_asci
 #target_compile_options(surfacebmi_obj PUBLIC -cpp -ffree-line-length-none)
 #target_include_directories(surfacebmi_obj PUBLIC noah-mp-modular/modules/surface_bmi/driver)
 
-#target_include_directories(surfacebmi_obj PUBLIC ${NETCDF_F90_INCLUDE_DIRS} ${netCDF_INCLUDE_DIR})
-#ensure relocatable object, make a different obj lib for a static lib and turn this off?
-
+#target_include_directories(surfacebmi_obj PUBLIC ${netCDF_INCLUDE_DIR})
+#ensure relocatable object, make a different obj lib for a static lib and turn this off
 #set_property(TARGET surfacebmi_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(WIN32)
@@ -54,16 +54,13 @@ target_include_directories(surfacebmi PUBLIC ${NETCDF_F90_INCLUDE_DIRS} ${netCDF
 #We know we are building this for NGEN support, so define the NGEN_ACTIVE preprocessor directive in the compile options
 target_compile_options(surfacebmi PUBLIC -DNGEN_ACTIVE -cpp -ffree-line-length-none)
 
-#TODO is this needed for fortran?
-target_include_directories(surfacebmi PRIVATE ${MODEL_SOURCE_DIR})
-target_link_libraries( surfacebmi iso_c_bmi ${NETCDF_LIBRARIES})
+target_link_libraries( surfacebmi iso_c_bmi ${netCDF_LIBRARIES} ${netCDF_FORTRAN})
 set_target_properties(surfacebmi PROPERTIES VERSION ${PROJECT_VERSION})
 
 #TODO is this needed for fortran?
 #set_target_properties(surfacebmi PROPERTIES PUBLIC_HEADER ${BMI_SOURCE})
 
 include(GNUInstallDirs)
-
 
 install(TARGETS surfacebmi
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/extern/noah-mp-modular/CMakeLists.txt
+++ b/extern/noah-mp-modular/CMakeLists.txt
@@ -29,25 +29,26 @@ else()
   find_package(NetCDF COMPONENTS F90 MODULE)
   if(NetCDF_FOUND)
     message("Found netCDF package")
-    set(netCDF_INCLUDE_DIR ${NetCDF_INCLUDE_DIRS} CACHE PATH "NetCDF Include Directories" )
+    set(netCDF_INCLUDE_DIR ${NetCDF_INCLUDE_DIRS} CACHE PATH "NetCDF Include Directory" )
     message("NetCDF inc: " ${NetCDF_INCLUDE_DIR})
-    set(netCDF_C_LIB ${NetCDF_LIBRARIES} CACHE PATH "NetCDF Libraries to link" )
+    set(netCDF_C_LIB ${NetCDF_LIBRARIES} CACHE PATH 
+    "The path to the C shared object library file, libnetcdf.so or the library name if it can be found by the linker, i.e. netcdf" )
     message("NetCDF lib: " ${NetCDF_LIBRARIES})
   else()
       message(SEND_ERROR "Cound not find NetCDF package")
   endif()
 endif()
 # Ensure we can find the netcdf.mod file, leave a cache var that can be set if we can't
-find_path(netCDF_MOD_PATH "netcdf.mod" ${netCDF_INCLUDE_DIR})
-if(NOT netCDF_MOD_PATH)
-  message(SEND_ERROR "no netcdf fortran module found")
-endif()
+find_path(_netCDF_MOD_PATH "netcdf.mod" ${netCDF_INCLUDE_DIR} REQUIRED NO_CACHE)
+set(netCDF_MOD_PATH ${_netCDF_MOD_PATH} CACHE PATH "Directory containing the netcdf.mod fortran module")
 
 # For some reason the netcdf config.cmake doesn't set the netcdff lib correctly in
 # ${netCDF_Libararies}, so it only links the C lib (netcdf) and not the fortran lib (netcdff)
 # So find that library explicitly and make sure we link with it.
 # also, the FindNetCDF.cmake doesn't seem to do it correctly either.
-find_library(netCDF_FORTRAN_LIB netcdff REQUIRED)
+find_library(_netCDF_FORTRAN_LIB netcdff REQUIRED  NO_CACHE)
+set(netCDF_FORTRAN_LIB ${_netCDF_FORTRAN_LIB} CACHE PATH 
+"The path to the C shared object library file, libnetcdff.so or the library name if it can be found by the linker, i.e. netcdff")
 
 set(MODEL_SOURCE_DIR noah-mp-modular/modules/surface_bmi/src/)
 set(BMI_SOURCE_DIR noah-mp-modular/modules/surface_bmi/bmi/)

--- a/extern/noah-mp-modular/CMakeLists.txt
+++ b/extern/noah-mp-modular/CMakeLists.txt
@@ -20,11 +20,34 @@ set(SURFACE_LIB_DESC_CMAKE "External Noah-MP Surface Shared Library")
 
 # Make sure these are compiled with this directive
 add_compile_definitions(BMI_ACTIVE)
-find_package (netCDF REQUIRED COMPONENTS F90 CONFIG)
+
+find_package (netCDF COMPONENTS F90 CONFIG)
+if(netCDF_FOUND)
+  message("Found netCDF config package")
+else()
+  # Try the VTK like FindNetCDF.cmake
+  find_package(NetCDF COMPONENTS F90 MODULE)
+  if(NetCDF_FOUND)
+    message("Found netCDF package")
+    set(netCDF_INCLUDE_DIR ${NetCDF_INCLUDE_DIRS} CACHE PATH "NetCDF Include Directories" )
+    message("NetCDF inc: " ${NetCDF_INCLUDE_DIR})
+    set(netCDF_C_LIB ${NetCDF_LIBRARIES} CACHE PATH "NetCDF Libraries to link" )
+    message("NetCDF lib: " ${NetCDF_LIBRARIES})
+  else()
+      message(SEND_ERROR "Cound not find NetCDF package")
+  endif()
+endif()
+# Ensure we can find the netcdf.mod file, leave a cache var that can be set if we can't
+find_path(netCDF_MOD_PATH "netcdf.mod" ${netCDF_INCLUDE_DIR})
+if(NOT netCDF_MOD_PATH)
+  message(SEND_ERROR "no netcdf fortran module found")
+endif()
+
 # For some reason the netcdf config.cmake doesn't set the netcdff lib correctly in
 # ${netCDF_Libararies}, so it only links the C lib (netcdf) and not the fortran lib (netcdff)
 # So find that library explicitly and make sure we link with it.
-find_library(netCDF_FORTRAN netcdff REQUIRED)
+# also, the FindNetCDF.cmake doesn't seem to do it correctly either.
+find_library(netCDF_FORTRAN_LIB netcdff REQUIRED)
 
 set(MODEL_SOURCE_DIR noah-mp-modular/modules/surface_bmi/src/)
 set(BMI_SOURCE_DIR noah-mp-modular/modules/surface_bmi/bmi/)
@@ -50,11 +73,11 @@ else()
     #add_library(surfacebmi_a STATIC ${BMI_SOURCE})
 endif()
 
-target_include_directories(surfacebmi PUBLIC ${NETCDF_F90_INCLUDE_DIRS} ${netCDF_INCLUDE_DIR})
+target_include_directories(surfacebmi PUBLIC ${netCDF_INCLUDE_DIR} ${netCDF_MOD_PATH})
 #We know we are building this for NGEN support, so define the NGEN_ACTIVE preprocessor directive in the compile options
 target_compile_options(surfacebmi PUBLIC -DNGEN_ACTIVE -cpp -ffree-line-length-none)
 
-target_link_libraries( surfacebmi iso_c_bmi ${netCDF_LIBRARIES} ${netCDF_FORTRAN})
+target_link_libraries( surfacebmi iso_c_bmi ${netCDF_C_LIB} ${netCDF_FORTRAN_LIB})
 set_target_properties(surfacebmi PROPERTIES VERSION ${PROJECT_VERSION})
 
 #TODO is this needed for fortran?

--- a/extern/noah-mp-modular/README.md
+++ b/extern/noah-mp-modular/README.md
@@ -57,6 +57,20 @@ Before library files can be built, a CMake build system must be generated.  E.g.
 
 Note that when there is an existing directory, it may sometimes be necessary to clear it and regenerate, especially if any changes were made to the [CMakeLists.txt](CMakeLists.txt) file.
 
+> 🚧 Warning
+> 
+> This module depends on the netCDF libraries for C and Fortran. If your libraries or include files are in a non-standard location, the build system may not be able to find them and it may be necessary to provide one or more of the following variables to `cmake`:
+> 
+> * `netCDF_C_LIB` The path to the C shared object library file, `libnetcdf.so`
+> * `netCDF_FORTRAN_LIB` The path to the Fortran shared object library file, `libnetcdff.so`
+> * `netCDF_INCLUDE_DIR` netCDF Include Directory.
+> * `netCDF_MOD_PATH` Directory containing the `netcdf.mod` Fortran module
+>
+> These can be specified with the `-D` flag like so:
+> ```
+> cmake -DnetCDF_MOD_PATH=/usr/include/openmpi-x86_64/ -B cmake_am_libs -S .
+> ```
+
 After there is build system directory, the shared libraries can be built. For example, the Noah-MP surface bmi shared library file (i.e., the build config's `surfacebmi` target) can be built using:
 
     cmake --build cmake_am_libs --target surfacebmi -- -j 2


### PR DESCRIPTION
This PR simply cleans up the extern noah-mp-modular BMI shared library build.  Specifically, it provides CMake cache variables for each key piece of netcdf info that is needed.  It tries to set them from automatically looking, but this doesn't always work, and even if it does, it may not be correct.  So you can run `cmake`, then edit the cache variables manually (using `ccmake` or `cmake gui` or directly editing `CMakeCahche.txt`.  The following variables control the liked netcdf libs

`netCDF_C_LIB` The path to the C shared object library file, `libnetcdf.so`
`netCDF_FORTRAN_LIB` The path to the Fortran shared object library file, `libnetcdff.so`
`netCDF_INCLUDE_DIR` NetCDF Include Directory.
`netCDF_MOD_PATH` Directory containing the netcdf.mod fortran module