### PR TITLE
Support look-back for nest BMI module input values and bootstrapping of defaults.

### DIFF
--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -330,6 +330,29 @@ A few other items of note:
       * since modules get executed in order of configuration, "earlier" and "later" are with respect to the order they are defined in the ``modules`` config list
 * the framework allows independent configuration of the `uses_forcing_file` property among the individual sub-formulations, although this is not generally recommended
 * configuration of `variables_names_map` maps a given variable to a variable name of the directly 
+* it is now possible to have an earlier nested module use as a provider (for one of its inputs) a later nested module, as long as a default value is configured
+  * a collection of variable default values can be given in the formulation config at the top level by providing an entry in `default_output_values` with the variable's mapped configuration alias (or just variable name if it is unique) and the default value:
+```json
+{
+  "global": {
+    "formulations": [
+      {
+        "name": "bmi_multi",
+        "params": {
+          "model_type_name": "bmi_multi_noahmp_cfe",
+          "forcing_file": "",
+          "init_config": "",
+          "allow_exceed_end_time": true,
+          "main_output_variable": "Q_OUT",
+          "default_output_values": [
+            {
+              "name": "QINSUR",
+              "value": 42.0
+            }
+          ],
+          "modules": [
+...
+```
 
 
 

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -2,6 +2,7 @@
 #define NGEN_DEFERREDWRAPPEDPROVIDER_HPP
 
 #include <string>
+#include <utility>
 #include <vector>
 #include "WrappedForcingProvider.hpp"
 
