### PR TITLE
Fix a build error when Python is turned off

### DIFF
--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -665,7 +665,9 @@ TEST_F(Bmi_Multi_Formulation_Test, GetResponse_3_b) {
         double response, mod_0_input_1, mod_1_output_2;
         for (int i = 0; i < 39; i++) {
             // Note that we need to get this before the "current" get_response ...
+#if ACTIVATE_PYTHON
             mod_1_output_2 = get_friend_nested_var_value<Bmi_Py_Formulation>(formulation, 1, "OUTPUT_VAR_2");
+#endif
             response = formulation.get_response(i, 3600);
             // But we need to get this after the "current" get_response ...
             mod_0_input_1 = get_friend_nested_var_value<Bmi_Fortran_Formulation>(formulation, 0, "INPUT_VAR_1");


### PR DESCRIPTION
Fixed issue 403. Build successfully. Bmi_Py_Formulation should not be used when python is off.

## Additions

-

## Removals

-

## Changes

test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp

## Testing

Passed all unit tests.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
