### PR TITLE
Bmi parameter initialization integration

### DIFF
--- a/data/bmi/c/cfe/cat-27_bmi_config.ini
+++ b/data/bmi/c/cfe/cat-27_bmi_config.ini
@@ -19,3 +19,4 @@ K_lf=0.01
 K_nash=0.03
 nash_storage=0.0,0.0
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
+num_timesteps=720

--- a/extern/test_bmi_c/include/test_bmi_c.h
+++ b/extern/test_bmi_c/include/test_bmi_c.h
@@ -27,6 +27,10 @@ struct test_bmi_c_model {
 
     double* output_var_1;
     double* output_var_2;
+
+    int param_var_1;
+    double param_var_2;
+    double* param_var_3;
 };
 typedef struct test_bmi_c_model test_bmi_c_model;
 

--- a/extern/test_bmi_c/src/bmi_test_bmi_c.c
+++ b/extern/test_bmi_c/src/bmi_test_bmi_c.c
@@ -8,7 +8,7 @@
 
 #define INPUT_VAR_NAME_COUNT 2
 #define OUTPUT_VAR_NAME_COUNT 2
-
+#define PARAM_VAR_NAME_COUNT 3
 
 // Don't forget to update Get_value/Get_value_at_indices (and setter) implementation if these are adjusted
 static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = { "OUTPUT_VAR_1", "OUTPUT_VAR_2" };
@@ -26,6 +26,13 @@ static const int input_var_item_count[INPUT_VAR_NAME_COUNT] = { 1, 1 };
 static const char *input_var_grids[INPUT_VAR_NAME_COUNT] = { 0, 0 };
 static const char *input_var_locations[INPUT_VAR_NAME_COUNT] = { "node", "node" };
 
+// Don't forget to update Get_value/Get_value_at_indices (and setter) implementation if these are adjusted
+static const char *param_var_names[PARAM_VAR_NAME_COUNT] = { "PARAM_VAR_1", "PARAM_VAR_2", "PARAM_VAR_3" };
+static const char *param_var_types[PARAM_VAR_NAME_COUNT] = { "int", "double", "double" };
+static const char *param_var_units[PARAM_VAR_NAME_COUNT] = {  "m", "m/s", "m"};
+static const int param_var_item_count[PARAM_VAR_NAME_COUNT] = { 1, 1, 2 };
+static const char *param_var_grids[PARAM_VAR_NAME_COUNT] = { 0, 0, 0 };
+static const char *param_var_locations[PARAM_VAR_NAME_COUNT] = { "node", "node", "node" };
 
 static int Finalize (Bmi *self)
 {
@@ -40,6 +47,8 @@ static int Finalize (Bmi *self)
             free(model->output_var_1);
         if( model->output_var_2 != NULL )
             free(model->output_var_2);
+        if (model->param_var_3 != NULL )
+            free(model->param_var_3);
         free(self->data);
     }
 
@@ -345,6 +354,20 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
+    if (strcmp (name, "PARAM_VAR_1") == 0) {
+        *dest = &((test_bmi_c_model *)(self->data))->param_var_1;
+        return BMI_SUCCESS;
+    }
+
+    if (strcmp (name, "PARAM_VAR_2") == 0) {
+        *dest = &((test_bmi_c_model *)(self->data))->param_var_2;
+        return BMI_SUCCESS;
+    }
+
+    if (strcmp (name, "PARAM_VAR_3") == 0) {
+        *dest = ((test_bmi_c_model *)(self->data))->param_var_3;
+        return BMI_SUCCESS;
+    }
     return BMI_FAILURE;
 }
 
@@ -433,6 +456,14 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
             }
         }
     }
+    if (item_count < 1) {
+        for (i = 0; i < PARAM_VAR_NAME_COUNT; i++) {
+            if (strcmp(name, param_var_names[i]) == 0) {
+                item_count = param_var_item_count[i];
+                break;
+            }
+        }
+    }
     if (item_count < 1)
         item_count = ((test_bmi_c_model *) self->data)->num_time_steps;
 