@@ -33,7 +34,7 @@ namespace forcing {
          *
          * @param providedValues The collection of the names of values this instance will need to provide.
          */
-        explicit DeferredWrappedProvider(vector<string> providedValues) : WrappedForcingProvider(nullptr), providedValues(providedValues) { }
+        explicit DeferredWrappedProvider(vector<string> providedValues) : WrappedForcingProvider(nullptr), providedValues(std::move(providedValues)) { }
 
         /**
          * Convenience constructor for when there is only one provided property name.

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -18,14 +18,18 @@ namespace forcing {
      * to eventually be able to provide.
      *
      * This type allows for deferring reconciling of whether a provider for some data output is available.  This is
-     * useful for situations when a required provider is not current known, but is expected, and there will be ample
+     * useful for situations when a required provider is not currently known, but is expected, and there will be ample
      * time to validate the expectation and make the necessary associations before the data must be provided.
      *
-     * Note that this type does not alter the behavior of inherited functions, except for
-     * @ref get_available_forcing_outputs.  That particular function is implemented to only return outputs guaranteed to
-     * be provideable by the instance.  Instances of this type otherwise defer to the wrapped, backing provider object
-     * and its function implementations.  This means the backing wrapped object's type control behavior of cases when
-     * some unknown value name is given.
+     * The runtime behavior of inherited functions depends on the type of the wrapped object.  I.e., nested calls to the
+     * analogous function of the wrapped provider object are made, with those results returned. The one exception to
+     * this is @ref get_available_forcing_outputs.  A particular effect of this is that the type of the wrapped provider
+     * object will dictate how an instance behaves in cases when an unrecognized output name is supplied as a parameter
+     * to @ref get_value.
+     *
+     * As noted above, the @ref get_available_forcing_outputs virtual function is overridden here.  Instead of directly
+     * returning results from a nested call to the wrapped provider, this type's implementation ensures only the outputs
+     * set as provideable in this instance (i.e., the outer wrapper) are returned.
      */
     class DeferredWrappedProvider : public WrappedForcingProvider {
     public:

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -33,14 +33,14 @@ namespace forcing {
          *
          * @param providedValues The collection of the names of values this instance will need to provide.
          */
-        DeferredWrappedProvider(vector<string> providedValues) : WrappedForcingProvider(nullptr), providedValues(providedValues) { }
+        explicit DeferredWrappedProvider(vector<string> providedValues) : WrappedForcingProvider(nullptr), providedValues(providedValues) { }
 
         /**
          * Convenience constructor for when there is only one provided property name.
          *
          * @param valueName The name of the single value this instance will need to provide.
          */
-        DeferredWrappedProvider(const string& valueName) : DeferredWrappedProvider(vector<string>(1)) {
+        explicit DeferredWrappedProvider(const string& valueName) : DeferredWrappedProvider(vector<string>(1)) {
             providedValues[0] = valueName;
         }
 
@@ -49,8 +49,8 @@ namespace forcing {
          *
          * @param provider_to_move
          */
-        DeferredWrappedProvider(DeferredWrappedProvider &&provider_to_move)
-        : DeferredWrappedProvider(provider_to_move.providedValues)
+        DeferredWrappedProvider(DeferredWrappedProvider &&provider_to_move) noexcept
+            : DeferredWrappedProvider(provider_to_move.providedValues)
         {
             wrapped_provider = provider_to_move.wrapped_provider;
             provider_to_move.wrapped_provider = nullptr;

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -82,10 +82,21 @@ namespace forcing {
         }
 
         /**
-         * Get whether the backing provider this instance wraps has been set yet.
+         * Get whether the instance is initialized such that it can handle requests to provide data.
          *
-         * @return Whether the backing provider this instance wraps has been set yet.
+         * For this type, this is equivalent to whether the wrapped provider member has been set.
+         *
+         * @return Whether the instance is initialized such that it can handle requests to provide data.
          */
+        virtual bool isReadyToProvideData() {
+            return isWrappedProviderSet();
+        }
+
+        /**
+      * Get whether the backing provider this instance wraps has been set yet.
+      *
+      * @return Whether the backing provider this instance wraps has been set yet.
+      */
         inline bool isWrappedProviderSet() {
             return wrapped_provider != nullptr;
         }
@@ -106,7 +117,7 @@ namespace forcing {
          * @param provider A pointer for the wrapped provider.
          * @return Whether @ref wrapped_provider was set to the given arg.
          */
-        inline bool setWrappedProvider(ForcingProvider *provider) {
+        virtual bool setWrappedProvider(ForcingProvider *provider) {
             // Disallow re-setting the provider if already validly set
             if (isWrappedProviderSet()) {
                 setMessage = "Cannot change wrapped provider after a valid provide has already been set";
@@ -134,7 +145,7 @@ namespace forcing {
             return true;
         }
 
-    private:
+    protected:
         /** The collection of names of the values this type can/will be able to provide from its wrapped source. */
         vector<string> providedValues;
 

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -14,17 +14,18 @@ namespace forcing {
      * A specialized @WrappedForcingProvider that is created without first knowing the backing source it wraps.
      *
      * This type wraps another @ref ForcingProvider, similarly to its parent.  This is "optimistic," however, in that it
-     * is constructed without the backing data source it will wrap.  It only requires the data value names it expects to
-     * eventually be able to provide.
+     * is constructed without the backing data source it will wrap.  It only requires the data output names it expects
+     * to eventually be able to provide.
      *
-     * This type allows for deferring reconciling of whether a provider for some data property is available.  This is
+     * This type allows for deferring reconciling of whether a provider for some data output is available.  This is
      * useful for situations when a required provider is not current known, but is expected, and there will be ample
      * time to validate the expectation and make the necessary associations before the data must be provided.
      *
      * Note that this type does not alter the behavior of inherited functions, except for
-     * @ref get_available_forcing_outputs.  It will only list outputs guaranteed to be provideable by it, but it still
-     * defers to the wrapped instance completely for other functions.  This means the wrapped type will control behavior
-     * of cases when some unknown value name is given.
+     * @ref get_available_forcing_outputs.  That particular function is implemented to only return outputs guaranteed to
+     * be provideable by the instance.  Instances of this type otherwise defer to the wrapped, backing provider object
+     * and its function implementations.  This means the backing wrapped object's type control behavior of cases when
+     * some unknown value name is given.
      */
     class DeferredWrappedProvider : public WrappedForcingProvider {
     public:
@@ -32,17 +33,17 @@ namespace forcing {
         /**
          * Constructor for instance.
          *
-         * @param providedValues The collection of the names of values this instance will need to provide.
+         * @param providedOutputs The collection of the names of outputs this instance will need to provide.
          */
-        explicit DeferredWrappedProvider(vector<string> providedValues) : WrappedForcingProvider(nullptr), providedValues(std::move(providedValues)) { }
+        explicit DeferredWrappedProvider(vector<string> providedOutputs) : WrappedForcingProvider(nullptr), providedOutputs(std::move(providedOutputs)) { }
 
         /**
-         * Convenience constructor for when there is only one provided property name.
+         * Convenience constructor for when there is only one provided output name.
          *
-         * @param valueName The name of the single value this instance will need to provide.
+         * @param outputName The name of the single output this instance will need to provide.
          */
-        explicit DeferredWrappedProvider(const string& valueName) : DeferredWrappedProvider(vector<string>(1)) {
-            providedValues[0] = valueName;
+        explicit DeferredWrappedProvider(const string& outputName) : DeferredWrappedProvider(vector<string>(1)) {
+            providedOutputs[0] = outputName;
         }
 
         /**
@@ -51,21 +52,21 @@ namespace forcing {
          * @param provider_to_move
          */
         DeferredWrappedProvider(DeferredWrappedProvider &&provider_to_move) noexcept
-            : DeferredWrappedProvider(provider_to_move.providedValues)
+            : DeferredWrappedProvider(provider_to_move.providedOutputs)
         {
             wrapped_provider = provider_to_move.wrapped_provider;
             provider_to_move.wrapped_provider = nullptr;
         }
 
         /**
-         * Get the names of the outputs for which this instance is (or will be) able to provide values.
+         * Get the names of the outputs that this instance is (or will be) able to provide.
          *
          * Note that this function behaves the same regardless of whether the wrapped provider has been set.
          *
          * @return The names of the outputs for which this instance is (or will be) able to provide values.
          */
         const std::vector<std::string> &get_available_forcing_outputs() override {
-            return providedValues;
+            return providedOutputs;
         }
 
         /**
@@ -93,10 +94,10 @@ namespace forcing {
         }
 
         /**
-      * Get whether the backing provider this instance wraps has been set yet.
-      *
-      * @return Whether the backing provider this instance wraps has been set yet.
-      */
+         * Get whether the backing provider this instance wraps has been set yet.
+         *
+         * @return Whether the backing provider this instance wraps has been set yet.
+         */
         inline bool isWrappedProviderSet() {
             return wrapped_provider != nullptr;
         }
@@ -111,7 +112,7 @@ namespace forcing {
          * There are several invalid argument cases:
          *
          * - an arg that is actually a null pointer
-         * - an arg that points to a provider that does not itself provide all the required values this must provide
+         * - an arg that points to a provider that does not itself provide all the required outputs this must provide
          * - any arg if there has already been a valid provider set
          *
          * @param provider A pointer for the wrapped provider.
@@ -120,19 +121,19 @@ namespace forcing {
         virtual bool setWrappedProvider(ForcingProvider *provider) {
             // Disallow re-setting the provider if already validly set
             if (isWrappedProviderSet()) {
-                setMessage = "Cannot change wrapped provider after a valid provide has already been set";
+                setMessage = "Cannot change wrapped provider after a valid provider has already been set";
                 return false;
             }
 
             // Confirm this will provide anything
             if (provider == nullptr) {
-                setMessage = "Cannot set provider as null, as this cannot provide the values this type must proxy";
+                setMessage = "Cannot set provider as null, as this cannot provide the outputs this type must proxy";
                 return false;
             }
 
             // Confirm this will provide everything needed
             const vector<string> &available = provider->get_available_forcing_outputs();
-            for (const string &requiredName : providedValues) {
+            for (const string &requiredName : providedOutputs) {
                 if (std::find(available.begin(), available.end(), requiredName) == available.end()) {
                     setMessage = "Given provider does not provide the required " + requiredName;
                     return false;
@@ -146,8 +147,8 @@ namespace forcing {
         }
 
     protected:
-        /** The collection of names of the values this type can/will be able to provide from its wrapped source. */
-        vector<string> providedValues;
+        /** The collection of names of the outputs this type can/will be able to provide from its wrapped source. */
+        vector<string> providedOutputs;
 
         /**
          * A message providing information from the last @ref setWrappedProvider call.

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -1,0 +1,151 @@
+#ifndef NGEN_DEFERREDWRAPPEDPROVIDER_HPP
+#define NGEN_DEFERREDWRAPPEDPROVIDER_HPP
+
+#include <string>
+#include <vector>
+#include "WrappedForcingProvider.hpp"
+
+using namespace std;
+
+namespace forcing {
+
+    /**
+     * A specialized @WrappedForcingProvider that is created without first knowing the backing source it wraps.
+     *
+     * This type wraps another @ref ForcingProvider, similarly to its parent.  This is "optimistic," however, in that it
+     * is constructed without the backing data source it will wrap.  It only requires the data value names it expects to
+     * eventually be able to provide.
+     *
+     * This type allows for deferring reconciling of whether a provider for some data property is available.  This is
+     * useful for situations when a required provider is not current known, but is expected, and there will be ample
+     * time to validate the expectation and make the necessary associations before the data must be provided.
+     *
+     * Note that this type does not alter the behavior of inherited functions, except for
+     * @ref get_available_forcing_outputs.  It will only list outputs guaranteed to be provideable by it, but it still
+     * defers to the wrapped instance completely for other functions.  This means the wrapped type will control behavior
+     * of cases when some unknown value name is given.
+     */
+    class DeferredWrappedProvider : public WrappedForcingProvider {
+    public:
+
+        /**
+         * Constructor for instance.
+         *
+         * @param providedValues The collection of the names of values this instance will need to provide.
+         */
+        DeferredWrappedProvider(vector<string> providedValues) : WrappedForcingProvider(nullptr), providedValues(providedValues) { }
+
+        /**
+         * Convenience constructor for when there is only one provided property name.
+         *
+         * @param valueName The name of the single value this instance will need to provide.
+         */
+        DeferredWrappedProvider(const string& valueName) : DeferredWrappedProvider(vector<string>(1)) {
+            providedValues[0] = valueName;
+        }
+
+        /**
+         * Move constructor.
+         *
+         * @param provider_to_move
+         */
+        DeferredWrappedProvider(DeferredWrappedProvider &&provider_to_move)
+        : DeferredWrappedProvider(provider_to_move.providedValues)
+        {
+            wrapped_provider = provider_to_move.wrapped_provider;
+            provider_to_move.wrapped_provider = nullptr;
+        }
+
+        /**
+         * Get the names of the outputs for which this instance is (or will be) able to provide values.
+         *
+         * Note that this function behaves the same regardless of whether the wrapped provider has been set.
+         *
+         * @return The names of the outputs for which this instance is (or will be) able to provide values.
+         */
+        const std::vector<std::string> &get_available_forcing_outputs() override {
+            return providedValues;
+        }
+
+        /**
+         * Get the message string for the last call to @ref setWrappedProvider.
+         *
+         * The value of the backing member for this function will be empty if the last call to @ref setWrappedProvider
+         * returned ``true`` (or has not been called yet).  If @ref setWrappedProvider it returned ``false``, then an
+         * info message will be saved in the member returned by this function, explaining more detail on the failure.
+         *
+         * @return The message string for the last call to @ref setWrappedProvider.
+         */
+        inline const string &getSetMessage() {
+            return setMessage;
+        }
+
+        /**
+         * Get whether the backing provider this instance wraps has been set yet.
+         *
+         * @return Whether the backing provider this instance wraps has been set yet.
+         */
+        inline bool isWrappedProviderSet() {
+            return wrapped_provider != nullptr;
+        }
+
+        /**
+         * Set the wrapped provider, if the given arg is valid for doing so.
+         *
+         * For a valid provider pointer argument, set the wrapped provider to it, clear the info message and return
+         * ``true``.  For an invalid arg, set the info message member to provide details on why it is invalid.  Then
+         * return ``false`` without setting the wrapped provider.
+         *
+         * There are several invalid argument cases:
+         *
+         * - an arg that is actually a null pointer
+         * - an arg that points to a provider that does not itself provide all the required values this must provide
+         * - any arg if there has already been a valid provider set
+         *
+         * @param provider A pointer for the wrapped provider.
+         * @return Whether @ref wrapped_provider was set to the given arg.
+         */
+        inline bool setWrappedProvider(ForcingProvider *provider) {
+            // Disallow re-setting the provider if already validly set
+            if (isWrappedProviderSet()) {
+                setMessage = "Cannot change wrapped provider after a valid provide has already been set";
+                return false;
+            }
+
+            // Confirm this will provide anything
+            if (provider == nullptr) {
+                setMessage = "Cannot set provider as null, as this cannot provide the values this type must proxy";
+                return false;
+            }
+
+            // Confirm this will provide everything needed
+            const vector<string> &available = provider->get_available_forcing_outputs();
+            for (const string &requiredName : providedValues) {
+                if (std::find(available.begin(), available.end(), requiredName) == available.end()) {
+                    setMessage = "Given provider does not provide the required " + requiredName;
+                    return false;
+                }
+            }
+
+            // If this is good, set things and return true
+            wrapped_provider = provider;
+            setMessage.clear();
+            return true;
+        }
+
+    private:
+        /** The collection of names of the values this type can/will be able to provide from its wrapped source. */
+        vector<string> providedValues;
+
+        /**
+         * A message providing information from the last @ref setWrappedProvider call.
+         *
+         * The value will be empty if the function returned ``true``.  If it returned ``false``, this will have an
+         * info message set explaining more detail on the failure.
+         */
+        string setMessage;
+    };
+
+}
+
+#endif //NGEN_DEFERREDWRAPPEDPROVIDER_HPP

--- a/include/forcing/OptionalWrappedProvider.hpp
+++ b/include/forcing/OptionalWrappedProvider.hpp
@@ -243,38 +243,6 @@ namespace forcing {
         }
 
         /**
-         * Record that there was an instance of a default value being used and manage the default usage "waits."
-         *
-         * When constructed, this instance may have been provided with a number of default usage "waits" for one or more
-         * outputs; i.e., a number of times it should wait to proxy a particular output value from the backing provider
-         * and instead allow a default value to override the aforementioned backing value.  This function, which should
-         * be called by @ref get_value any time a default is used, performs any modifications to the object's state that
-         * are necessary when a default is used, in particular with respect to managing "waits."
-         *
-         * In this base implementation, a recorded default usage does not count against the required number of "waits"
-         * for an output unless/until there is a wrapped backing provider set that can provide the given output.
-         * Otherwise, positive wait counts for this output be reduced by 1.  This allows negative wait counts to be used
-         * to represent that some output should always have the default used, even if the backing provider could supply
-         * a value for it.
-         *
-         * @param output_name The name of the output for which a default was used.
-         */
-        virtual void recordUsingDefault(const string &output_name) {
-            // Don't bother doing anything if there aren't waits assigned for this output
-            // Also, in this implementation, don't count usages until there is a backing provider that can provide this
-            auto waits_it = defaultUsageWaits.find(output_name);
-            if (waits_it != defaultUsageWaits.end() && isSuppliedByWrappedProvider(output_name)) {
-                // A value of 0 should be inferred and cleared from the collection, so ...
-                if (waits_it->second == 1) {
-                    defaultUsageWaits.erase(waits_it);
-                }
-                else if (waits_it->second > 1) {
-                    waits_it->second -= 1;
-                }
-            }
-        }
-
-        /**
          * Set the wrapped provider, if the given arg is valid for doing so.
          *
          * For a valid provider pointer argument, set the wrapped provider to it, clear the info message and return
@@ -317,6 +285,40 @@ namespace forcing {
             wrapped_provider = provider;
             setMessage.clear();
             return true;
+        }
+
+    protected:
+
+        /**
+         * Record that there was an instance of a default value being used and manage the default usage "waits."
+         *
+         * When constructed, this instance may have been provided with a number of default usage "waits" for one or more
+         * outputs; i.e., a number of times it should wait to proxy a particular output value from the backing provider
+         * and instead allow a default value to override the aforementioned backing value.  This function, which should
+         * be called by @ref get_value any time a default is used, performs any modifications to the object's state that
+         * are necessary when a default is used, in particular with respect to managing "waits."
+         *
+         * In this base implementation, a recorded default usage does not count against the required number of "waits"
+         * for an output unless/until there is a wrapped backing provider set that can provide the given output.
+         * Otherwise, positive wait counts for this output be reduced by 1.  This allows negative wait counts to be used
+         * to represent that some output should always have the default used, even if the backing provider could supply
+         * a value for it.
+         *
+         * @param output_name The name of the output for which a default was used.
+         */
+        virtual void recordUsingDefault(const string &output_name) {
+            // Don't bother doing anything if there aren't waits assigned for this output
+            // Also, in this implementation, don't count usages until there is a backing provider that can provide this
+            auto waits_it = defaultUsageWaits.find(output_name);
+            if (waits_it != defaultUsageWaits.end() && isSuppliedByWrappedProvider(output_name)) {
+                // A value of 0 should be inferred and cleared from the collection, so ...
+                if (waits_it->second == 1) {
+                    defaultUsageWaits.erase(waits_it);
+                }
+                else if (waits_it->second > 1) {
+                    waits_it->second -= 1;
+                }
+            }
         }
 
     private:

--- a/include/forcing/OptionalWrappedProvider.hpp
+++ b/include/forcing/OptionalWrappedProvider.hpp
@@ -1,0 +1,214 @@
+#ifndef NGEN_OPTIONALWRAPPEDPROVIDER_HPP
+#define NGEN_OPTIONALWRAPPEDPROVIDER_HPP
+
+#include "DeferredWrappedProvider.hpp"
+
+using namespace std;
+
+namespace forcing {
+
+    /**
+     * Extension of @ref DeferredWrappedProvider, where default values can be used when there is no backing provider.
+     */
+    class OptionalWrappedProvider : public DeferredWrappedProvider {
+
+    public:
+        /**
+         * Constructor for instance.
+         *
+         * Also validates that given defaults only contain keys that are in given provided outputs.
+         *
+         * @param providedOuts The collection of the names of outputs this instance will need to provide.
+         * @param defaultVals Mapping of some or all provided output defaults, keyed by output name.
+         */
+        OptionalWrappedProvider(vector<string> providedOuts, map<string, double> defaultVals)
+                : DeferredWrappedProvider(providedOuts), defaultValues(defaultVals)
+        {
+            // Validate the provided map of defaults to make sure there aren't unrecognized keys
+            if (!providedOutputs.empty() && !defaultValues.empty()) {
+                for (auto def_vals_it = defaultValues.begin(); def_vals_it < defaultValues.end(); def_vals_it++) {
+                    auto name_it = find(providedOutputs.begin(), providedOutputs.end(), def_vals_it->first);
+                    if (name_it == providedOutputs.end()) {
+                        string msg = "Invalid default values for OptionalWrappedProvider: default value given for "
+                                     "unknown output with name '" + def_vals_it->first + "' (expected names are ["
+                                     + providedOutputs[0];
+                        for (int i = 1; i < providedOutputs.size(); ++i) {
+                            msg += ", " + providedOutputs[i];
+                        }
+                        msg += "])";
+                        thrown runtime_error(msg);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Convenience constructor for instance when default values are not provided.
+         *
+         * @param providedOutputs The collection of the names of outputs this instance will need to provide.
+         */
+        explicit OptionalWrappedProvider(vector<string> providedOutputs)
+            : OptionalWrappedProvider(providedOutputs, map<string, double>()) { }
+
+        /**
+         * Convenience constructor for when there is only one provided output name, which does not have a default.
+         *
+         * @param outputName The name of the single output this instance will need to provide.
+         */
+        explicit OptionalWrappedProvider(const string& outputName) : OptionalWrappedProvider(vector<string>(1)) {
+            providedOutputs[0] = valueName;
+        }
+
+        /**
+         * Convenience constructor for when there is only one provided output name, which has a default value.
+         *
+         * @param outputName The name of the single output this instance will need to provide.
+         * @param defaultValue The default to associate with the given output.
+         */
+        OptionalWrappedProvider(const string& outputName, double defaultValue) : OptionalWrappedProvider(valueName) {
+            defaultValues[providedOutputs[0]] = defaultValue;
+        }
+
+        /**
+         * Get the value of a forcing property for an arbitrary time period, converting units if needed.
+         *
+         * This implementation can supply a default value in certain cases.  Otherwise, it defers to the wrapped,
+         * backing object.
+         *
+         * An @ref std::out_of_range exception should be thrown if the data for the time period is not available.
+         *
+         * @param output_name The name of the forcing property of interest.
+         * @param init_time_epoch The epoch time (in seconds) of the start of the time period.
+         * @param duration_seconds The length of the time period, in seconds.
+         * @param output_units The expected units of the desired output value.
+         * @return The value of the forcing property for the described time period, with units converted if needed.
+         * @throws std::out_of_range If data for the time period is not available.
+         */
+        double get_value(const std::string &output_name, const time_t &init_time, const long &duration_s,
+                         const std::string &output_units) override
+        {
+            // Balk if not in this instance's collection of outputs
+            if (find(providedOutputs.begin(), providedOutputs.end(), output_name) == providedOutputs.end()) {
+                throw runtime_error("Unknown output " + output_name + " requested from wrapped provider");
+            }
+            // Balk if this instance is not ready
+            if (!isReadyToProvideData()) {
+                throw runtime_error("Cannot get value for " + output_name
+                                    + " from optional wrapped provider before it is ready");
+            }
+            // TODO: how do we handle forcing use of a default the first (or possibly more) time when there is a backing provider?
+            // If there is a wrapped provider, try to find this output there and make a nested call
+            if (isWrappedProviderSet()) {
+                const vector<string> &backed_outputs = wrapped_provider->get_available_forcing_outputs();
+                if (find(backed_outputs.begin(), backed_outputs.end(), output_name) != backed_outputs.end()) {
+                    return wrapped_provider->get_value(output_name, init_time, duration_s, output_units);
+                }
+            }
+            // Given the above checks and implied conditions, if we get here then there must be a default
+            return defaultValues.at(output_name);
+        }
+
+        /**
+         * Move constructor.
+         *
+         * @param provider_to_move
+         */
+        OptionalWrappedProvider(OptionalWrappedProvider &&provider_to_move) noexcept
+        : OptionalWrappedProvider(provider_to_move.providedOutputs)
+        {
+            // TODO: come back to this for any other members added here
+            defaultValues = move(provider_to_move.defaultValues);
+            wrapped_provider = provider_to_move.wrapped_provider;
+            provider_to_move.wrapped_provider = nullptr;
+        }
+
+        /**
+         * Get whether the instance is initialized such that it can handle requests to provide data.
+         *
+         * For this type, this is true if either the wrapped provider member has been set, or if there are default
+         * values set up for all outputs that must be provided.
+         *
+         * @return Whether the instance is initialized such that it can handle requests to provide data.
+        */
+        bool isReadyToProvideData() override {
+            // When set, all values are either backed or have defaults, so instance is ready
+            if (isWrappedProviderSet()) {
+                return true;
+            }
+            // Otherwise, if there is a default for everything, we are also good
+            // Since the constructor validates there are no unexpected defaults, we can just compare sizes
+            else {
+                return providedOutputs.size() == defaultValues.size();
+            }
+        }
+
+        /**
+         * Set the wrapped provider, if the given arg is valid for doing so.
+         *
+         * For a valid provider pointer argument, set the wrapped provider to it, clear the info message and return
+         * ``true``.  For an invalid arg, set the info message member to provide details on why it is invalid.  Then
+         * return ``false`` without setting the wrapped provider.
+         *
+         * There are several invalid argument cases:
+         *
+         * - a null pointer, except when all provided outputs have a default available
+         * - a pointer to a provider that cannot provide all the ***required*** outputs this instance must proxy
+         *     - only values that do not have a default available are considered required
+         * - any arg if there has already been a valid provider set
+         *
+         * @param provider A pointer for the wrapped provider.
+         * @return Whether @ref wrapped_provider was set to the given arg.
+         */
+        bool setWrappedProvider(ForcingProvider *provider) override {
+            // Disallow re-setting the provider if already validly set
+            if (isWrappedProviderSet()) {
+                setMessage = "Cannot change wrapped provider after a valid provide has already been set";
+                return false;
+            }
+
+            // Confirm this will provide anything
+            if (provider == nullptr) {
+                setMessage = "Cannot set provider as null, as this cannot provide the values this type must proxy";
+                return false;
+            }
+
+            // Confirm this will provide everything needed, though allow for defaults when available
+            for (const string &requiredName : providedOutputs) {
+                // When not provided by this provider and there is not a default value set up ...
+                if (!isSuppliedByProvider(requiredName, provider) && !isSuppliedWithDefault(requiredName)) {
+                    setMessage = "Given provider does not provide the required " + requiredName;
+                    return false;
+                }
+            }
+
+            // If this is good, set things and return true
+            wrapped_provider = provider;
+            setMessage.clear();
+            return true;
+        }
+
+    private:
+
+        /**
+         * A collection of mapped default values for some or all of the provided outputs.
+         */
+        map<string, double> defaultValues;
+
+        static bool isSuppliedByProvider(const string &valName, ForcingProvider *provider) {
+            auto available = provider.get_available_forcing_outputs();
+            return std::find(available.begin(), available.end(), valName) == available.end();
+        }
+
+        inline bool isSuppliedByWrappedProvider(const string &valName) {
+            return wrapped_provider != nullptr && isSuppliedByProvider(valName, wrapped_provider);
+        }
+
+        inline bool isSuppliedWithDefault(const string &valName) {
+            return defaultValues.find(valName) == defaultValues.end();
+        }
+
+    };
+
+}
+
+#endif //NGEN_OPTIONALWRAPPEDPROVIDER_HPP

--- a/include/forcing/OptionalWrappedProvider.hpp
+++ b/include/forcing/OptionalWrappedProvider.hpp
@@ -243,6 +243,16 @@ namespace forcing {
         }
 
         /**
+         * Test whether the instance was supplied with default values that can be returned for this output.
+         *
+         * @param outputName The output in question.
+         * @return Whether a default value is available for this output.
+         */
+        inline bool isSuppliedWithDefault(const string &outputName) {
+            return defaultValues.find(outputName) != defaultValues.end();
+        }
+
+        /**
          * Set the wrapped provider, if the given arg is valid for doing so.
          *
          * For a valid provider pointer argument, set the wrapped provider to it, clear the info message and return
@@ -342,10 +352,6 @@ namespace forcing {
 
         inline bool isSuppliedByWrappedProvider(const string &outputName) {
             return wrapped_provider != nullptr && isSuppliedByProvider(outputName, wrapped_provider);
-        }
-
-        inline bool isSuppliedWithDefault(const string &outputName) {
-            return defaultValues.find(outputName) != defaultValues.end();
         }
 
     };

--- a/include/forcing/OptionalWrappedProvider.hpp
+++ b/include/forcing/OptionalWrappedProvider.hpp
@@ -335,17 +335,17 @@ namespace forcing {
          */
         map<string, int> defaultUsageWaits;
 
-        static bool isSuppliedByProvider(const string &valName, ForcingProvider *provider) {
+        static bool isSuppliedByProvider(const string &outputName, ForcingProvider *provider) {
             const vector<string> &available = provider->get_available_forcing_outputs();
-            return find(available.begin(), available.end(), valName) != available.end();
+            return find(available.begin(), available.end(), outputName) != available.end();
         }
 
-        inline bool isSuppliedByWrappedProvider(const string &valName) {
-            return wrapped_provider != nullptr && isSuppliedByProvider(valName, wrapped_provider);
+        inline bool isSuppliedByWrappedProvider(const string &outputName) {
+            return wrapped_provider != nullptr && isSuppliedByProvider(outputName, wrapped_provider);
         }
 
-        inline bool isSuppliedWithDefault(const string &valName) {
-            return defaultValues.find(valName) != defaultValues.end();
+        inline bool isSuppliedWithDefault(const string &outputName) {
+            return defaultValues.find(outputName) != defaultValues.end();
         }
 
     };

--- a/include/forcing/OptionalWrappedProvider.hpp
+++ b/include/forcing/OptionalWrappedProvider.hpp
@@ -1,6 +1,8 @@
 #ifndef NGEN_OPTIONALWRAPPEDPROVIDER_HPP
 #define NGEN_OPTIONALWRAPPEDPROVIDER_HPP
 
+#include <utility>
+
 #include "DeferredWrappedProvider.hpp"
 
 using namespace std;
@@ -8,7 +10,19 @@ using namespace std;
 namespace forcing {
 
     /**
-     * Extension of @ref DeferredWrappedProvider, where default values can be used when there is no backing provider.
+     * Extension of @ref DeferredWrappedProvider, where default values can be used instead of a backing provider.
+     *
+     * This type allows for default values for provided outputs to be supplied during construction.  These can then be
+     * provided instead of values proxied from a backing provider.  Instances can, therefore, either be ready to provide
+     * even before/without a backing provider is set, or accept as valid a backing provider that does not supply all of
+     * its required outputs.
+     *
+     * Additionally, this type can be initialized to override a backing provider in some situations.  A collection of
+     * "wait" count values can be given at construction, with these mapped to provided outputs for which defaults are
+     * also supplied. These "wait" counts represent the number of times the instance should wait to proxy the
+     * corresponding output's value from a backing provider.  In such cases, the available default value is used
+     * instead.  It is also possible to set this "wait" count to a negative number to indicate that a default should
+     * always be used for a certain output, even if a backing provider could provide it.
      */
     class OptionalWrappedProvider : public DeferredWrappedProvider {
 
@@ -22,23 +36,60 @@ namespace forcing {
          * @param defaultVals Mapping of some or all provided output defaults, keyed by output name.
          */
         OptionalWrappedProvider(vector<string> providedOuts, map<string, double> defaultVals)
-                : DeferredWrappedProvider(providedOuts), defaultValues(defaultVals)
+                : DeferredWrappedProvider(move(providedOuts)), defaultValues(move(defaultVals))
         {
             // Validate the provided map of defaults to make sure there aren't unrecognized keys
             if (!providedOutputs.empty() && !defaultValues.empty()) {
-                for (auto def_vals_it = defaultValues.begin(); def_vals_it < defaultValues.end(); def_vals_it++) {
-                    auto name_it = find(providedOutputs.begin(), providedOutputs.end(), def_vals_it->first);
+                for (const auto &def_vals_it : defaultValues) {
+                    auto name_it = find(providedOutputs.begin(), providedOutputs.end(), def_vals_it.first);
                     if (name_it == providedOutputs.end()) {
                         string msg = "Invalid default values for OptionalWrappedProvider: default value given for "
-                                     "unknown output with name '" + def_vals_it->first + "' (expected names are ["
+                                     "unknown output with name '" + def_vals_it.first + "' (expected names are ["
                                      + providedOutputs[0];
                         for (int i = 1; i < providedOutputs.size(); ++i) {
                             msg += ", " + providedOutputs[i];
                         }
                         msg += "])";
-                        thrown runtime_error(msg);
+                        throw runtime_error(msg);
                     }
                 }
+            }
+        }
+
+        /**
+         * Constructor for instance including defaults and default wait counts.
+         *
+         * Also validates that given defaults only contain keys that are in given provided outputs.
+         *
+         * @param providedOuts The collection of the names of outputs this instance will need to provide.
+         * @param defaultVals Mapping of some or all provided output defaults, keyed by output name.
+         * @param defaultWaits Map of the number of default usages for each provided output that the instance must wait
+         *                     before using values from the backing provider.
+         */
+        OptionalWrappedProvider(vector<string> providedOuts, map<string, double> defaultVals,
+                                map<string, int> defaultWaits)
+                : OptionalWrappedProvider(move(providedOuts), move(defaultVals))
+        {
+            if (!defaultWaits.empty()) {
+                // Make sure all the keys/names in the mapping of waits are recognized
+                for (const auto &wait_it : defaultWaits) {
+                    auto def_it = defaultValues.find(wait_it.first);
+                    if (def_it == defaultValues.end()) {
+                        string msg = "Invalid default usage waits for OptionalWrappedProvider: wait count given for "
+                                     "non-default output '" + wait_it.first + "' (outputs with defaults set are [";
+                        def_it = defaultValues.begin();
+                        msg += def_it->first;
+                        def_it++;
+                        while (def_it != defaultValues.end()) {
+                            msg += ", " + def_it->first;
+                            def_it++;
+                        }
+                        msg += "])";
+                        throw runtime_error(msg);
+                    }
+                }
+                // Assuming the mapping is valid, set it for the instance
+                defaultUsageWaits = move(defaultWaits);
             }
         }
 
@@ -48,7 +99,7 @@ namespace forcing {
          * @param providedOutputs The collection of the names of outputs this instance will need to provide.
          */
         explicit OptionalWrappedProvider(vector<string> providedOutputs)
-            : OptionalWrappedProvider(providedOutputs, map<string, double>()) { }
+            : OptionalWrappedProvider(move(providedOutputs), map<string, double>()) { }
 
         /**
          * Convenience constructor for when there is only one provided output name, which does not have a default.
@@ -56,7 +107,29 @@ namespace forcing {
          * @param outputName The name of the single output this instance will need to provide.
          */
         explicit OptionalWrappedProvider(const string& outputName) : OptionalWrappedProvider(vector<string>(1)) {
-            providedOutputs[0] = valueName;
+            providedOutputs[0] = outputName;
+        }
+
+        /**
+         * Convenience constructor for instance with one output and default that must be used a minimum number of times.
+         *
+         * This constructor sets up the instance to provide an output and be able to supply a default value if the
+         * backing provider is not set.  It also sets a minimum number of forced usages of the default value.  This will
+         * result in the default being used even if the backing provider has been set, according to the implementations
+         * of @ref isDefaultOverride and @ref recordUsingDefault.
+         *
+         * @param outputName The name of the single output this instance will need to provide.
+         * @param defaultValue The default to associate with the given output.
+         * @param defaultUsageWait The number of default usages that the instance must wait before using values from
+         *                          the backing provider.
+         */
+        OptionalWrappedProvider(const string& outputName, double defaultValue, int defaultUsageWait)
+            : OptionalWrappedProvider(outputName)
+        {
+            defaultValues[providedOutputs[0]] = defaultValue;
+            if (defaultUsageWait > 0) {
+                defaultUsageWaits[providedOutputs[0]] = defaultUsageWait;
+            }
         }
 
         /**
@@ -65,8 +138,21 @@ namespace forcing {
          * @param outputName The name of the single output this instance will need to provide.
          * @param defaultValue The default to associate with the given output.
          */
-        OptionalWrappedProvider(const string& outputName, double defaultValue) : OptionalWrappedProvider(valueName) {
-            defaultValues[providedOutputs[0]] = defaultValue;
+        OptionalWrappedProvider(const string& outputName, double defaultValue)
+            : OptionalWrappedProvider(outputName, defaultValue, 0) { }
+
+        /**
+         * Move constructor.
+         *
+         * @param provider_to_move
+         */
+        OptionalWrappedProvider(OptionalWrappedProvider &&provider_to_move) noexcept
+                : OptionalWrappedProvider(provider_to_move.providedOutputs)
+        {
+            defaultValues = move(provider_to_move.defaultValues);
+            defaultUsageWaits = move(provider_to_move.defaultUsageWaits);
+            wrapped_provider = provider_to_move.wrapped_provider;
+            provider_to_move.wrapped_provider = nullptr;
         }
 
         /**
@@ -75,17 +161,17 @@ namespace forcing {
          * This implementation can supply a default value in certain cases.  Otherwise, it defers to the wrapped,
          * backing object.
          *
-         * An @ref std::out_of_range exception should be thrown if the data for the time period is not available.
+         * An @ref out_of_range exception should be thrown if the data for the time period is not available.
          *
          * @param output_name The name of the forcing property of interest.
          * @param init_time_epoch The epoch time (in seconds) of the start of the time period.
          * @param duration_seconds The length of the time period, in seconds.
          * @param output_units The expected units of the desired output value.
          * @return The value of the forcing property for the described time period, with units converted if needed.
-         * @throws std::out_of_range If data for the time period is not available.
+         * @throws out_of_range If data for the time period is not available.
          */
-        double get_value(const std::string &output_name, const time_t &init_time, const long &duration_s,
-                         const std::string &output_units) override
+        double get_value(const string &output_name, const time_t &init_time, const long &duration_s,
+                         const string &output_units) override
         {
             // Balk if not in this instance's collection of outputs
             if (find(providedOutputs.begin(), providedOutputs.end(), output_name) == providedOutputs.end()) {
@@ -96,30 +182,44 @@ namespace forcing {
                 throw runtime_error("Cannot get value for " + output_name
                                     + " from optional wrapped provider before it is ready");
             }
-            // TODO: how do we handle forcing use of a default the first (or possibly more) time when there is a backing provider?
-            // If there is a wrapped provider, try to find this output there and make a nested call
-            if (isWrappedProviderSet()) {
+            // If there is a backing provider and default should not override, try to get output from backing provider
+            if (isWrappedProviderSet() && !isDefaultOverride(output_name)) {
                 const vector<string> &backed_outputs = wrapped_provider->get_available_forcing_outputs();
                 if (find(backed_outputs.begin(), backed_outputs.end(), output_name) != backed_outputs.end()) {
                     return wrapped_provider->get_value(output_name, init_time, duration_s, output_units);
                 }
             }
-            // Given the above checks and implied conditions, if we get here then there must be a default
+            // Take note if/how often default gets used in case that information is needed later
+            recordUsingDefault(output_name);
             return defaultValues.at(output_name);
         }
 
         /**
-         * Move constructor.
+         * Test whether an available default should override an available backing provider output value.
          *
-         * @param provider_to_move
+         * This method returns whether an default value is available and, despite there being a wrapped backing provider
+         * that can provide the given output, that the default value should be used instead of the backing value.
+         *
+         * When constructed, this instance may have been provided with a number of default usage "waits" for one or more
+         * outputs; i.e., a number of times it should wait to proxy a particular output value from the backing provider
+         * and instead allow a default value to override the aforementioned backing value.  This function tests whether
+         * the object is in a state in which such an override applies, with respect to the given output.
+         *
+         * The rules for transitioning through default usage "waits" are implemented in @ref recordUsingDefault.
+         *
+         * Note that the intent of the function is not the same as "should use default."  As such, the function will
+         * return ``false`` in cases when there is not a backing provider or the backing provider cannot provide the
+         * given output, even if there is a suitable default available.
+         *
+         * @param output_name The name of the output in question.
+         * @return Whether an available default should override an available backing provider output value.
+         * @see get_value
+         * @see recordUsingDefault
          */
-        OptionalWrappedProvider(OptionalWrappedProvider &&provider_to_move) noexcept
-        : OptionalWrappedProvider(provider_to_move.providedOutputs)
-        {
-            // TODO: come back to this for any other members added here
-            defaultValues = move(provider_to_move.defaultValues);
-            wrapped_provider = provider_to_move.wrapped_provider;
-            provider_to_move.wrapped_provider = nullptr;
+        bool isDefaultOverride(const string &output_name) {
+            return isSuppliedWithDefault(output_name)                                  // Must be a default
+                   && isSuppliedByWrappedProvider(output_name)                         // Must be something to override
+                   && defaultUsageWaits.find(output_name) != defaultUsageWaits.end();  // Must have a wait indicator
         }
 
         /**
@@ -139,6 +239,38 @@ namespace forcing {
             // Since the constructor validates there are no unexpected defaults, we can just compare sizes
             else {
                 return providedOutputs.size() == defaultValues.size();
+            }
+        }
+
+        /**
+         * Record that there was an instance of a default value being used and manage the default usage "waits."
+         *
+         * When constructed, this instance may have been provided with a number of default usage "waits" for one or more
+         * outputs; i.e., a number of times it should wait to proxy a particular output value from the backing provider
+         * and instead allow a default value to override the aforementioned backing value.  This function, which should
+         * be called by @ref get_value any time a default is used, performs any modifications to the object's state that
+         * are necessary when a default is used, in particular with respect to managing "waits."
+         *
+         * In this base implementation, a recorded default usage does not count against the required number of "waits"
+         * for an output unless/until there is a wrapped backing provider set that can provide the given output.
+         * Otherwise, positive wait counts for this output be reduced by 1.  This allows negative wait counts to be used
+         * to represent that some output should always have the default used, even if the backing provider could supply
+         * a value for it.
+         *
+         * @param output_name The name of the output for which a default was used.
+         */
+        virtual void recordUsingDefault(const string &output_name) {
+            // Don't bother doing anything if there aren't waits assigned for this output
+            // Also, in this implementation, don't count usages until there is a backing provider that can provide this
+            auto waits_it = defaultUsageWaits.find(output_name);
+            if (waits_it != defaultUsageWaits.end() && isSuppliedByWrappedProvider(output_name)) {
+                // A value of 0 should be inferred and cleared from the collection, so ...
+                if (waits_it->second == 1) {
+                    defaultUsageWaits.erase(waits_it);
+                }
+                else if (waits_it->second > 1) {
+                    waits_it->second -= 1;
+                }
             }
         }
 
@@ -193,10 +325,17 @@ namespace forcing {
          * A collection of mapped default values for some or all of the provided outputs.
          */
         map<string, double> defaultValues;
+        /**
+         * The number of times a default value should still be used before beginning to proxy a backing provider value.
+         *
+         * Note than all elements should have values greater than zero.  Any elements that would have their value
+         * reduced to zero should instead be removed.
+         */
+        map<string, int> defaultUsageWaits;
 
         static bool isSuppliedByProvider(const string &valName, ForcingProvider *provider) {
-            auto available = provider.get_available_forcing_outputs();
-            return std::find(available.begin(), available.end(), valName) == available.end();
+            const vector<string> &available = provider->get_available_forcing_outputs();
+            return find(available.begin(), available.end(), valName) != available.end();
         }
 
         inline bool isSuppliedByWrappedProvider(const string &valName) {
@@ -204,7 +343,7 @@ namespace forcing {
         }
 
         inline bool isSuppliedWithDefault(const string &valName) {
-            return defaultValues.find(valName) == defaultValues.end();
+            return defaultValues.find(valName) != defaultValues.end();
         }
 
     };

--- a/include/forcing/WrappedForcingProvider.hpp
+++ b/include/forcing/WrappedForcingProvider.hpp
@@ -114,7 +114,7 @@ namespace forcing {
             return wrapped_provider->is_property_sum_over_time_step(name);
         }
 
-    private:
+    protected:
         ForcingProvider* wrapped_provider;
 
     };

--- a/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
@@ -109,6 +109,7 @@ namespace realization {
         friend class Bmi_Multi_Formulation;
 
         // Unit test access
+        friend class ::Bmi_Multi_Formulation_Test;
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_Fortran_Formulation_Test;
 

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -14,6 +14,7 @@
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_Formulation_Test;
+class Bmi_Multi_Formulation_Test;
 class Bmi_C_Formulation_Test;
 class Bmi_Cpp_Formulation_Test;
 class Bmi_C_Cfe_IT;
@@ -442,9 +443,9 @@ namespace realization {
 
         /**
          * @brief Get correct BMI variable name, which may be the output or something mapped to this output.
-         * 
-         * @param name 
-         * @param bmi_var_name 
+         *
+         * @param name
+         * @param bmi_var_name
          */
         inline void get_bmi_output_var_name(const std::string &name, std::string &bmi_var_name)
         {
@@ -473,12 +474,12 @@ namespace realization {
 
         /**
          * @brief Check for implementation of internal calculators/data for a given requsted output_name
-         * 
+         *
          * @tparam T the type expected to be returned for the value of @p output_name
-         * @param output_name 
+         * @param output_name
          * @return T
          * @throws std::runtime_error If no known value or function for @p output_name
-         */ 
+         */
         template <typename T>
         inline T check_internal_providers(std::string output_name){
             // Only use the internal et_calc() if this formulation (or possibly multi-formulation)
@@ -853,6 +854,7 @@ namespace realization {
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_C_Formulation_Test;
+        friend class ::Bmi_Multi_Formulation_Test;
         friend class ::Bmi_Cpp_Formulation_Test;
 
     private:

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -7,6 +7,7 @@
 #include "Bmi_Module_Formulation.hpp"
 #include "bmi.hpp"
 #include "ForcingProvider.hpp"
+#include "DeferredWrappedProvider.hpp"
 
 #define BMI_REALIZATION_CFG_PARAM_REQ__MODULES "modules"
 #define DEFAULT_ET_FORMULATION_INDEX 0
@@ -643,6 +644,23 @@ namespace realization {
 
         /** The set of available "forcings" (output variables, plus their mapped aliases) this instance can provide. */
         std::vector<std::string> available_forcings;
+        /**
+         * A collection of wrappers to nested formulations providing some output to an earlier nested formulation.
+         *
+         * During formulation creation, when a nested formulation requires as input some output from a later formulation
+         * (e.g., in a look-back scenario to an earlier time step), then an "optimistic" wrapper gets put into place.
+         * It assumes that the necessary provider will be available and associated once all nested formulations have
+         * been created.  This member tracks these so that this deferred association can be done.
+         */
+        std::vector<std::shared_ptr<forcing::DeferredWrappedProvider>> deferredProviders;
+
+        /**
+         * The module indices for the modules associated with each item in @ref deferredProviders.
+         *
+         * E.g., the value in this vector at index ``0`` is the index of a module within @ref modules.  That module is
+         * what required the deferred provider in the @ref deferredProviders collection at its index ``0``.
+         */
+        std::vector<int> deferredProviderModuleIndices;
         /**
          * Whether the @ref Bmi_Formulation::output_variable_names value is just the analogous value from this
          * instance's final nested module.

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -8,6 +8,7 @@
 #include "bmi.hpp"
 #include "ForcingProvider.hpp"
 #include "OptionalWrappedProvider.hpp"
+#include "ConfigurationException.hpp"
 
 #define BMI_REALIZATION_CFG_PARAM_REQ__MODULES "modules"
 #define BMI_REALIZATION_CFG_PARAM_OPT__DEFAULT_OUT_VALS "default_output_values"
@@ -606,7 +607,7 @@ namespace realization {
                     for (int i = 1; i < deferredProvider->get_available_forcing_outputs().size(); ++i)
                         msg += ", " + deferredProvider->get_available_forcing_outputs()[i];
                     msg += "}";
-                    throw std::runtime_error(msg);
+                    throw realization::ConfigurationException(msg);
                 }
             }
         }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -572,7 +572,7 @@ namespace realization {
          *
          * During nested formulation creation, when a nested formulation requires as input some output expected from
          * soon-to-be-created (i.e., later in execution order) formulation (e.g., in a look-back scenario to an earlier
-         * time step), then a deferred provider gets registered with the nested module and has a referenced added to
+         * time step), then a deferred provider gets registered with the nested module and has a reference added to
          * the @ref deferredProviders member.  This function goes through all such the deferred providers, ensures there
          * is something available that can serve as the backing wrapped provider, and associates them.
          */

--- a/include/realizations/catchment/Bmi_Py_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Py_Formulation.hpp
@@ -119,6 +119,7 @@ namespace realization {
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_Py_Formulation_Test;
+        friend class ::Bmi_Multi_Formulation_Test;
 
     private:
 

--- a/include/utilities/ConfigurationException.hpp
+++ b/include/utilities/ConfigurationException.hpp
@@ -1,0 +1,36 @@
+#ifndef NGEN_CONFIGURATIONEXCEPTION_HPP
+#define NGEN_CONFIGURATIONEXCEPTION_HPP
+
+#include <exception>
+#include <string>
+#include <utility>
+
+
+namespace realization {
+    /**
+     * Custom exception indicating a problem when integrating with the provided realization configuration.
+     */
+    class ConfigurationException : public std::exception {
+
+    public:
+
+        ConfigurationException(char const *const message) noexcept : ConfigurationException(std::string(message)) {}
+
+        ConfigurationException(std::string message) noexcept : std::exception(), what_message(std::move(message)) {}
+
+        ConfigurationException(ConfigurationException &exception) noexcept : ConfigurationException(exception.what_message) {}
+
+        ConfigurationException(ConfigurationException &&exception) noexcept
+                : ConfigurationException(std::move(exception.what_message)) {}
+
+        virtual char const *what() const noexcept {
+            return what_message.c_str();
+        }
+
+    private:
+
+        std::string what_message;
+    };
+}
+
+#endif //NGEN_CONFIGURATIONEXCEPTION_HPP

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -22,6 +22,17 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         availableData[forcing_name_or_alias] = forcing_provider;
     }
 
+    // Pull default output values, if any present
+    auto defaults_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__DEFAULT_OUT_VALS);
+    if (defaults_it != properties.end()) {
+        std::vector<geojson::JSONProperty> default_entries_list = defaults_it->second.as_list();
+        for (size_t i = 0; i < default_entries_list.size(); ++i) {
+            // TODO: think through whether something needed to check for duplicates (probably not, because caught later)
+            geojson::JSONProperty default_entry = default_entries_list[i];
+            default_output_values[default_entry.at("name").as_string()] = default_entry.at("value").as_real_number();
+        }
+    }
+
     // TODO: go back and set this up properly in required params collection
     auto nested_module_configs_it = properties.find(BMI_REALIZATION_CFG_PARAM_REQ__MODULES);
     std::vector<geojson::JSONProperty> nested_module_configs = nested_module_configs_it->second.as_list();

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -15,7 +15,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     set_bmi_main_output_var(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR).as_string());
     set_model_type_name(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE).as_string());
 
+    // TODO: move this to an inline function and/or perhaps the constructor
     std::shared_ptr<forcing::WrappedForcingProvider> forcing_provider = std::make_shared<forcing::WrappedForcingProvider>(forcing.get());
+    // TODO: look through the existing provider types to add the valid alias names also
     for (const std::string &forcing_name_or_alias : forcing->get_available_forcing_outputs()) {
         availableData[forcing_name_or_alias] = forcing_provider;
     }
@@ -73,6 +75,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         modules[i] = module;
 
     } /* ************************ End outer loop: "for sub_formulations_list" ************************ */
+
+    // After all nested formulations have been initialized, reconcile deferred providers
+    init_deferred_associations();
 
     // TODO: get synced start_time values for all models
     // TODO: get synced end_time values for all models

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -268,7 +268,7 @@ add_test(
 ########################## Primary Combined Unit Test Target
 add_test(
         test_unit
-        17
+        18
         models/hymod/include/HymodTest.cpp
         models/hymod/include/Reservoir_Test.cpp
         models/hymod/include/Reservoir_Timeless_Test.cpp
@@ -280,6 +280,7 @@ add_test(
         geojson/FeatureCollection_Test.cpp
         forcing/Forcing_Test.cpp
         forcing/CsvPerFeatureForcingProvider_Test.cpp
+        forcing/OptionalWrappedProvider_Test.cpp
         core/mediator/UnitsHelper_Tests.cpp
         simulation_time/Simulation_Time_Test.cpp
         core/catchment/giuh/GIUH_Test.cpp
@@ -300,7 +301,7 @@ add_test(
 # All automated tests
 add_test(
         test_all
-        16
+        17
         models/hymod/include/HymodTest.cpp
         models/hymod/include/Reservoir_Test.cpp
         models/hymod/include/Reservoir_Timeless_Test.cpp
@@ -312,6 +313,7 @@ add_test(
         geojson/FeatureCollection_Test.cpp
         forcing/Forcing_Test.cpp
         forcing/CsvPerFeatureForcingProvider_Test.cpp
+        forcing/OptionalWrappedProvider_Test.cpp
         simulation_time/Simulation_Time_Test.cpp
         core/catchment/giuh/GIUH_Test.cpp
         core/mediator/UnitsHelper_Tests.cpp

--- a/test/forcing/OptionalWrappedProvider_Test.cpp
+++ b/test/forcing/OptionalWrappedProvider_Test.cpp
@@ -1,0 +1,181 @@
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "TrivialForcingProvider.hpp"
+#include "OptionalWrappedProvider.hpp"
+
+using namespace std;
+using namespace forcing;
+
+class OptionalWrappedProvider_Test : public ::testing::Test {
+protected:
+
+    void SetUp() override;
+
+    //void TearDown() override;
+
+    test::TrivialForcingProvider backingProvider;
+
+    vector<OptionalWrappedProvider> providers;
+
+};
+
+void OptionalWrappedProvider_Test::SetUp() {
+    // Example 0: no waits
+    providers.push_back(OptionalWrappedProvider(OUTPUT_NAME_1, OUTPUT_DEFAULT_1));
+    // Example 1: 1 wait
+    providers.push_back(OptionalWrappedProvider(OUTPUT_NAME_1, OUTPUT_DEFAULT_1, 1));
+    // Example 2: 2 wait
+    providers.push_back(OptionalWrappedProvider(OUTPUT_NAME_1, OUTPUT_DEFAULT_1, 2));
+
+    backingProvider = test::TrivialForcingProvider();
+}
+
+// TODO: add more test scenarios
+
+/**
+ * Test when no override set, before backing provider set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_is_default_override_0_a) {
+    int example_index = 0;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    //optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    bool value = optProvider.isDefaultOverride(OUTPUT_NAME_1);
+
+    ASSERT_FALSE(value);
+}
+
+/**
+ * Test when no override set, after backing provider set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_is_default_override_0_b) {
+    int example_index = 0;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    bool value = optProvider.isDefaultOverride(OUTPUT_NAME_1);
+
+    ASSERT_FALSE(value);
+}
+
+/**
+ * Test when override is set, but before backing provider set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_is_default_override_1_a) {
+    int example_index = 1;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    //optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    bool value = optProvider.isDefaultOverride(OUTPUT_NAME_1);
+
+    ASSERT_FALSE(value);
+}
+
+/**
+ * Test when override is set, after backing provider set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_is_default_override_1_b) {
+    int example_index = 1;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+
+    // Try first time, when it should override
+    bool value = optProvider.isDefaultOverride(OUTPUT_NAME_1);
+    ASSERT_TRUE(value);
+
+    // Try again, after getting the (default) value once, meaning it should no longer override
+    // Args don't really matter (apart from the name) for backing trivial item
+    double output_value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+    value = optProvider.isDefaultOverride(OUTPUT_NAME_1);
+    ASSERT_FALSE(value);
+}
+
+/**
+ * Test when default provided but no override behavior is set, for single call after provider has been set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_0_a) {
+    int example_index = 0;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+
+    ASSERT_EQ(value, OUTPUT_VALUE_1);
+}
+
+/**
+ * Test when default provided but no override behavior is set, for several calls after provider has been set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_0_b) {
+    int example_index = 0;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value;
+
+    for (int i = 0; i < 10; ++i) {
+        value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+        ASSERT_EQ(value, OUTPUT_VALUE_1);
+    }
+}
+
+/**
+ * Test when default provided but no override behavior is set, for several calls without a provider having been set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_0_c) {
+    int example_index = 0;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value;
+
+    for (int i = 0; i < 10; ++i) {
+        value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+        ASSERT_EQ(value, OUTPUT_DEFAULT_1);
+    }
+}
+
+/**
+ * Test when default is provided and 1 override wait is set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_1_a) {
+    int example_index = 1;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+    ASSERT_EQ(value, OUTPUT_DEFAULT_1);
+
+    // Second time should be the actual value
+    value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+    ASSERT_EQ(value, OUTPUT_VALUE_1);
+}
+
+/**
+ * Test when default is provided and 2 override waits are set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_2_a) {
+    int example_index = 2;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value;
+
+    for (int i = 0; i < 2; ++i) {
+        value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+        ASSERT_EQ(value, OUTPUT_DEFAULT_1);
+    }
+
+    // Third time should be the actual value
+    value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+    ASSERT_EQ(value, OUTPUT_VALUE_1);
+}

--- a/test/forcing/OptionalWrappedProvider_Test.cpp
+++ b/test/forcing/OptionalWrappedProvider_Test.cpp
@@ -27,6 +27,8 @@ void OptionalWrappedProvider_Test::SetUp() {
     providers.push_back(OptionalWrappedProvider(OUTPUT_NAME_1, OUTPUT_DEFAULT_1, 1));
     // Example 2: 2 wait
     providers.push_back(OptionalWrappedProvider(OUTPUT_NAME_1, OUTPUT_DEFAULT_1, 2));
+    // Example 3: no defaults and no waits
+    providers.push_back(OptionalWrappedProvider(OUTPUT_NAME_1));
 
     backingProvider = test::TrivialForcingProvider();
 }
@@ -178,4 +180,37 @@ TEST_F(OptionalWrappedProvider_Test, test_get_value_2_a) {
     // Third time should be the actual value
     value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
     ASSERT_EQ(value, OUTPUT_VALUE_1);
+}
+
+/**
+ * Test when default is not provided, for a single call after provider has been set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_3_a) {
+    int example_index = 3;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+    double backing_value = backingProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+
+    ASSERT_EQ(value, backing_value);
+}
+
+/**
+ * Test when default is not provided, for several calls after provider has been set.
+ */
+TEST_F(OptionalWrappedProvider_Test, test_get_value_3_b) {
+    int example_index = 3;
+
+    OptionalWrappedProvider &optProvider = providers[example_index];
+    optProvider.setWrappedProvider(&backingProvider);
+    // Args don't really matter (apart from the name) for backing trivial item
+    double value, backing_value;
+
+    for (int i = 0; i < 10; ++i) {
+        value = optProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+        backing_value = backingProvider.get_value(OUTPUT_NAME_1, 0, 10, "m");
+        ASSERT_EQ(value, backing_value);
+    }
 }

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -1,0 +1,57 @@
+#ifndef TRIVALFORCINGPROVIDER_HPP
+#define TRIVALFORCINGPROVIDER_HPP
+
+#include <string>
+#include <vector>
+#include "ForcingProvider.hpp"
+
+#define OUTPUT_NAME_1 "output_name_1"
+#define OUTPUT_VALUE_1 42.0
+#define OUTPUT_DEFAULT_1 36.8
+
+using namespace std;
+
+namespace forcing {
+    namespace test {
+/**
+ * A trivial implementation, strictly for testing OptionalWrappedProvider.
+ */
+        class TrivialForcingProvider : public ForcingProvider {
+        public:
+
+            TrivialForcingProvider() {
+                outputs.push_back(OUTPUT_NAME_1);
+            }
+
+            const vector<string> &get_available_forcing_outputs() override {
+                return outputs;
+            }
+
+            time_t get_forcing_output_time_begin(const string &output_name) override {
+                return 0;
+            }
+
+            time_t get_forcing_output_time_end(const string &output_name) override {
+                return 1000000;
+            }
+
+            size_t get_ts_index_for_time(const time_t &epoch_time) override {
+                return 0;
+            }
+
+            double get_value(const string &output_name, const time_t &init_time, const long &duration_s,
+                             const string &output_units) override {
+                return (output_name == OUTPUT_NAME_1) ? OUTPUT_VALUE_1 : 0.0;
+            }
+
+            bool is_property_sum_over_time_step(const string &name) override {
+                return true;
+            }
+
+        private:
+            vector<string> outputs;
+        };
+    }
+}
+
+#endif // TRIVALFORCINGPROVIDER_HPP

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -419,7 +419,7 @@ void Bmi_Multi_Formulation_Test::SetUp() {
 
     // Define this manually to set how many nested modules per example, and implicitly how many examples.
     // This means 2 example scenarios with 2 nested modules
-    example_module_depth = {2, 2};
+    example_module_depth = {2, 2, 2, 2};
 
     // Initialize the members for holding required input and result test data for individual example scenarios
     setupExampleDataCollections();
@@ -447,6 +447,10 @@ void Bmi_Multi_Formulation_Test::SetUp() {
     #endif // ACTIVATE_PYTHON
 
     initializeTestExample(1, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)});
+
+    initializeTestExample(2, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)});
+
+    initializeTestExample(3, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)});
 }
 
 /** Simple test to make sure the model config from example 0 initializes. */
@@ -467,6 +471,28 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_0_a) {
 /** Simple test to make sure the model config from example 1 initializes. */
 TEST_F(Bmi_Multi_Formulation_Test, Initialize_1_a) {
     int ex_index = 1;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    ASSERT_EQ(get_friend_nested_module_model_type_name(formulation, 0), nested_module_type_name_lists[ex_index][0]);
+    ASSERT_EQ(get_friend_nested_module_model_type_name(formulation, 1), nested_module_type_name_lists[ex_index][1]);
+    ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 0), nested_module_main_output_variables[ex_index][0]);
+    ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
+    ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
+    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
+}
+
+/** Simple test to make sure the model config from example 2 does not initialize because of a bad config alias. */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_2_a) {
+    int ex_index = 2;
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    ASSERT_THROW(formulation.create_formulation(config_prop_ptree[ex_index]), realization::ConfigurationException);
+}
+
+/** Test to make sure the model config from example 3 initializes properly with module varible lookback configured. */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_3_a) {
+    int ex_index = 3;
 
     Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
     formulation.create_formulation(config_prop_ptree[ex_index]);

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -295,13 +295,11 @@ private:
     }
 
     inline void buildExampleConfig(const int ex_index) {
-        int i = 0;
-
         std::string config =
                 "{\n"
                 "    \"global\": {},\n"
                 "    \"catchments\": {\n"
-                "        \"" + catchment_ids[i] + "\": {\n"
+                "        \"" + catchment_ids[ex_index] + "\": {\n"
                 "            \"formulations\": [\n"
                 "                {\n"
                 "                    \"name\": \"" + std::string(BMI_MULTI_TYPE) + "\",\n"

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -41,6 +41,12 @@ protected:
         return formulation.get_bmi_main_output_var();
     }
 
+    static const std::vector<std::shared_ptr<forcing::OptionalWrappedProvider>> &get_friend_deferred_providers(
+            const Bmi_Multi_Formulation& formulation)
+    {
+        return formulation.deferredProviders;
+    }
+
     static std::string get_friend_nested_module_main_output_variable(const Bmi_Multi_Formulation& formulation,
                                                                      const int nested_index) {
         return formulation.modules[nested_index]->get_bmi_main_output_var();
@@ -466,6 +472,16 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_0_a) {
     ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
+/** Test to make sure the model config from example 0 initializes no deferred providers. */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_0_b) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    ASSERT_EQ(get_friend_deferred_providers(formulation).size(), 0);
+}
+
 /** Simple test to make sure the model config from example 1 initializes. */
 TEST_F(Bmi_Multi_Formulation_Test, Initialize_1_a) {
     int ex_index = 1;
@@ -479,6 +495,16 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_1_a) {
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
     ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
+}
+
+/** Test to make sure the model config from example 1 initializes no deferred providers. */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_1_b) {
+    int ex_index = 1;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    ASSERT_EQ(get_friend_deferred_providers(formulation).size(), 0);
 }
 
 /** Simple test to make sure the model config from example 2 does not initialize because of a bad config alias. */
@@ -501,6 +527,30 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_3_a) {
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
     ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
+}
+
+/** Test to make sure the model config from example 3 initializes expected number of deferred providers. */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_3_b) {
+    int ex_index = 3;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    ASSERT_GT(get_friend_deferred_providers(formulation).size(), 0);
+}
+
+/** Test to make sure the model config from example 3 initializes wrapepd provider of deferred providers properly. */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_3_c) {
+    int ex_index = 3;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    const std::vector<std::shared_ptr<forcing::OptionalWrappedProvider>> deferred = get_friend_deferred_providers(
+            formulation);
+    for (size_t i = 0; i < deferred.size(); ++i) {
+        ASSERT_TRUE(deferred[i]->isWrappedProviderSet());
+    }
 }
 
 /**

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -649,7 +649,7 @@ TEST_F(Bmi_Multi_Formulation_Test, GetResponse_3_b) {
     for (int i = 0; i < 39; i++) {
         response = formulation.get_response(i, 3600);
     }
-    double expected = 4.866464273262429e-08;
+    double expected = 2.7809780039160068e-08;
     ASSERT_EQ(expected, response);
 }
 


### PR DESCRIPTION
Add support for allowing a nested formulation in a BMI multi formulation to use as a provider a later nested formulation.  Previously, only earlier nested formulations could be used like this, where earlier/later is with respect to their listed order in the realization config.  Since a later nested formulation's outputs won't have been (re)calculated yet, this effectively is a look-back to the previous time step.

Also, adding support for configuring a default value for nested formulation outputs, including having it be used as the value during the first time step in the aforementioned look-back scenario.
