### PR TITLE
Support pattern match and ID replacement in BMI formulation init_config values

### DIFF
--- a/data/example_bmi_multi_realization_config.json
+++ b/data/example_bmi_multi_realization_config.json
@@ -20,7 +20,6 @@
                                 "allow_exceed_end_time": true,
                                 "main_output_variable": "QINSUR",
                                 "variables_names_map": {
-                                    "ETRAN": "water_potential_evaporation_flux",
                                     "PRCPNONC": "atmosphere_water__liquid_equivalent_precipitation_rate",
                                     "Q2": "atmosphere_air_water~vapor__relative_saturation",
                                     "SFCTMP": "land_surface_air__temperature",
@@ -64,7 +63,8 @@
         ],
         "forcing": {
             "file_pattern": ".*{{id}}.*..csv",
-            "path": "./data/forcings/"
+            "path": "./data/forcings/",
+            "provider": "CsvPerFeature"
         }
     },
     "time": {

--- a/data/example_bmi_multi_realization_config.json
+++ b/data/example_bmi_multi_realization_config.json
@@ -16,7 +16,7 @@
                                 "model_type_name": "bmi_fortran_noahmp",
                                 "library_file": "./extern/noah-mp-modular/cmake_build/libsurfacebmi.so",
                                 "forcing_file": "",
-                                "init_config": "./data/multi_bmi/noah-mp-modular-init.namelist.input",
+                                "init_config": "./data/multi_bmi/noah-mp-modular-init-{{id}}.namelist.input",
                                 "allow_exceed_end_time": true,
                                 "main_output_variable": "QINSUR",
                                 "variables_names_map": {
@@ -38,7 +38,7 @@
                                 "model_type_name": "bmi_c_cfe",
                                 "library_file": "./extern/cfe/cmake_build/libcfebmi.so",
                                 "forcing_file": "",
-                                "init_config": "./bmi_cfe_config.ini",
+                                "init_config": "./{{id}}_bmi_cfe_config.ini",
                                 "allow_exceed_end_time": true,
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -628,6 +628,9 @@ namespace realization {
             std::shared_ptr<forcing::ForcingProvider> self = std::make_shared<forcing::WrappedForcingProvider>(this);
             input_forcing_providers[NGEN_STD_NAME_POTENTIAL_ET_FOR_TIME_STEP] = self;
             input_forcing_providers[CSDMS_STD_NAME_POTENTIAL_ET] = self;
+
+            // Finally, make sure this is set
+            model_initialized = get_bmi_model()->is_model_initialized();
         }
 
         /**

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -47,8 +47,7 @@ namespace realization {
                 } while (id_index != std::string::npos);
 
                 properties.erase(key);
-                properties.template insert(
-                        std::pair<std::string, geojson::JSONProperty>(key, geojson::JSONProperty(key, value)));
+                properties.emplace(key, geojson::JSONProperty(key, value));
             }
         }
 

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -310,7 +310,12 @@ namespace realization {
                 forcing_params forcing_config = this->get_global_forcing_params(identifier, simulation_time_config);
 
                 std::shared_ptr<Catchment_Formulation> missing_formulation = construct_formulation(formulation_type_key, identifier, forcing_config, output_stream);
-                missing_formulation->create_formulation(this->global_formulation_parameters);
+                // Need to work with a copy, since it is altered in-place
+                geojson::PropertyMap global_properties_copy = global_formulation_parameters;
+                Catchment_Formulation::config_pattern_substitution(global_properties_copy,
+                                                                   BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG, "{{id}}",
+                                                                   identifier);
+                missing_formulation->create_formulation(global_properties_copy);
                 return missing_formulation;
             }
 


### PR DESCRIPTION
Adds support for catchment ID substitution in the `init_config` value for BMI formulations within the realization config, similarly to how this previously was in place for the global forcing config.

Also includes a few other fixes for bugs found when testing the aforementioned change, which were necessary for the primary change to work.

## Additions

- Add static helper function for performing the pattern matching and substitution in the values of an inflated realization config _PropertyMap_.

## Changes

- Fixes a bug with creation of the nested formulations for a BMI multi formulation.
- Applies new config substitution logic within BMI multi formulation function that initializes nested formulations, replacing `{{id}}` with the feature's actual id value in `init_config_ values.
- Applies new config substitution logic as described above, but in _Formulation_Manager_ when creating "missing" formulations based on the `global` config.
- Adjusts the example configuration for recent forcing provider changes.
