### PR TITLE
require c99 standard compiler to build cfe and topmodel libs

### DIFF
--- a/extern/cfe/CMakeLists.txt
+++ b/extern/cfe/CMakeLists.txt
@@ -24,6 +24,9 @@ set_target_properties(cfebmi PROPERTIES VERSION ${PROJECT_VERSION})
 
 set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER cfe/bmi_cfe.h)
 
+# Code requires minimum of C99 standard to compile
+set_target_properties(cfebmi PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)
+
 include(GNUInstallDirs)
 
 install(TARGETS cfebmi

--- a/extern/topmodel/CMakeLists.txt
+++ b/extern/topmodel/CMakeLists.txt
@@ -23,6 +23,9 @@ set_target_properties(topmodelbmi PROPERTIES VERSION ${PROJECT_VERSION})
 
 set_target_properties(topmodelbmi PROPERTIES PUBLIC_HEADER topmodel/include/bmi_topmodel.h)
 
+# Code requires minimum of C99 standard to compile
+set_target_properties(topmodelbmi PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)
+
 include(GNUInstallDirs)
 
 install(TARGETS topmodelbmi


### PR DESCRIPTION
Invalid syntax causes build errors for compilers <c99. 
```
for( int i = 0; i < INPUT_VAR_NAME_COUNT; i++){

}
```
See initial conversion in submodule [evapotranspiration](https://github.com/NOAA-OWP/evapotranspiration/pull/11).

## Additions

- Make C99 standard required for building external topmodel and cfe libraries.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