@@ -455,6 +486,13 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
     for (i = 0; i < INPUT_VAR_NAME_COUNT; i++) {
         if (strcmp(name, input_var_names[i]) == 0) {
             strncpy(type, input_var_types[i], BMI_MAX_TYPE_NAME);
+            return BMI_SUCCESS;
+        }
+    }
+    // Finally check to see if in param array
+    for (i = 0; i < PARAM_VAR_NAME_COUNT; i++) {
+        if (strcmp(name, param_var_names[i]) == 0) {
+            strncpy(type, param_var_types[i], BMI_MAX_TYPE_NAME);
             return BMI_SUCCESS;
         }
     }
@@ -528,6 +566,12 @@ static int Initialize (Bmi *self, const char *file)
     model->input_var_2 = malloc(sizeof(double));
     model->output_var_1 = malloc(sizeof(double));
     model->output_var_2 = malloc(sizeof(double));
+
+    model->param_var_1 = 0;
+    model->param_var_2 = 0.0;
+    model->param_var_3 = malloc(2*sizeof(double));
+    model->param_var_3[0] = 0.0;
+    model->param_var_3[1] = 0.0;
 
     return BMI_SUCCESS;
 }

--- a/extern/test_bmi_c/src/bmi_test_bmi_c.c
+++ b/extern/test_bmi_c/src/bmi_test_bmi_c.c
@@ -281,9 +281,28 @@ static int Get_time_units (Bmi *self, char * units)
 
 static int Get_value (Bmi *self, const char *name, void *dest)
 {
-    // Since all the variables are scalar, use nested call to "by index" version, with just index 0
-    int inds[] = {0};
-    return self->get_value_at_indices(self, name, dest, inds, 1);
+    int i = 0;
+    int item_count = -1;
+    for (i = 0; i < PARAM_VAR_NAME_COUNT; i++) {
+            if (strcmp(name, param_var_names[i]) == 0) {
+                item_count = param_var_item_count[i];
+                break;
+            }
+        }
+    
+    if( item_count < 1 ){
+        // Since all the variables are scalar, use nested call to "by index" version, with just index 0
+        int inds[] = {0};
+        return self->get_value_at_indices(self, name, dest, inds, 1);
+    }
+    else{
+        //All linear indicies
+        int inds[item_count];
+        for(i = 0; i < item_count; i++){
+            inds[i] = i;
+        }
+        return self->get_value_at_indices(self, name, dest, inds, item_count);
+    }
 }
 
 

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -387,6 +387,39 @@ namespace geojson {
 
             bool as_boolean() const;
 
+            /**
+             * @brief Populates a std::vector<T> with PropertyVariant values.
+             * 
+             * Scalar properties will yeild a vector of size 1.
+             * 
+             * List properties will yield a vector of compatible types.
+             * E.g. a List with [1, 2.1, 3] can upcast the Natural number 1 and 3 iff 
+             * a container is provided with sufficient datatype (double)
+             * 
+             * std::vector<double> double_vec;
+             * as_vector(double_vec);
+             * 
+             * Will give a vector of doubles = {1.0, 2.1, 3.0}.
+             * 
+             * However, if a vector of long is used, only the Natural numbers will be extracted
+             * 
+             * std::vector<long> long_vec;
+             * as_vector(long_vec); 
+             * 
+             * Will give a vector of longs = {1, 3}.
+             * 
+             * Other than this caveat, as_vector effetively filters the property list for types
+             * representable by T.
+             * 
+             * @tparam T 
+             * @param vector 
+             */
+            template <typename T>
+            void as_vector(std::vector<T>& vector) const{
+                PropertyVisitor<T> visitor(vector);
+                boost::apply_visitor(visitor, data);
+            }
+
             std::vector<JSONProperty> as_list() const;
 
             std::vector<long> as_natural_vector() const;

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -8,9 +8,45 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/variant.hpp>
 
 namespace geojson {
     class JSONProperty;
+    //Forward declare variant types
+    struct List;
+    struct Object;
+    using PropertyVariant = boost::variant<boost::blank, 
+                                           long, 
+                                           double, 
+                                           bool, 
+                                           std::string, 
+                                           boost::recursive_wrapper<List>, 
+                                           boost::recursive_wrapper<Object>
+                                          >;
+    
+    /**
+     * @brief Struct wrapping a vector of \ref PropertyVariant representing a JSON list.
+     * 
+     */
+    struct List{
+        std::vector<PropertyVariant> values;
+        friend std::ostream& operator<<(std::ostream& os, const List& obj){
+            os<<"LIST";
+            return os;
+        }
+    };
+
+    /**
+     * @brief Struct wrapping a map of nested \ref PropertyVariant representing a JSON object.
+     * 
+     */
+    struct Object{
+        std::map<std::string, PropertyVariant> values;
+        friend std::ostream& operator<<(std::ostream& os, const Object& obj){
+            os<<"OBJECT";
+            return os;
+        }
+    };
     
     /**
      * Defines the different types of properties that are stored within a JSON property 
@@ -373,6 +409,11 @@ namespace geojson {
             bool boolean;
             PropertyMap values;
             std::vector<JSONProperty> value_list;
+            //boost::variant to hold the parsed data
+            //can be one of boost::blank, long, double, bool, string, List, Object
+            //Defaults to boost::blank
+            //TODO port this entire class to use this variant
+            PropertyVariant data;
     };
 }
 #endif // GEOJSON_JSONPROPERTY_H

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -704,7 +704,8 @@ namespace realization {
          * 
          */
         void set_initial_bmi_parameters(geojson::PropertyMap properties){
-            //NJF FIXME
+            auto model = get_bmi_model();
+            if( model == nullptr ) return;
             //Now that the model is ready, we can set some intial parameters passed in the config
             auto model_params = properties.find("model_params");
             
@@ -714,7 +715,7 @@ namespace realization {
                 for (auto& param : params) {
                     //FIXME type???
                     auto data = param.second.as_real_vector().data();
-                        get_bmi_model()->SetValue(param.first, &data);
+                        model->SetValue(param.first, &data);
                 }
                 
             }

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -825,6 +825,54 @@ namespace realization {
             return ptr;
         }
 
+        /**
+         * @brief Gets values in iterator range, casted based on @p type then returned as typeless (void) pointer.  
+         * 
+         * @tparam Iterator 
+         * @param type 
+         * @param begin 
+         * @param end 
+         * @return std::shared_ptr<void> 
+         */
+        template <typename Iterator>
+        std::shared_ptr<void> get_values_as_type(std::string type, Iterator begin, Iterator end)
+        {
+            //Use std::vector range constructor to ensure contiguous storage of values
+            //Return the pointer to the contiguous storage
+            if (type == "double" || type == "double precision")
+                return as_c_array<double>(begin, end);
+           
+            if (type == "float" || type == "real")
+                return as_c_array<float>(begin, end);
+
+            if (type == "short" || type == "short int" || type == "signed short" || type == "signed short int")
+                return as_c_array<short>(begin, end);
+
+            if (type == "unsigned short" || type == "unsigned short int")
+                return as_c_array<unsigned short>(begin, end);
+
+            if (type == "int" || type == "signed" || type == "signed int" || type == "integer")
+                return as_c_array<int>(begin, end);
+
+            if (type == "unsigned" || type == "unsigned int")
+                return as_c_array<unsigned int>(begin, end);
+
+            if (type == "long" || type == "long int" || type == "signed long" || type == "signed long int")
+                return as_c_array<long>(begin, end);
+
+            if (type == "unsigned long" || type == "unsigned long int")
+                return as_c_array<unsigned long>(begin, end);
+
+            if (type == "long long" || type == "long long int" || type == "signed long long" || type == "signed long long int")
+                return as_c_array<long long>(begin, end);
+
+            if (type == "unsigned long long" || type == "unsigned long long int")
+                return as_c_array<unsigned long long>(begin, end);
+
+            throw std::runtime_error("Unable to get values of iterable as type" + type + " from " + get_model_type_name() +
+                " : no logic for converting values to variable's type.");
+        }
+
         // TODO: need to modify this to support arrays properly, since in general that's what BMI modules deal with
         template<typename T>
         std::shared_ptr<void> get_value_as_type(std::string type, T value)

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -795,6 +795,36 @@ namespace realization {
             model_initialized = is_initialized;
         }
 
+        /**
+         * @brief Template function for copying iterator range into contiguous array.
+         * 
+         * This function will iterate the range and cast the iterator value to type T
+         * and copy that value into a C-like array of contiguous, dynamically allocated memory.
+         * This array is stored in a smart pointer with a custom array deleter.
+         * 
+         * @tparam T 
+         * @tparam Iterator 
+         * @param begin 
+         * @param end 
+         * @return std::shared_ptr<T> 
+         */
+        template <typename T, typename Iterator>
+        std::shared_ptr<T> as_c_array(Iterator begin, Iterator end){
+            //Make a shared pointer large enough to hold all elements
+            //This is a CONTIGUOUS array of type T
+            //Must provide a custom deleter to delete the array
+            std::shared_ptr<T> ptr( new T[std::distance(begin, end)], [](T *p) { delete[] p; } );
+            Iterator it = begin;
+            int i = 0;
+            while(it != end){
+                //Be safe and cast the input to the desired type
+                ptr.get()[i] = static_cast<T>(*it);
+                ++it;
+                ++i;
+            }
+            return ptr;
+        }
+
         // TODO: need to modify this to support arrays properly, since in general that's what BMI modules deal with
         template<typename T>
         std::shared_ptr<void> get_value_as_type(std::string type, T value)

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -640,7 +640,22 @@ namespace realization {
             // Do this next, since after checking whether other input variables are present in the properties, we can
             // now construct the adapter and init the model
             set_bmi_model(construct_model(properties));
-
+            
+            //NJF FIXME
+            //Now that the model is ready, we can set some intial parameters passed in the config
+            auto model_params = properties.find("model_params");
+            
+            if (model_params != properties.end() ){
+                
+                geojson::PropertyMap params = model_params->second.get_values();
+                for (auto& param : params) {
+                    //FIXME type???
+                    auto data = param.second.as_real_vector().data();
+                        get_bmi_model()->SetValue(param.first, &data);
+                }
+                
+            }
+            
             // Make sure that this is able to interpret model time and convert to real time, since BMI model time is
             // usually starting at 0 and just counting up
             determine_model_time_offset();

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -641,20 +641,9 @@ namespace realization {
             // now construct the adapter and init the model
             set_bmi_model(construct_model(properties));
             
-            //NJF FIXME
-            //Now that the model is ready, we can set some intial parameters passed in the config
-            auto model_params = properties.find("model_params");
-            
-            if (model_params != properties.end() ){
-                
-                geojson::PropertyMap params = model_params->second.get_values();
-                for (auto& param : params) {
-                    //FIXME type???
-                    auto data = param.second.as_real_vector().data();
-                        get_bmi_model()->SetValue(param.first, &data);
-                }
-                
-            }
+            //Check if any parameter values need to be set on the BMI model,
+            //and set them before it is run
+            set_initial_bmi_parameters(properties);
             
             // Make sure that this is able to interpret model time and convert to real time, since BMI model time is
             // usually starting at 0 and just counting up
@@ -701,6 +690,34 @@ namespace realization {
 
             // Finally, make sure this is set
             model_initialized = get_bmi_model()->is_model_initialized();
+        }
+
+        /**
+         * @brief Check configuration properties for `model_params` and attempt to set them in the bmi model.
+         * 
+         * This checks for a key named `model_params` in the parsed properties, and for each property
+         * it will attempt to call `SetValue` using the property's key as the BMI variable
+         * and the property's value as the value to set.
+         * 
+         * This function should only be called once @p bmi_model is properly constructed.
+         * If @p bmi_model is a nullptr, this function becomes a no-op.
+         * 
+         */
+        void set_initial_bmi_parameters(geojson::PropertyMap properties){
+            //NJF FIXME
+            //Now that the model is ready, we can set some intial parameters passed in the config
+            auto model_params = properties.find("model_params");
+            
+            if (model_params != properties.end() ){
+                
+                geojson::PropertyMap params = model_params->second.get_values();
+                for (auto& param : params) {
+                    //FIXME type???
+                    auto data = param.second.as_real_vector().data();
+                        get_bmi_model()->SetValue(param.first, &data);
+                }
+                
+            }
         }
 
         /**

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -728,7 +728,10 @@ namespace realization {
                     //Figure out the c++ type to convert data to
                     std::string type = get_bmi_model()->get_analogous_cxx_type(get_bmi_model()->GetVarType(param.first),
                                                                            varItemSize);
-
+                    //TODO might consider refactoring as_vector and get_values_as_type
+                    //(and by extension, as_c_array) into the JSONProperty class
+                    //then instead of the PropertyVariant visitor filling vectors
+                    //it could fill the c-like array and avoid another copy.
                      switch( param.second.get_type() ){
                         case geojson::PropertyType::Natural:
                             param.second.as_vector(long_vec);

--- a/src/geojson/JSONProperty.cpp
+++ b/src/geojson/JSONProperty.cpp
@@ -192,3 +192,10 @@ bool JSONProperty::has_key(std::string key) const {
 std::string JSONProperty::get_key() const {
     return key;
 }
+
+namespace geojson{
+    //Template specialization
+    template<> template<> void JSONProperty::PropertyVisitor<double>::operator ()<long>(const long& value){
+                        vec.push_back(static_cast<double>(value));
+        }
+}

--- a/test/geojson/JSONProperty_Test.cpp
+++ b/test/geojson/JSONProperty_Test.cpp
@@ -186,3 +186,113 @@ TEST_F(JSONProperty_Test, ptree_test) {
     ASSERT_EQ(properties[3].get_type(), geojson::PropertyType::Natural);
     ASSERT_EQ(properties[4].get_type(), geojson::PropertyType::Real);
 }
+
+TEST_F(JSONProperty_Test, test_as_vector_natural){
+    geojson::JSONProperty natural_property("natural", 4);
+    ASSERT_EQ(natural_property.get_type(), geojson::PropertyType::Natural);
+    ASSERT_EQ(natural_property.as_natural_number(), 4);
+    std::vector<long> vec;
+    natural_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 1);
+    ASSERT_EQ(vec[0], 4);
+}
+
+TEST_F(JSONProperty_Test, test_as_vector_real){
+    geojson::JSONProperty natural_property("real", 4.2);
+    ASSERT_EQ(natural_property.get_type(), geojson::PropertyType::Real);
+    ASSERT_EQ(natural_property.as_real_number(), 4.2);
+    std::vector<double> vec;
+    natural_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 1);
+    ASSERT_EQ(vec[0], 4.2);
+}
+
+TEST_F(JSONProperty_Test, test_as_vector_string){
+    geojson::JSONProperty natural_property("string", "test");
+    ASSERT_EQ(natural_property.get_type(), geojson::PropertyType::String);
+    ASSERT_EQ(natural_property.as_string(), "test");
+    std::vector<std::string> vec;
+    natural_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 1);
+    ASSERT_EQ(vec[0], "test");
+}
+
+TEST_F(JSONProperty_Test, test_as_vector_natural_list){
+    std::vector<long> test_list = {1,2,3,4};
+    std::vector<geojson::JSONProperty> properties;
+    for(auto const num : test_list){
+        properties.push_back(geojson::JSONProperty("", num));
+    }
+
+    geojson::JSONProperty natural_property("natural_list", properties);
+    ASSERT_EQ(natural_property.get_type(), geojson::PropertyType::List);
+    ASSERT_EQ(natural_property.as_natural_vector(), test_list);
+    std::vector<long> vec;
+    natural_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 4);
+    ASSERT_EQ(vec, test_list);
+}
+
+TEST_F(JSONProperty_Test, test_as_vector_real_list){
+    std::vector<double> test_list = {1.1,2.2,3.3,4.4};
+    std::vector<geojson::JSONProperty> properties;
+    for(auto const num : test_list){
+        properties.push_back(geojson::JSONProperty("", num));
+    }
+
+    geojson::JSONProperty real_property("real_list", properties);
+    ASSERT_EQ(real_property.get_type(), geojson::PropertyType::List);
+    ASSERT_EQ(real_property.as_real_vector(), test_list);
+    std::vector<double> vec;
+    real_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 4);
+    ASSERT_EQ(vec, test_list);
+}
+
+TEST_F(JSONProperty_Test, test_as_vector_mixed_list){
+    //Test to ensure a mixed list of natural and real numbers
+    //can be converted to a single vector of real (double)
+    std::vector<double> test_list_real = {1.1,2.2,3.3,4.4};
+    std::vector<long> test_list_natural = {1,2,3,4};
+    std::vector<geojson::JSONProperty> properties;
+    for(auto const num : test_list_real){
+        properties.push_back(geojson::JSONProperty("", num));
+    }
+    for(auto const num : test_list_natural){
+        properties.push_back(geojson::JSONProperty("", num));
+    }
+    geojson::JSONProperty mixed_property("mixed_list", properties);
+    std::vector<double> vec;
+    mixed_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 8);
+    std::vector<double> all = {1.1,2.2,3.3,4.4,1,2,3,4};
+    ASSERT_EQ(vec, all);
+}
+
+TEST_F(JSONProperty_Test, test_as_vector_mixed_list_0a){
+    std::vector<double> test_list_real = {1.1,2.2,3.3,4.4};
+    std::vector<long> test_list_natural = {1,2,3,4};
+    std::vector<std::string> test_list_str = {"hello", "world"};
+    std::vector<geojson::JSONProperty> properties;
+    for(auto const num : test_list_real){
+        properties.push_back(geojson::JSONProperty("", num));
+    }
+    for(auto const num : test_list_natural){
+        properties.push_back(geojson::JSONProperty("", num));
+    }
+    for(auto const str : test_list_str){
+        properties.push_back(geojson::JSONProperty("", str));
+    }
+    geojson::JSONProperty mixed_property("mixed_list", properties);
+    std::vector<double> vec;
+    mixed_property.as_vector(vec);
+    ASSERT_EQ(vec.size(), 8);
+    std::vector<double> all = {1.1,2.2,3.3,4.4,1,2,3,4};
+    ASSERT_EQ(vec, all);
+
+    std::vector<std::string> vec2;
+    mixed_property.as_vector(vec2);
+    ASSERT_EQ(vec2.size(), 2);
+    ASSERT_EQ(vec2, test_list_str);
+
+}

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -206,7 +206,8 @@ void Bmi_C_Formulation_Test::SetUp() {
                          "                },"
                          "                \"registration_function\": \"" + registration_functions[i] + "\","
                          + variables_line +
-                         "                \"uses_forcing_file\": " + (uses_forcing_file[i] ? "true" : "false") + ""
+                         "                \"uses_forcing_file\": " + (uses_forcing_file[i] ? "true" : "false") + ","
+                         "                \"model_params\": { \"PARAM_VAR_1\": 42, \"PARAM_VAR_2\": 4.2, \"PARAM_VAR_3\": [4, 2]}" +
                          "            },"
                          "            \"forcing\": { \"path\": \"" + forcing_file[i] + "\", \"provider\": \"CsvPerFeature\"}"
                          "        }"

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -267,6 +267,23 @@ TEST_F(Bmi_C_Formulation_Test, GetResponse_0_a) {
     ASSERT_EQ(response, 00);
 }
 
+/** Simple test of initial parameter setting. */
+TEST_F(Bmi_C_Formulation_Test, set_initial_parameters_0_a) {
+    int ex_index = 0;
+
+    Bmi_C_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    int param = get_friend_bmi_model(formulation)->GetValue<int>("PARAM_VAR_1")[0];
+    ASSERT_EQ(param, 42);
+    double param2 = get_friend_bmi_model(formulation)->GetValue<double>("PARAM_VAR_2")[0];
+    ASSERT_EQ(param2, 4.2);
+    std::vector<double> param3 = get_friend_bmi_model(formulation)->GetValue<double>("PARAM_VAR_3");
+    ASSERT_EQ(param3.size(), 2);
+    ASSERT_EQ(param3[0], 4.0);
+    ASSERT_EQ(param3[1], 2.0);
+}
+
 /** Test of get response after several iterations. */
 TEST_F(Bmi_C_Formulation_Test, GetResponse_0_b) {
     int ex_index = 0;


### PR DESCRIPTION
This change allows the ngen framework to read a model parameter key in the realization configuration and, once a BMI model has been initialized, it will use `Set_value` to modify the parameter values of the BMI model to use the ones read from the ngen configuration.

## Additions

- a `model_params` optional key in the configuration input file.
- private `JSONProperty::PropertyVariant` member
- private `JSONProperty::PropertyVistor` struct
- public `JSONProperty::as_vector()` template function
- private helper functions in `BMI_Module_Formulation:`
    - `as_c_array()`
    - `get_values_as_types()`

## Removals

-

## Changes

- Formulations now look for and loop through `model_params` in the passed property tree and attempt to `Set_value` for those parameter variables.

## Testing

1. Tested with `ngen_cal` to support calibration iterations.
2. Unit tests added (and passed) for JSON Property and BMI_C_Formulation

## Screenshots


## Notes

- Requires BMI models to enable `Set_value` for the respective parameter variables.

## Todos

- Optimize the handling of data between JSONProperty and Formulation
- Refactor JSONProperty using newly introduced PropertyVariant

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
