### PR TITLE
Fix workflow failure from wrong python version

### DIFF
--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -678,7 +678,7 @@ jobs:
       - name: Init Python Dependencies
         if: steps.cache-unix-py3-dependencies.outputs.cache-hit != 'true'
         run: |
-          python -m venv .venv
+          python3 -m venv .venv
           . .venv/bin/activate
           pip install pip
           pip install numpy


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- 
## Removals

-

## Changes

- Ensures `python3` is used to create a venv 

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] macOS
