### PR TITLE
disable waterbody execution in pybind/troute test

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -68,3 +68,71 @@ jobs:
 
     - name: Run surfacebmi plus cfebmi
       run: ./cmake_build/ngen data/catchment_data.geojson "cat-27" data/nexus_data.geojson "nex-26" data/example_bmi_multi_realization_config.json
+
+# Run t-route/pybind integration test
+  test_troute_integration:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      
+    - name: Init Submodules
+      run: git submodule update --init --recursive
+
+    - name: Cache Boost Dependency
+      id: cache-boost-dep
+      uses: actions/cache@v1
+      with:
+        path: boost_1_72_0
+        key: unix-boost-dep
+
+    - name: Get Boost Dependency
+      if: steps.cache-boost-dep.outputs.cache-hit != 'true'
+      run: |
+        curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+        tar xjf boost_1_72_0.tar.bz2
+
+    - name: Get netcdff library
+      run: |
+        sudo apt-get install -y libnetcdf-dev libnetcdff-dev
+
+    - name: Cache troute dependency
+      id: cache-linux-troute-dep
+      uses: actions/cache@v1
+      with:
+        path: .venv
+        key: linux-troute-dep
+
+    - name: Build T-route Dependency
+      if: steps.cache-linux-troute-dep.outputs.cache-hit != 'true'
+      run: |
+        python -m venv .venv
+        . .venv/bin/activate
+        cd extern/t-route
+        pip install pip
+        pip install -r requirements.txt
+        cd src
+        pip install -e nwm_routing
+        pip install -e ngen_routing
+        cd python_routing_v02
+        FC=gfortran ./compiler.sh
+        deactivate
+
+    - name: cmake_init_build
+      run: |
+        export BOOST_ROOT="$(pwd)/boost_1_72_0"
+        [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
+        cmake -B cmake_build -DNGEN_ACTIVATE_ROUTING:BOOL=on -S .
+
+    - name: Build test
+      run: cmake --build cmake_build --target test_routing_pybind -- -j ${{ env.LINUX_NUM_PROC_CORES }}
+      timeout-minutes: 15
+
+    - name: Run test
+      run: |
+        . .venv/bin/activate
+        ./cmake_build/test/test_routing_pybind
+        deactivate

--- a/test/data/routing/ngen_routing_config_unit_test.yaml
+++ b/test/data/routing/ngen_routing_config_unit_test.yaml
@@ -83,53 +83,53 @@ supernetwork_parameters:
     layer_string: 0
 
 #waterbody parameters and assignments from lake parm file
-waterbody_parameters:
-    level_pool:
-        #WRF-Hydro lake parm file
-        level_pool_waterbody_parameter_file_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/primary_domain/DOMAIN/LAKEPARM.nc"
-        level_pool_waterbody_id: lake_id
-        level_pool_waterbody_area: LkArea
-        level_pool_weir_elevation: WeirE
-        level_pool_waterbody_max_elevation: LkMxE
-        level_pool_outfall_weir_coefficient: WeirC
-        level_pool_outfall_weir_length: WeirL
-        level_pool_overall_dam_length: DamL
-        level_pool_orifice_elevation: OrificeE
-        level_pool_orifice_coefficient: OrificeC
-        level_pool_orifice_area: OrificeA
+# waterbody_parameters:
+#     level_pool:
+#         #WRF-Hydro lake parm file
+#         level_pool_waterbody_parameter_file_path: "./test/data/routing/waterbody-params.json"
+#         level_pool_waterbody_id: lake_id
+#         level_pool_waterbody_area: LkArea
+#         level_pool_weir_elevation: WeirE
+#         level_pool_waterbody_max_elevation: LkMxE
+#         level_pool_outfall_weir_coefficient: WeirC
+#         level_pool_outfall_weir_length: WeirL
+#         level_pool_overall_dam_length: DamL
+#         level_pool_orifice_elevation: OrificeE
+#         level_pool_orifice_coefficient: OrificeC
+#         level_pool_orifice_area: OrificeA
 
-    hybrid_and_rfc:
-        # Specify the reservoir parameter file
-        reservoir_parameter_file: ""
+#     hybrid_and_rfc:
+#         # Specify the reservoir parameter file
+#         reservoir_parameter_file: ""
 
-        # If using USGS persistence reservoirs, set to True. (default=.FALSE.)
-        reservoir_persistence_usgs: False
+#         # If using USGS persistence reservoirs, set to True. (default=.FALSE.)
+#         reservoir_persistence_usgs: False
 
-        # Specify the path to the timeslice files to be used by USGS reservoirs
-        reservoir_usgs_timeslice_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/observations/"
+#         # Specify the path to the timeslice files to be used by USGS reservoirs
+#         reservoir_usgs_timeslice_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/observations/"
 
-        # If using USACE persistence reservoirs, set to True. (default=.FALSE.)
-        reservoir_persistence_usace: False
+#         # If using USACE persistence reservoirs, set to True. (default=.FALSE.)
+#         reservoir_persistence_usace: False
 
-        # Specify the path to the timeslice files to be used by USACE reservoirs
-        reservoir_usace_timeslice_path: ""
+#         # Specify the path to the timeslice files to be used by USACE reservoirs
+#         reservoir_usace_timeslice_path: ""
 
-        # Specify lookback hours to read reservoir observation data
-        reservoir_observation_lookback_hours: 48
+#         # Specify lookback hours to read reservoir observation data
+#         reservoir_observation_lookback_hours: 48
 
-        # Specify update time interval in seconds to read new reservoir observation data
-        # The default is 86400 (seconds per day). Set to 3600 for standard and extended AnA simulations.
-        # Set to 1000000000 for short range and medium range forecasts.
-        reservoir_observation_update_time_interval_seconds: 1000000000
+#         # Specify update time interval in seconds to read new reservoir observation data
+#         # The default is 86400 (seconds per day). Set to 3600 for standard and extended AnA simulations.
+#         # Set to 1000000000 for short range and medium range forecasts.
+#         reservoir_observation_update_time_interval_seconds: 1000000000
         
-        # If using RFC forecast reservoirs, set to True. (default=.FALSE.)
-        reservoir_rfc_forecasts: False
+#         # If using RFC forecast reservoirs, set to True. (default=.FALSE.)
+#         reservoir_rfc_forecasts: False
 
-        # Specify the path to the RFC time series files to be used by reservoirs
-        reservoir_rfc_forecasts_time_series_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/observations/"
+#         # Specify the path to the RFC time series files to be used by reservoirs
+#         reservoir_rfc_forecasts_time_series_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Croton_NY_TEST1/observations/"
 
-        # Specify lookback hours to read reservoir RFC forecasts
-        reservoir_rfc_forecasts_lookback_hours: 48
+#         # Specify lookback hours to read reservoir RFC forecasts
+#         reservoir_rfc_forecasts_lookback_hours: 48
 
 #WRF-Hydro output file
 forcing_parameters:


### PR DESCRIPTION
The t-route waterbody input structure has changed enough that the test input file doesn't conform to the required inputs.  Until the inputs can be fixed, simply disabling the waterbody execution portion of the t-route run will allow the test to still execute a simple routing test via the pybind interface in ngen.

Also added a runner to test the routing adapter integration with the ngen framework.

## Changes

- disable waterbody execution in t-route configuration for pybind/troute test

## Testing

1.  Using the correct t-route submodule (#399) should allow the test to pass with this config change.

## Todos

- Fix the watebody-params.json to conform to latest waterbody/lake definition (and probably create a lakes.json) sorry @mikejohnson51 😄 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
