### PR TITLE
Fix 393

### DIFF
--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -438,6 +438,8 @@ namespace realization {
             return get_bmi_model()->GetOutputVarNames();
         }
 
+    protected:
+
         /**
          * @brief Get correct BMI variable name, which may be the output or something mapped to this output.
          * 
@@ -468,8 +470,6 @@ namespace realization {
                 //else not an output variable
             }
         }
-
-    protected:
 
         /**
          * @brief Check for implementation of internal calculators/data for a given requsted output_name

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -374,7 +374,7 @@ namespace realization {
 
             // check if output is available from BMI
             std::string bmi_var_name;
-            get_bmi_var_name(output_name, bmi_var_name);
+            get_bmi_output_var_name(output_name, bmi_var_name);
             
             if( !bmi_var_name.empty() )
             {
@@ -444,19 +444,28 @@ namespace realization {
          * @param name 
          * @param bmi_var_name 
          */
-        inline void get_bmi_var_name(const std::string &name, std::string &bmi_var_name)
+        inline void get_bmi_output_var_name(const std::string &name, std::string &bmi_var_name)
         {
+            //check standard output names first
             std::vector<std::string> output_names = get_bmi_model()->GetOutputVarNames();
             if (std::find(output_names.begin(), output_names.end(), name) != output_names.end()) {
                 bmi_var_name = name;
             }
-            else {
+            else
+            {
+                //check mapped names
+                std::string mapped_name;
                 for (auto & iter : bmi_var_names_map) {
                     if (iter.second == name) {
-                        bmi_var_name = iter.first;
+                        mapped_name = iter.first;
                         break;
                     }
                 }
+                //ensure mapped name maps to an output variable, see GH #393 =)
+                if (std::find(output_names.begin(), output_names.end(), mapped_name) != output_names.end()){
+                    bmi_var_name = mapped_name;
+                }
+                //else not an output variable
             }
         }
 

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -307,7 +307,7 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_0_a) {
 
     formulation.get_response(0, 3600);
     std::string output = formulation.get_output_line_for_timestep(0, ",");
-    EXPECT_THAT(output, MatchesRegex("-?0.000000,-?0.000000"));
+    EXPECT_THAT(output, MatchesRegex("0.000000,0.000000"));
 }
 
 /** Simple test of output with modified variables. */
@@ -323,7 +323,7 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_1_a) {
     // OUTPUT_VAR_1 first.
     formulation.get_response(0, 3600);
     std::string output = formulation.get_output_line_for_timestep(0, ",");
-    EXPECT_THAT(output, MatchesRegex("-?0.000000,-?0.000000"));
+    EXPECT_THAT(output, MatchesRegex("0.000000,0.000000"));
 }
 
 /** Simple test of output with modified variables, picking time step when there was non-zero rain rate. */
@@ -338,7 +338,7 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_1_b) {
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
     std::string output = formulation.get_output_line_for_timestep(i, ",");
-    EXPECT_THAT(output, MatchesRegex("-?0.000000,0.000001"));
+    EXPECT_THAT(output, MatchesRegex("0.000000,0.000001"));
 }
 
 TEST_F(Bmi_C_Formulation_Test, determine_model_time_offset_0_a) {


### PR DESCRIPTION
Fixes #393
Fixes #392 

## Changes

- Rename `get_bmi_var_name` to `get_bmi_output_var_name` and make it a protected function
- validate name map lookup resolves to an output variable
- Removed the -0.0 allowance in C formulation unit test

## Testing

1. Tested with unit tests and local runs using example realizations, but with standalone CFE and CFE+PET multi-bmi

## Notes

- I had worked up a more generic `get_bmi_alias` function that validates names/alias by type (output, input, any).  But I'm not sure if it is needed here or not...

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
