### PR TITLE
Execute git submodule commands from project root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ endif()
 function(git_update_submodule PATH)
     if(GIT_SUBMODULE)
         message(STATUS "Updating submodule ${PATH}")
-        execute_process(COMMAND cd ${PROJECT_SOURCE_DIR} && ${GIT_EXECUTABLE} submodule update --init -- ${PATH}
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init -- ${PATH}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             RESULT_VARIABLE GIT_SUBMOD_RESULT
             )
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 function(git_update_submodule PATH)
     if(GIT_SUBMODULE)
         message(STATUS "Updating submodule ${PATH}")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init -- ${PATH}
+        execute_process(COMMAND cd ${PROJECT_SOURCE_DIR} && ${GIT_EXECUTABLE} submodule update --init -- ${PATH}
             RESULT_VARIABLE GIT_SUBMOD_RESULT
             )
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")


### PR DESCRIPTION
Quick patch of the recent CMakeLists build magic to help automate the usage of git submodules.  `git submodule` commands can only be run from the root git directory, so make sure to `cd` to the root before initiating calls to `git submodule`