### PR TITLE
Setting up environment for Evapotranspiration submodule in ngen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,10 @@
 	path = extern/UDUNITS-2
 	url = https://github.com/Unidata/UDUNITS-2.git
 	ignore = dirty
-
 [submodule "extern/bmi-cxx"]
 	path = extern/bmi-cxx
 	url = https://github.com/csdms/bmi-cxx.git
+[submodule "extern/evapotranspiration/evapotranspiration"]
+	path = extern/evapotranspiration/evapotranspiration
+	url = https://github.com/NOAA-OWP/evapotranspiration.git
+        branch = master

--- a/extern/evapotranspiration/README.md
+++ b/extern/evapotranspiration/README.md
@@ -1,0 +1,50 @@
+# PET Submodule
+
+## About
+
+This directory wraps the *pet* Git submodule repo, which contains a clone of the repo for the OWP PET module library that implements BMI.  From here, the shared library file for the PET module can be built for use in NGen.  This is configured with the [CMakeLists.txt](CMakeLists.txt) and other files in this outer directory.
+
+#### Extra Outer Directory
+
+Currently there are two directory layers beneath the top-level *extern/* directory.  This was done so that certain things used by NGen (i.e., a *CMakeLists.txt* file for building shared library files) can be placed alongside, but not within, the submodule.
+
+## Working with the Submodule
+
+Some simple explanations of several command actions are included below.  To better understand what these things are doing, consult the [Git Submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 
+
+### Getting the Latest Changes
+
+There are two steps to getting upstream submodule changes fully 
+  1. fetching and locally checking out the changes from the remote
+  2. committing the new checkout revision for the submodule
+
+To fetch and check out the latest revision (for the [currently used branch](#viewing-the-current-branch)):
+
+    git submodule update --init -- extern/evapotranspiration
+
+To commit the current submodule checkout revision to the NGen repo:
+
+    git add extern/evapotranspiration
+    git commit
+
+### Viewing the Commit Hash
+
+Git submodule configurations include the specific commit to be checked out (or an implicit default).  The current commit can be view with `git submodule status`:
+
+    git submodule status -- extern/evapotranspiration/
+
+This will show the **commit**, **submodule local path**, and the git description for the **commit**.  The specific configuration, including the configured branch, is set in the _.gitmodules_ file in the NGen project root.
+
+### Changing the Commit Branch
+
+The latest commit in the configured branch can be brought in as described here.  If it is ever necessary to change to a different branch, the following will do so:
+
+    git config -f .gitmodules "submodule.extern/evapotranspiration/evapotranspiration.branch" <branchName>
+
+Note that this will be done in the NGen repo configuration, so it can then be committed and push to remotes.  It is also possible to do something similar in just the local clone of a repo, by configuring `.git/config` instead of `.gitmodules`.  See the Git documentation for more on how that works if needed.
+
+# Usage
+
+## Building Libraries
+
+The instructions on how to build the submodule libraries can be found in extern/evapotranspiration/evapotranspiration/INSTALL.md after the submodule has been downloaded.

--- a/extern/evapotranspiration/README.md
+++ b/extern/evapotranspiration/README.md
@@ -2,11 +2,11 @@
 
 ## About
 
-This directory wraps the *pet* Git submodule repo, which contains a clone of the repo for the OWP PET module library that implements BMI.  From here, the shared library file for the PET module can be built for use in NGen.  This is configured with the [CMakeLists.txt](CMakeLists.txt) and other files in this outer directory.
+This directory wraps the *PET* Git submodule repo, which contains a clone of the repo for the OWP PET module library that implements BMI.  From here, the shared library file for the PET module can be built for use in NGen.  This is configured with the [CMakeLists.txt](CMakeLists.txt) and other files in this outer directory.
 
 #### Extra Outer Directory
 
-Currently there are two directory layers beneath the top-level *extern/* directory.  This was done so that certain things used by NGen (i.e., a *CMakeLists.txt* file for building shared library files) can be placed alongside, but not within, the submodule.
+Currently there are two directory layers beneath the top-level *extern/* directory. While this module has its CMakeLists.txt within the submodule, at present this extra directory exists primarily to be consistent with other modules which have their CMakeLists.txt files in the interstitial directory (this may change in the future).
 
 ## Working with the Submodule
 


### PR DESCRIPTION
## Additions

extern/evapotranspiration/evapotranspiration

## Removals

extern/evapotranspiration/CMakeLists.txt
extern/evapotranspiration/petbmi.pc.in

## Changes

.gitsubmodules
README.md

## Testing

1. Clone the submodule
2. Build the libpetbmi shared library


## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [x ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
