### PR TITLE
Et calc bug fix

### DIFF
--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -176,7 +176,9 @@ namespace realization {
             // Surface radiation forcing parameter values that must come from other models
             //--------------------------------------------------------------------------------------------------------
             surf_rad_forcing.surface_skin_temperature_C = made_up_surface_skin_temperature_C;
-
+            //Compute net_radiation et forcing value
+            et_forcing.net_radiation_W_per_sq_m=et::calculate_net_radiation_W_per_sq_m(&et_options,&surf_rad_params, 
+                                                                         &surf_rad_forcing);
             // TODO: and this just needs to be created with nothing set?
             struct et::intermediate_vars inter_vars;
 


### PR DESCRIPTION
BMI_Module_Formulations were not properly calling the et combination method when PET was requested as an input variable by a model.

## Changes

- Use correct option flag
- Compute net radiation prior to calling combination method

## Testing
This patch fixes unit tests failures seen on certain environments.  It essentially fixes an uninitialized variable bug that occured in the et kernel code.

## Todos

- Clean up the et kernel code to be a little more robust to input configuration and errors

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS