### PR TITLE
Increase and allow configurability of precision in output from BMI formulations

### DIFF
--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -22,6 +22,7 @@
 // TODO: change this (and output_header_fields) to something like output_file_variables to distinguish from BMI output variables
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS "output_variables"
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS "output_header_fields"
+#define BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION "output_precision"
 #define BMI_REALIZATION_CFG_PARAM_OPT__ALLOW_EXCEED_END "allow_exceed_end_time"
 #define BMI_REALIZATION_CFG_PARAM_OPT__FIXED_TIME_STEP "fixed_time_step"
 #define BMI_REALIZATION_CFG_PARAM_OPT__LIB_FILE "library_file"

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -1,6 +1,7 @@
 #ifndef NGEN_BMI_FORMULATION_HPP
 #define NGEN_BMI_FORMULATION_HPP
 
+#include <iomanip>
 #include <string>
 #include <utility>
 #include <vector>
@@ -61,7 +62,11 @@ namespace realization {
          * @param output_stream
          */
         Bmi_Formulation(std::string id, std::unique_ptr<forcing::ForcingProvider> forcing, utils::StreamHandler output_stream)
-                : Catchment_Formulation(std::move(id), std::move(forcing), output_stream) { };
+                : Catchment_Formulation(std::move(id), std::move(forcing), output_stream)
+        {
+            // Do this here, as this function also handles initializing the output string stream for formatting.
+            set_output_precision(9);
+        };
 
 
         virtual ~Bmi_Formulation() {};
@@ -201,7 +206,26 @@ namespace realization {
          */
         virtual bool is_model_initialized() = 0;
 
+        /**
+         * Set the precision of output values when converted to text.
+         *
+         * @param precision The desired precision, as a number of decimal places.
+         */
+        void set_output_precision(int precision) {
+            output_precision = precision;
+            output_text_stream = std::make_shared<std::ostringstream>();
+            *output_text_stream << std::fixed;
+            *output_text_stream << std::setprecision(output_precision);
+        }
+
     protected:
+
+        /** Object to help with converting numeric output values to text. */
+        std::shared_ptr<std::ostringstream> output_text_stream;
+
+        int get_output_precision() {
+            return output_precision;
+        }
 
         void set_bmi_main_output_var(const string &main_output_var) {
             bmi_main_output_var = main_output_var;
@@ -246,6 +270,8 @@ namespace realization {
          * the BMI module output variables accessible to the instance.
          */
         std::vector<std::string> output_variable_names;
+        /** The degree of precision in output values when converting to text. */
+        int output_precision;
 
         std::vector<std::string> OPTIONAL_PARAMETERS = {
                 BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE,

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -639,6 +639,12 @@ namespace realization {
             input_forcing_providers[NGEN_STD_NAME_POTENTIAL_ET_FOR_TIME_STEP] = self;
             input_forcing_providers[CSDMS_STD_NAME_POTENTIAL_ET] = self;
 
+            // Output precision, if present
+            auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
+            if (out_precision_it != properties.end()) {
+                set_output_precision(properties.at(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION).as_natural_number());
+            }
+
             // Finally, make sure this is set
             model_initialized = get_bmi_model()->is_model_initialized();
         }
@@ -838,6 +844,7 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES,
                 BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS,
                 BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS,
+                BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION,
                 BMI_REALIZATION_CFG_PARAM_OPT__ALLOW_EXCEED_END,
                 BMI_REALIZATION_CFG_PARAM_OPT__FIXED_TIME_STEP,
                 BMI_REALIZATION_CFG_PARAM_OPT__LIB_FILE

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -47,12 +47,22 @@ std::string Bmi_C_Formulation::get_output_line_for_timestep(int timestep, std::s
     if (timestep != (next_time_step_index - 1)) {
         throw std::invalid_argument("Only current time step valid when getting output for BMI C formulation");
     }
-    std::string output_str;
 
-    for (const std::string& name : get_output_variable_names()) {
-        output_str += (output_str.empty() ? "" : ",") + std::to_string(get_var_value_as_double(name));
+    // Clear anything currently in there
+    output_text_stream->str(std::string());
+
+    const std::vector<std::string> &output_var_names = get_output_variable_names();
+    // This probably should never happen, but just to be safe ...
+    if (output_var_names.empty()) { return ""; }
+
+    // Do the first separately, without the leading comma
+    *output_text_stream << get_var_value_as_double(output_var_names[0]);
+
+    // Do the rest with a leading comma
+    for (int i = 1; i < output_var_names.size(); ++i) {
+        *output_text_stream << "," << get_var_value_as_double(output_var_names[i]);
     }
-    return output_str;
+    return output_text_stream->str();
 }
 
 /**

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -48,6 +48,7 @@ std::string Bmi_C_Formulation::get_output_line_for_timestep(int timestep, std::s
         throw std::invalid_argument("Only current time step valid when getting output for BMI C formulation");
     }
 
+    // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
     // Clear anything currently in there
     output_text_stream->str(std::string());
 

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -96,6 +96,7 @@ string Bmi_Fortran_Formulation::get_output_line_for_timestep(int timestep, std::
 
     // TODO: for now, just get current value, and ignore the timestep param
 
+    // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
     // Clear anything currently in there
     output_text_stream->str(std::string());
 

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -96,12 +96,21 @@ string Bmi_Fortran_Formulation::get_output_line_for_timestep(int timestep, std::
 
     // TODO: for now, just get current value, and ignore the timestep param
 
-    std::string output_str;
+    // Clear anything currently in there
+    output_text_stream->str(std::string());
 
-    for (const std::string& name : get_output_variable_names()) {
-        output_str += (output_str.empty() ? "" : ",") + std::to_string(get_var_value_as_double(name));
+    const std::vector<std::string> &output_var_names = get_output_variable_names();
+    // This probably should never happen, but just to be safe ...
+    if (output_var_names.empty()) { return ""; }
+
+    // Do the first separately, without the leading comma
+    *output_text_stream << get_var_value_as_double(output_var_names[0]);
+
+    // Do the rest with a leading comma
+    for (int i = 1; i < output_var_names.size(); ++i) {
+        *output_text_stream << "," << get_var_value_as_double(output_var_names[i]);
     }
-    return output_str;
+    return output_text_stream->str();
 }
 
 /**

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -277,6 +277,7 @@ string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::st
     // Start by first checking whether we are NOT just using the last module's values
     if (!is_out_vars_from_last_mod) {
 
+        // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
         // Clear anything currently in the multi formulation's stream buffer
         output_text_stream->str(std::string());
 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -114,6 +114,12 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     else {
         set_output_header_fields(get_output_variable_names());
     }
+
+    // Output precision, if present
+    auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
+    if (out_precision_it != properties.end()) {
+        set_output_precision(properties.at(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION).as_natural_number());
+    }
 }
 
 /**

--- a/src/realizations/catchment/Bmi_Py_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Py_Formulation.cpp
@@ -49,12 +49,21 @@ string Bmi_Py_Formulation::get_output_line_for_timestep(int timestep, std::strin
     if (timestep != (next_time_step_index - 1)) {
         throw std::invalid_argument("Only current time step valid when getting output for BMI Python formulation");
     }
-    std::string output_str;
+    // Clear anything currently in there
+    output_text_stream->str(std::string());
 
-    for (const std::string& name : get_output_variable_names()) {
-        output_str += (output_str.empty() ? "" : ",") + std::to_string(get_var_value_as_double(name));
+    const std::vector<std::string> &output_var_names = get_output_variable_names();
+    // This probably should never happen, but just to be safe ...
+    if (output_var_names.empty()) { return ""; }
+
+    // Do the first separately, without the leading comma
+    *output_text_stream << get_var_value_as_double(output_var_names[0]);
+
+    // Do the rest with a leading comma
+    for (int i = 1; i < output_var_names.size(); ++i) {
+        *output_text_stream << "," << get_var_value_as_double(output_var_names[i]);
     }
-    return output_str;
+    return output_text_stream->str();
 }
 
 double Bmi_Py_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {

--- a/src/realizations/catchment/Bmi_Py_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Py_Formulation.cpp
@@ -49,6 +49,8 @@ string Bmi_Py_Formulation::get_output_line_for_timestep(int timestep, std::strin
     if (timestep != (next_time_step_index - 1)) {
         throw std::invalid_argument("Only current time step valid when getting output for BMI Python formulation");
     }
+
+    // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
     // Clear anything currently in there
     output_text_stream->str(std::string());
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,6 +179,29 @@ add_test(
         libudunits2
 )
 
+########################## All BMI Unit Tests
+if(BMI_C_LIB_ACTIVE)
+    if (${BMI_FORTRAN_ACTIVE})
+        if (${NGEN_ACTIVATE_PYTHON})
+            add_test(
+                    test_bmi_unit_all
+                    7
+                    realizations/catchments/Bmi_C_Adapter_Test.cpp
+                    realizations/catchments/Bmi_C_Formulation_Test.cpp
+                    realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
+                    realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+                    realizations/catchments/Bmi_Py_Adapter_Test.cpp
+                    realizations/catchments/Bmi_Py_Formulation_Test.cpp
+                    realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+                    NGen::core
+                    NGen::realizations_catchment
+                    NGen::core_mediator
+                    libudunits2
+            )
+        endif()
+    endif()
+endif()
+
 ########################## Comparison tests for the BMI CFE implementation
 # TODO: this probably needs to be added to integration testing also
 add_test(

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -197,6 +197,7 @@ void Bmi_C_Formulation_Test::SetUp() {
                          "                \"forcing_file\": \"" + forcing_file[i] + "\","
                          "                \"init_config\": \"" + init_config[i] + "\","
                          "                \"main_output_variable\": \"" + main_output_variable[i] + "\","
+                         "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
                          "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES + "\": { "
                          "                      \"INPUT_VAR_2\": \"" + NGEN_STD_NAME_POTENTIAL_ET_FOR_TIME_STEP + "\","
                          "                      \"INPUT_VAR_1\": \"" + AORC_FIELD_NAME_PRECIP_RATE + "\""

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -205,6 +205,7 @@ void Bmi_Fortran_Formulation_Test::SetUp() {
                          "                \"forcing_file\": \"" + forcing_file[i] + "\","
                          "                \"init_config\": \"" + init_config[i] + "\","
                          "                \"main_output_variable\": \"" + main_output_variable[i] + "\","
+                         "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
                          "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES + "\": { "
                          "                      \"INPUT_VAR_3\": \"" + AORC_FIELD_NAME_PRESSURE_SURFACE + "\","
                          "                      \"INPUT_VAR_2\": \"" + AORC_FIELD_NAME_SPEC_HUMID_2M_AG + "\","

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -208,6 +208,7 @@ private:
                 "                                \"init_config\": \"" + nested_init_config_lists[ex_index][nested_index] + "\",\n"
                 "                                \"allow_exceed_end_time\": true,\n"
                 "                                \"main_output_variable\": \"" + nested_module_main_output_variables[ex_index][nested_index] + "\",\n"
+                "                                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
                 + type_specific_properties +
                 "                                \"variables_names_map\": {\n"
                 + type_specific_var_map +

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -264,6 +264,7 @@ void Bmi_Py_Formulation_Test::generate_realization_config(int ex_idx) {
               "                \"forcing_file\": \"" + examples[ex_idx].forcing_params->path + "\","
               "                \"init_config\": \"" + examples[ex_idx].bmi_init_config + "\","
               "                \"main_output_variable\": \"" + examples[ex_idx].main_output_variable + "\","
+              "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
               "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES + "\": { "
               "                      \"INPUT_VAR_2\": \"" + NGEN_STD_NAME_POTENTIAL_ET_FOR_TIME_STEP + "\","
               "                      \"INPUT_VAR_1\": \"" + AORC_FIELD_NAME_PRECIP_RATE + "\""


### PR DESCRIPTION
This change primarily makes adjustments to the `get_output_line_for_timestep` functions of the BMI formulation types to have controllable precision with respect to the number of decimal places included in the output.  It also sets the default precision to 9 decimal places if not explicitly set.  Previously, the effective precision was 6 decimal places.

