### PR TITLE
Quiet option fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,16 @@ target_include_directories(ngen PUBLIC
 #add_subdirectory("extern/cfe")
 #add_subdirectory("extern/test_bmi_c")
 
+if(QUIET)
+set(UDUNITS_QUIET true)
+set(ET_QUIET true)
+set(NGEN_QUIET true)
+endif()
+
+if(UDUNITS_QUIET)
+add_compile_definitions(UDUNITS_QUIET)
+endif()
+
 add_subdirectory("src/core")
 add_dependencies(core libudunits2)
 add_subdirectory("src/geojson")
@@ -333,16 +343,6 @@ if(PACKAGE_TESTS)
     enable_testing()
     include(GoogleTest)
     add_subdirectory(test)
-endif()
-
-if(QUIET)
-set(UDUNITS_QUIET true)
-set(ET_QUIET true)
-set(NGEN_QUIET true)
-endif()
-
-if(UDUNITS_QUIET)
-add_compile_definitions(UDUNITS_QUIET)
 endif()
 
 #add_library(Hymod ${HYMOD_INCLUDE_DIR}/Hymod.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,14 @@ if(UDUNITS_QUIET)
 add_compile_definitions(UDUNITS_QUIET)
 endif()
 
+if(ET_QUIET)
+add_compile_definitions(ET_QUIET)
+endif()
+
+if(NGEN_QUIET)
+add_compile_definitions(NGEN_QUIET)
+endif()
+
 add_subdirectory("src/core")
 add_dependencies(core libudunits2)
 add_subdirectory("src/geojson")


### PR DESCRIPTION
Fixes #375 by including compile definitions for `ET_QUIET` and `NGEN_QUIET`, as well as ensuring these are set before the various subdirectory builds are added.

## Additions

- Compile definitions in CMakeLists.txt for `ET_QUIET` and `NGEN_QUIET`

## Changes

- Add compiler definitions before calls to `add_subdirectory` in CMakeLists.txt

## Testing

1. Build tested for `QUIET` operations using cmake 3.17.5

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOs
