### PR TITLE
GCC 11 fixes

### DIFF
--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cstring>
 #include <math.h>
+#include <stdexcept>
 
 std::string TestBmiCpp::GetComponentName(){
   return "Testing BMI C++ Model";

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <algorithm>
 #include "WrappedForcingProvider.hpp"
 
 using namespace std;

--- a/models/tshirt/include/Tshirt.h
+++ b/models/tshirt/include/Tshirt.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 #include <memory>
+#include <limits>
 
 namespace tshirt {
 

--- a/models/tshirt/include/tshirt_params.h
+++ b/models/tshirt/include/tshirt_params.h
@@ -1,6 +1,8 @@
 #ifndef NGEN_TSHIRT_PARAMS_H
 #define NGEN_TSHIRT_PARAMS_H
 
+#include <limits>
+
 namespace tshirt {
 
     /**
@@ -78,7 +80,7 @@ namespace tshirt {
                 max_groundwater_storage_meters(max_gw_storage) {
             this->max_soil_storage_meters = this->depth * maxsmc;
             this->Cschaake = refkdt * satdk / (2.0e-6);
-            this->max_lateral_flow = numeric_limits<double>::max();//satdk * multiplier * this->max_soil_storage_meters;
+            this->max_lateral_flow = std::numeric_limits<double>::max();//satdk * multiplier * this->max_soil_storage_meters;
         }
 
     };


### PR DESCRIPTION
GCC changes certain assumptions in version 11 that causes compilation failures. This addresses all I could find. Notably, GCC 11 is what's currently the default in Homebrew (Mac and Linux).

## Additions

- Added `#include <limits>` and `#include <stdexcept>` explicitly where needed

## Removals

- None

## Changes

- Upped GoogleTest from tag for v1.10.0 to v1.11.0

## Testing

1. Compiled and ran all tests (except MPI/parallel tests) in a GCC 11 stack

## Screenshots


## Notes

- None

## Todos

- Possible some issues still exist in parallel code, but this was harder to test in my test environment

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. All non-parallel tests run with success, including all BMI language tests. Parallel tests not yet run. All passed except for routing, which probably isn't passing anywhere right now.

### Target Environment support

- [X] Linux
