### PR TITLE
translate numpy/python int64 type in py adapter

### DIFF
--- a/include/realizations/catchment/Bmi_Py_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Py_Adapter.hpp
@@ -232,7 +232,7 @@ namespace models {
                     return "int";
                 } else if (py_type_name == "int" && item_size == sizeof(long)) {
                     return "long";
-                } else if (py_type_name == "int" && item_size == sizeof(long long)) {
+                } else if ( (py_type_name == "int" || py_type_name == "int64") && item_size == sizeof(long long)) {
                     return "long long";
                 } else if (py_type_name == "longlong" && item_size == sizeof(long long)) {
                     return "long long"; //numpy type


### PR DESCRIPTION
Quick update to support `int64` types from Python/numpy.   Required for integration of python LSTM model.