### PR TITLE
Added SOURCE_LOC macro

### DIFF
--- a/include/all.h
+++ b/include/all.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef __APPLE__
 #define GCC_VERSION (__GNUC__ * 10000 \
                      + __GNUC_MINOR__ * 100 \
@@ -7,3 +9,8 @@
 #include <unique.hpp>
 #endif
 #endif
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define SOURCE_LOC " (" __FILE__ ":" TOSTRING(__LINE__) ")"
+// ^ Credit https://www.decompile.com/cpp/faq/file_and_line_error_string.htm

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -1,5 +1,6 @@
 #include <udunits2.h>
 #include <mutex>
+#include "all.h"
 
 #ifndef NGEN_UNITSHELPER_H
 #define NGEN_UNITSHELPER_H
@@ -23,7 +24,7 @@ class UnitsHelper {
         #endif
         if (unit_system == NULL) 
         {
-            throw std::runtime_error("Unable to create UDUNITS2 Unit System.");
+            throw std::runtime_error("Unable to create UDUNITS2 Unit System." SOURCE_LOC);
         }
         #ifndef UDUNITS_QUIET
         ut_set_error_message_handler(ut_ignore);

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -17,7 +17,7 @@
 #include "AorcForcing.hpp"
 #include "ForcingProvider.hpp"
 #include <exception>
-
+#include "all.h"
 // Recognized Forcing Value Names (in particular for use when configuring BMI input variables)
 // TODO: perhaps create way to configure a mapping of these to something different
 #define AORC_FIELD_NAME_PRECIP_RATE "precip_rate"
@@ -655,12 +655,12 @@ class Forcing : public forcing::ForcingProvider
             if( header.size() != 10 ){
                     throw std::runtime_error("Error: Forcing data " + file_name +
                     " does not have the expected number of columns.  Did you mean to use "+
-                    "csvPerFeature forcing provider instead?");
+                    "csvPerFeature forcing provider instead?" SOURCE_LOC);
                 }
         }
         else {
             throw std::runtime_error("Error: Forcing data " + file_name +
-                    " does not have readable rows.");
+                    " does not have readable rows." SOURCE_LOC);
         }
 
         //Iterate through CSV starting on the second row

--- a/src/core/mediator/CMakeLists.txt
+++ b/src/core/mediator/CMakeLists.txt
@@ -10,6 +10,7 @@ if(UDUNITS_ACTIVE)
 endif()
 
 target_include_directories(core_mediator PUBLIC
+        ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/core
         ${PROJECT_SOURCE_DIR}/include/core/mediator
         )

--- a/test/forcing/Forcing_Test.cpp
+++ b/test/forcing/Forcing_Test.cpp
@@ -116,7 +116,7 @@ TEST_F(ForcingTest2, TestForcingDataLoad){
    forcing_params forcing_p(forcing_file_name, "", "2015-12-14 21:00:00", "2015-12-30 23:00:00");
 
    EXPECT_THROW(std::make_shared<Forcing>(forcing_p);, std::runtime_error);
-
+   //try {std::make_shared<Forcing>(forcing_p);} catch (std::runtime_error e){ cerr<<e.what()<<std::endl; }
 }
 /*Original Forcing Object Test
 //Test Forcing object


### PR DESCRIPTION
Adds an easy way to improve exception messages (or other logging output)

## Additions

Added a `SOURCE_LOC` macro in `all.h` that can be used to easily (and sustainably) report the location in code from which an exception was thrown or a log message was written.

Also adds some examples of use

## Removals

-

## Changes

-

## Testing

1. Added to a Forcing object test, the actual string returned is not tested because this could easily change with unrelated modifications to Forcing.h, so would be a bad test. A commented-out `cerr` write is present that can be used to check the result.

## Screenshots

```
[----------] 1 test from ForcingTest2
[ RUN      ] ForcingTest2.TestForcingDataLoad
Error: Forcing data ../../test/data/forcing/cat-27115-nwm-aorc-variant-derived-format.csv does not have the expected number of columns.  Did you mean to use csvPerFeature forcing provider instead? (/home/mattw-nws/ngen/include/forcing/Forcing.h:658)
[       OK ] ForcingTest2.TestForcingDataLoad (53618 ms)
```

## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
