### PR TITLE
Fix bmi fortran test library

### DIFF
--- a/extern/test_bmi_fortran/src/bmi_test_bmi_fortran.f90
+++ b/extern/test_bmi_fortran/src/bmi_test_bmi_fortran.f90
@@ -694,8 +694,10 @@ end function test_finalize
        bmi_status = BMI_SUCCESS
     case("INPUT_VAR_3")
        size = sizeof(this%model%input_var_3)
+       bmi_status = BMI_SUCCESS
     case("OUTPUT_VAR_1")
        size = sizeof(this%model%output_var_1)
+       bmi_status = BMI_SUCCESS
     case("OUTPUT_VAR_2")
        size = sizeof(this%model%output_var_2)
        bmi_status = BMI_SUCCESS


### PR DESCRIPTION
Two cases were missing a return status in `test_var_itemsize` in the bmi unit test library.  This PR fixes this, and should fix some of the testing issues that have come up with bmi fortran tests.