### PR TITLE
temporarily apply time scaling in driver

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -294,6 +294,11 @@ int main(int argc, char *argv[]) {
         {
           response *= (catchment_collection->get_feature(id)->get_property("area_sqkm").as_real_number() * 1000000);
         }
+        //TODO put this somewhere else as well, for now, an implicit assumption is that a modules get_response returns
+        //m/timestep
+        //since we are operating on a 1 hour (3600s) dt, we need to scale the output appropriately
+        //so no response is m^2/hr...m^2/hr * 1hr/3600s = m^3/hr
+        response /= 3600.0;
         //update the nexus with this flow
         for(auto& nexus : features.destination_nexuses(id)) {
           //TODO in a DENDRIDIC network, only one destination nexus per catchment


### PR DESCRIPTION
So far, all BMI models produce output `per timestep`.  So we need to adjust the formulation response based on the engine's clock, in this case 3600 seconds.  Note that this should probably be moved, and a TODO in the code exists to remind us to do so in the future.

## Additions

- Divide response by 3600 seconds

## Testing

1. AGU Demos run with this change and produce appropriately scaled outputs...

## Todos

- Eventually move this functionality into the formulation...

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOs