### PR TITLE
Quiet options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,21 @@ if(PACKAGE_TESTS)
     add_subdirectory(test)
 endif()
 
+<<<<<<< HEAD
+if(UDUNITS_QUITE)
+add_compile_definitions(UDUNITS_QUITE)
+=======
+if(QUITE)
+set(UDUNITS_QUITE true)
+set(ET_QUITE true)
+set(NGEN_QUITE true)
+endif()
+
+if(UDUNITS_QUIET)
+add_compile_definitions(UDUNITS_QUIET)
+>>>>>>> 7888582... sq udunits
+endif()
+
 #add_library(Hymod ${HYMOD_INCLUDE_DIR}/Hymod.h)
 #set_target_properties(Hymod PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,10 @@ endif()
 if(ET_QUIET)
 add_compile_definitions(ET_QUIET)
 endif()
+
+if(NGEN_QUIET)
+add_compile_definitions(NGEN_QUIET)
+endif()
 #add_library(Hymod ${HYMOD_INCLUDE_DIR}/Hymod.h)
 #set_target_properties(Hymod PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,28 +335,16 @@ if(PACKAGE_TESTS)
     add_subdirectory(test)
 endif()
 
-<<<<<<< HEAD
-if(UDUNITS_QUITE)
-add_compile_definitions(UDUNITS_QUITE)
-=======
-if(QUITE)
-set(UDUNITS_QUITE true)
-set(ET_QUITE true)
-set(NGEN_QUITE true)
+if(QUIET)
+set(UDUNITS_QUIET true)
+set(ET_QUIET true)
+set(NGEN_QUIET true)
 endif()
 
 if(UDUNITS_QUIET)
 add_compile_definitions(UDUNITS_QUIET)
->>>>>>> 7888582... sq udunits
 endif()
 
-if(ET_QUIET)
-add_compile_definitions(ET_QUIET)
-endif()
-
-if(NGEN_QUIET)
-add_compile_definitions(NGEN_QUIET)
-endif()
 #add_library(Hymod ${HYMOD_INCLUDE_DIR}/Hymod.h)
 #set_target_properties(Hymod PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,9 @@ add_compile_definitions(UDUNITS_QUIET)
 >>>>>>> 7888582... sq udunits
 endif()
 
+if(ET_QUIET)
+add_compile_definitions(ET_QUIET)
+endif()
 #add_library(Hymod ${HYMOD_INCLUDE_DIR}/Hymod.h)
 #set_target_properties(Hymod PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -25,6 +25,9 @@ class UnitsHelper {
         {
             throw std::runtime_error("Unable to create UDUNITS2 Unit System.");
         }
+        #ifndef UDUNITS_QUIET
+        ut_set_error_message_handler(ut_ignore);
+        #endif
     }
 
 };

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -151,7 +151,9 @@ class CsvPerFeatureForcingProvider : public forcing::ForcingProvider
             return UnitsHelper::get_converted_value(available_forcings_units[output_name], value, output_units);
         }
         catch (const std::runtime_error& e){
+            #ifndef UDUNITS_QUITE
             std::cerr<<"Unit conversion error: "<<std::endl<<e.what()<<std::endl<<"Returning unconverted value!"<<std::endl;
+            #endif
             return value;
         }
     }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -155,9 +155,11 @@ namespace realization {
                     for (std::pair<std::string, boost::property_tree::ptree> catchment_config : *possible_catchment_configs) {
                       if( fabric->find(catchment_config.first) == -1 )
                       {
-                        std::cout<<"WARNING Formulation_Manager::read: Cannot create formulation for catchment "
+                        #ifndef NGEN_QUIET
+                        std::cerr<<"WARNING Formulation_Manager::read: Cannot create formulation for catchment "
                                  <<catchment_config.first
                                  <<" that isn't identified in the hydrofabric or requested subset"<<std::endl;
+                        #endif
                         continue;
                       }
                       auto formulations = catchment_config.second.get_child_optional("formulations");

--- a/src/models/kernels/evapotranspiration/EtCalcProperty.cpp
+++ b/src/models/kernels/evapotranspiration/EtCalcProperty.cpp
@@ -421,10 +421,12 @@ void et::calculate_intermediate_variables
         if (air_actual_vapor_pressure_Pa > air_saturation_vapor_pressure_Pa) {
             // this is bad.   Actual vapor pressure of air should not be higher than saturated value.
             // warn and reset to something meaningful
+            #ifndef ET_QUIET
             fprintf(stderr,
                     "Invalid value of specific humidity with no supplied rel. humidity in ET calc. function:\n");
             fprintf(stderr, "Relative Humidity: %lf percent\n", et_forcing->relative_humidity_percent);
             fprintf(stderr, "Specific Humidity: %lf kg/kg\n", et_forcing->specific_humidity_2m_kg_per_kg);
+            #endif
             air_actual_vapor_pressure_Pa = 0.65 * air_saturation_vapor_pressure_Pa;
         }
     }


### PR DESCRIPTION
Add some compiler macros to suppress warnings that dominate the output.

## Additions
The following build options were added to the main CMakeLists.txt and used in various places in the code to suppress output messages.

- `UDUNITS_QUIET`
- `ET_QUIET`
- `NGEN_QUEIT`
- `QUEIT`

## Testing

1. CMake Build with `-DQUEIT:=On` runs unit tests successfully with reduced output.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOs