### PR TITLE
Bad exception type when compiling without BMI_C_LIB_ACTIVE or ACTIVATE_PYTHON on

### DIFF
--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -353,7 +353,7 @@ void Bmi_Multi_Formulation_Test::SetUp() {
 
     /* ********************************** First example scenario (Fortran / C) ********************************** */
     #ifndef NGEN_BMI_C_LIB_ACTIVE
-    throw std::runtime_exception("Error: can't run multi BMI tests for scenario at index 0 without BMI C functionality active");
+    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 0 without BMI C functionality active");
     #endif // NGEN_BMI_C_LIB_ACTIVE
 
     #ifndef NGEN_BMI_FORTRAN_ACTIVE
@@ -370,7 +370,7 @@ void Bmi_Multi_Formulation_Test::SetUp() {
     #endif // NGEN_BMI_FORTRAN_ACTIVE
 
     #ifndef ACTIVATE_PYTHON
-    throw std::runtime_exception("Error: can't run multi BMI tests for scenario at index 1 without BMI C functionality active");
+    throw std::runtime_error("Error: can't run multi BMI tests for scenario at index 1 without BMI C functionality active");
     #endif // ACTIVATE_PYTHON
 
     initializeTestExample(1, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)});


### PR DESCRIPTION
Minor typo that only shows up in uncommon build configurations.

## Additions

-

## Removals

-

## Changes

Fixed non-existent exception type

## Testing

1. Rebuilt and ran `test_all` with `BMI_C_LIB_ACTIVE` off

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. Rebuild and run tests on `test_all` with `BMI_C_LIB_ACTIVE` and `ACTIVATE_PYTHON` off

### Target Environment support

- [x] Linux
