### PR TITLE
Bmi array support

### DIFF
--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -287,6 +287,18 @@ jobs:
           mod-dir: "extern/test_bmi_c/"
           targets: "testbmicmodel"
 
+      #make sure cxx bmi is initialized/ready
+      - uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/bmi-cxx/"
+
+      - name: Build Submodules
+        id: submod_build_4
+        uses: ./.github/actions/ngen-submod-build
+        with:
+          mod-dir: "extern/test_bmi_cpp/"
+          targets: "testbmicppmodel"
+
       - name: Build Unit Tests
         uses: ./.github/actions/ngen-build
         with:
@@ -314,6 +326,10 @@ jobs:
       - uses: ./.github/actions/clean-build
         with:
           build-dir: ${{ steps.submod_build_3.outputs.build-dir }}
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_4.outputs.build-dir }}
+
 
   # TODO: fails due to compilation error, at least in large part due to use of POSIX functions not supported on Windows.
   # TODO: Need to determine whether Windows support (in particular, development environment support) is necessary.

--- a/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
+++ b/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <map>
 #include "bmi.hxx"
+#include <numeric>
+#include <iostream>
 
 #define TRUE 1
 #define FALSE 0
@@ -33,8 +35,11 @@ class TestBmiCpp : public bmi::Bmi {
         *
         * @return Pointer to the newly created @ref test_bmi_c_model struct instance in memory.
         */
-        TestBmiCpp(){};
-
+        TestBmiCpp(bool input_array = false, bool output_array = false):
+            use_input_array(input_array), use_output_array(output_array)
+        {
+            set_usage(input_array, output_array);
+        };
 
         virtual void Initialize(std::string config_file);
         virtual void Update();
@@ -96,9 +101,43 @@ class TestBmiCpp : public bmi::Bmi {
 
 
     private:
-        static const int input_var_name_count = INPUT_VAR_NAME_COUNT;
-        static const int output_var_name_count = OUTPUT_VAR_NAME_COUNT;
 
+        inline void set_usage(bool input_array = false, bool output_array = false){
+            use_input_array = input_array;
+            use_output_array = output_array;
+            //NOTE use the correct array constructor here or things get weird
+            //make_unique<double>(3) will give a unique pointer to a single double initialized to 3
+            //make_unique<double[]>(3) will give a unique pointer to an array of 3 doubles, default initialized
+            if( use_input_array ){ //Add input_var_3 array to required inputs
+                this->input_var_3 = std::make_unique<double[]>(3);
+                this->input_var_3.get()[0] = 0;
+                this->input_var_3.get()[1] = 0;
+                this->input_var_3.get()[2] = 0;
+                std::cout<<"USING INPUT ARRAY\n";
+                input_var_names.push_back("INPUT_VAR_3");
+                input_var_types.push_back("double");
+                input_var_units.push_back("mm");
+                input_var_locations.push_back("node");
+                input_var_item_count.push_back(3); //an array of 3 values
+                input_var_grids.push_back(1);
+            }
+            if( use_output_array ){ //Add output_var_3 array to required outputs
+                this->output_var_3 = std::make_unique<double[]>(3);
+                this->output_var_3.get()[0] = 0;
+                this->output_var_3.get()[1] = 0;
+                this->output_var_3.get()[2] = 0;
+                std::cout<<"USING OUTPUT ARRAY\n";
+                output_var_names.push_back("OUTPUT_VAR_3");
+                output_var_types.push_back("double");
+                output_var_units.push_back("m");
+                output_var_locations.push_back("node");
+                output_var_item_count.push_back(3); //an array of 3 values
+                output_var_grids.push_back(1);
+            }
+        }
+        //flags for conditional use of input/output var 3
+        bool use_input_array, use_output_array;
+   
         std::vector<std::string> input_var_names = { "INPUT_VAR_1", "INPUT_VAR_2" };
         std::vector<std::string> output_var_names = { "OUTPUT_VAR_1", "OUTPUT_VAR_2" };
         std::vector<std::string> input_var_types = { "double", "double" };
@@ -108,11 +147,11 @@ class TestBmiCpp : public bmi::Bmi {
         std::vector<std::string> input_var_locations = { "node", "node" };
         std::vector<std::string> output_var_locations = { "node", "node" };
 
-        int input_var_item_count[INPUT_VAR_NAME_COUNT] = { 1, 1 };
-        int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = { 1, 1 };
-        int input_var_grids[INPUT_VAR_NAME_COUNT] = { 1, 1 };
-        int output_var_grids[OUTPUT_VAR_NAME_COUNT] = { 1, 1 };
-
+        std::vector<int> input_var_item_count = { 1, 1 };
+        std::vector<int> output_var_item_count = { 1, 1 };
+        std::vector<int> input_var_grids = { 1, 1 };
+        std::vector<int> output_var_grids = { 1, 1 };
+        
         std::map<std::string,int> type_sizes = {
             {BMI_TYPE_NAME_DOUBLE, sizeof(double)},
             {BMI_TYPE_NAME_FLOAT, sizeof(float)},
@@ -139,6 +178,10 @@ class TestBmiCpp : public bmi::Bmi {
         std::unique_ptr<double> input_var_2 = nullptr;
         std::unique_ptr<double> output_var_1 = nullptr;
         std::unique_ptr<double> output_var_2 = nullptr;
+
+        //Variables for testing array in/out
+        std::unique_ptr<double[]> input_var_3 = nullptr;
+        std::unique_ptr<double[]> output_var_3 = nullptr;
 
         /**
         * Read the BMI initialization config file and use its contents to set the state of the model.

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -11,7 +11,7 @@ class UnitsHelper {
 
     static double get_converted_value(const std::string &in_units, const double &value, const std::string &out_units);
 
-    static double* get_converted_values(const std::string &in_units, double* values, const std::string &out_units, const size_t & count);
+    static double* convert_values(const std::string &in_units, double* values, const std::string &out_units, double* out_values, const size_t & count);
 
     private:
     static cv_converter* get_converter(const std::string &in_units, const std::string& out_units, ut_unit*& to, ut_unit*& from);

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -11,6 +11,8 @@ class UnitsHelper {
 
     static double get_converted_value(const std::string &in_units, const double &value, const std::string &out_units);
 
+    static double* get_converted_values(const std::string &in_units, double* values, const std::string &out_units, const size_t & count);
+
     private:
     static cv_converter* get_converter(const std::string &in_units, const std::string& out_units, ut_unit*& to, ut_unit*& from);
     // Theoretically thread-safe. //TODO: Test?

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -9,10 +9,10 @@ class UnitsHelper {
 
     public:
 
-    static double get_converted_value(const std::string &in_units, double value, const std::string &out_units);
+    static double get_converted_value(const std::string &in_units, const double &value, const std::string &out_units);
 
     private:
-
+    static cv_converter* get_converter(const std::string &in_units, const std::string& out_units, ut_unit*& to, ut_unit*& from);
     // Theoretically thread-safe. //TODO: Test?
     static ut_system* unit_system;
     static std::once_flag unit_system_inited;

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -170,6 +170,12 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         }
     }
 
+    virtual std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
+    {
+        return std::vector<double>(1, get_value(selector, m));
+    }
+
+
     /**
      * Get whether a param's value is an aggregate sum over the entire time step.
      *

--- a/include/forcing/DataProvider.hpp
+++ b/include/forcing/DataProvider.hpp
@@ -68,6 +68,23 @@ namespace data_access
          */
         virtual data_type get_value(const selection_type& selector, ReSampleMethod m=SUM) = 0;
 
+        /**
+         * Get the values of a forcing property for an arbitrary time period, converting units if needed.
+         *
+         * An @ref std::out_of_range exception should be thrown if the data for the time period is not available.
+         * 
+         * If a provider doesn't implement this function, then by default, get_values will be a simple proxy to @ref get_value
+         * with the result wrapped in a std::vector<double>
+         * 
+         * @param output_name The name of the forcing property of interest.
+         * @param init_time_epoch The epoch time (in seconds) of the start of the time period.
+         * @param duration_seconds The length of the time period, in seconds.
+         * @param output_units The expected units of the desired output value.
+         * @return std::vector<double> The vector of values of the forcing property for the described time period, with units converted if needed.
+         * @throws std::out_of_range If data for the time period is not available.
+         */
+        virtual std::vector<data_type> get_values(const selection_type& selector, ReSampleMethod m=SUM) = 0;
+
         virtual bool is_property_sum_over_time_step(const std::string& name) {return false; }
 
         private:

--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -300,6 +300,11 @@ class Forcing : public data_access::GenericDataProvider
         return value;
     }
 
+    virtual std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
+    {
+        return std::vector<double>(1, get_value(selector, m));
+    }
+
     /**
      * Get the current value of a forcing param identified by its name.
      *

--- a/include/forcing/ForcingProvider.hpp
+++ b/include/forcing/ForcingProvider.hpp
@@ -68,6 +68,26 @@ namespace forcing {
                                  const std::string &output_units) = 0;
 
         /**
+         * Get the values of a forcing property for an arbitrary time period, converting units if needed.
+         *
+         * An @ref std::out_of_range exception should be thrown if the data for the time period is not available.
+         * 
+         * If a provider doesn't implement this function, then by default, get_values will be a simple proxy to @ref get_value
+         * with the result wrapped in a std::vector<double>
+         * 
+         * @param output_name The name of the forcing property of interest.
+         * @param init_time_epoch The epoch time (in seconds) of the start of the time period.
+         * @param duration_seconds The length of the time period, in seconds.
+         * @param output_units The expected units of the desired output value.
+         * @return std::vector<double> The vector of values of the forcing property for the described time period, with units converted if needed.
+         * @throws std::out_of_range If data for the time period is not available.
+         */
+        virtual std::vector<double> get_values(const std::string &output_name, const time_t &init_time, const long &duration_s,
+                                 const std::string &output_units){
+            return std::vector<double>(1, get_value(output_name, init_time, duration_s, output_units));
+        };
+
+        /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.
          *
          * Certain properties, like rain fall, are aggregated sums over an entire time step.  Others, such as pressure,

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -383,6 +383,12 @@ namespace data_access
             return rvalue;
         }
 
+        virtual std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
+        {
+            return std::vector<double>(1, get_value(selector, m));
+        }
+
+
         private:
 
         std::vector<std::string> variable_names;

--- a/include/forcing/WrappedForcingProvider.hpp
+++ b/include/forcing/WrappedForcingProvider.hpp
@@ -132,6 +132,11 @@ namespace data_access {
             return wrapped_provider->get_value(selector, m);
         }
 
+        std::vector<double> get_values(const CatchmentAggrDataSelector& selector, ReSampleMethod m) override
+        {
+            return wrapped_provider->get_values(selector, m);
+        }
+
         /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.
          *

--- a/include/realizations/catchment/Bmi_C_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_C_Adapter.hpp
@@ -216,6 +216,7 @@ namespace models {
              * @see get_value
              */
             template <typename T>
+            [[deprecated("Functionality moved to models::bmi::GetValues in bmi_utilities.hpp")]]
             std::vector<T> GetValue(const std::string& name) {
                 std::string type = GetVarType(name);
                 int total_mem = GetVarNbytes(name);

--- a/include/realizations/catchment/Bmi_Cpp_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Cpp_Adapter.hpp
@@ -219,6 +219,7 @@ namespace models {
             }
 
             template <typename T>
+            [[deprecated("Functionality moved to models::bmi::GetValues in bmi_utilities.hpp")]]
             std::vector<T> GetValue(const std::string& name) {
                 std::string type = GetVarType(name);
                 int total_mem = GetVarNbytes(name);

--- a/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
@@ -173,6 +173,7 @@ namespace models {
              * @see get_value
              */
             template <typename T>
+            [[deprecated("Functionality moved to models::bmi::GetValues in bmi_utilities.hpp")]]
             std::vector<T> GetValue(const std::string& name) {
                 std::string type = inner_get_var_type(name);
                 int total_mem = GetVarNbytes(name);

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -421,7 +421,7 @@ namespace realization {
                 // Convert units
                 std::string native_units = get_bmi_model()->GetVarUnits(bmi_var_name);
                 try {
-                    UnitsHelper::get_converted_values(native_units, values.data(), output_units, values.size());
+                    UnitsHelper::convert_values(native_units, values.data(), output_units, values.data(), values.size());
                     return values;
                 }
                 catch (const std::runtime_error& e){

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1117,8 +1117,8 @@ namespace realization {
                                                                            varItemSize);
                 if (varItemSize != get_bmi_model()->GetVarNbytes(var_name)) {
                     //more than a single value needed for var_name
-                    auto values = provider->get_values(var_map_alias, model_epoch_time, t_delta,
-                                                   get_bmi_model()->GetVarUnits(var_name));
+                    auto values = provider->get_values(CatchmentAggrDataSelector("",var_map_alias, model_epoch_time, t_delta,
+                                                   get_bmi_model()->GetVarUnits(var_name)));
                     //need to marshal data types to the reciever as well
                     //this could be done a little more elegantly if the provider interface were
                     //"type aware", but for now, this will do (but requires yet another copy)
@@ -1126,8 +1126,8 @@ namespace realization {
 
                 } else {
                     //scalar value
-                    double value = provider->get_value(var_map_alias, model_epoch_time, t_delta,
-                                                    get_bmi_model()->GetVarUnits(var_name));
+                    double value = provider->get_value(CatchmentAggrDataSelector("",var_map_alias, model_epoch_time, t_delta,
+                                                   get_bmi_model()->GetVarUnits(var_name)));
                     value_ptr = get_value_as_type(type, value);      
                 }
                 get_bmi_model()->SetValue(var_name, value_ptr.get());

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -23,6 +23,7 @@ class Bmi_Multi_Formulation_Test;
 class Bmi_C_Formulation_Test;
 class Bmi_Cpp_Formulation_Test;
 class Bmi_C_Cfe_IT;
+class Bmi_Cpp_Multi_Array_Test;
 
 namespace realization {
 
@@ -1133,6 +1134,7 @@ namespace realization {
         friend class ::Bmi_C_Formulation_Test;
         friend class ::Bmi_Multi_Formulation_Test;
         friend class ::Bmi_Cpp_Formulation_Test;
+        friend class ::Bmi_Cpp_Multi_Array_Test;
 
     private:
         /**

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -429,7 +429,7 @@ namespace realization {
                 }
             }
             //Fall back to any internal providers as a last resort.
-            return check_internal_providers<double>(output_name);
+            return check_internal_providers<double>(output_name)[0];
         }
 
         bool is_bmi_input_variable(const std::string &var_name) override {
@@ -517,11 +517,11 @@ namespace realization {
          * @throws std::runtime_error If no known value or function for @p output_name
          */
         template <typename T>
-        inline T check_internal_providers(std::string output_name){
+        std::vector<T> check_internal_providers(std::string output_name){
             // Only use the internal et_calc() if this formulation (or possibly multi-formulation)
             // does not know how to supply potential et
             if (output_name == NGEN_STD_NAME_POTENTIAL_ET_FOR_TIME_STEP || output_name == CSDMS_STD_NAME_POTENTIAL_ET) {
-                return calc_et();
+                return std::vector<T>( 1, calc_et() );
             }
             //Note, when called via get_value, this is unlikely to throw since a pre-check on available names is done
             //in that function.

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -9,7 +9,7 @@
 #include "WrappedForcingProvider.hpp"
 #include "Bmi_C_Adapter.hpp"
 #include <AorcForcing.hpp>
-#include <ForcingProvider.hpp>
+#include <DataProvider.hpp>
 #include <UnitsHelper.hpp>
 #include "bmi_utilities.hpp"
 
@@ -384,8 +384,13 @@ namespace realization {
          * @throws std::out_of_range If data for the time period is not available.
          * @throws std::runtime_error output_name is not one of the available outputs of this provider instance.
          */
-        std::vector<double> get_values(const std::string &output_name, const time_t &init_time, const long &duration_s,
-                                 const std::string &output_units) override{
+        std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m=SUM) override
+        {
+            std::string output_name = selector.get_variable_name();
+            time_t init_time = selector.get_init_time();
+            long duration_s = selector.get_duration_secs();
+            std::string output_units = selector.get_output_units();
+
             // First make sure this is an available output
             const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1106,16 +1106,25 @@ namespace realization {
                 //  this type of behavior
                 // TODO: account for arrays later
                 int varItemSize = get_bmi_model()->GetVarItemsize(var_name);
-                if (varItemSize != get_bmi_model()->GetVarNbytes(var_name)) {
-                    throw std::runtime_error(
-                            "BMI input variable '" + var_name + "' is an array - not currently supported");
-                }
-                double value = provider->get_value(CatchmentAggrDataSelector("",var_map_alias, model_epoch_time, t_delta,
-                                                   get_bmi_model()->GetVarUnits(var_name)));
+                std::shared_ptr<void> value_ptr;
                 // Finally, use the value obtained to set the model input
                 std::string type = get_bmi_model()->get_analogous_cxx_type(get_bmi_model()->GetVarType(var_name),
                                                                            varItemSize);
-                std::shared_ptr<void> value_ptr = get_value_as_type(type, value);
+                if (varItemSize != get_bmi_model()->GetVarNbytes(var_name)) {
+                    //more than a single value needed for var_name
+                    auto values = provider->get_values(var_map_alias, model_epoch_time, t_delta,
+                                                   get_bmi_model()->GetVarUnits(var_name));
+                    //need to marshal data types to the reciever as well
+                    //this could be done a little more elegantly if the provider interface were
+                    //"type aware", but for now, this will do (but requires yet another copy)
+                    value_ptr = get_values_as_type( type, values.begin(), values.end() );
+
+                } else {
+                    //scalar value
+                    double value = provider->get_value(var_map_alias, model_epoch_time, t_delta,
+                                                    get_bmi_model()->GetVarUnits(var_name));
+                    value_ptr = get_value_as_type(type, value);      
+                }
                 get_bmi_model()->SetValue(var_name, value_ptr.get());
             }
         }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -17,6 +17,7 @@
 using namespace std;
 
 class Bmi_Multi_Formulation_Test;
+class Bmi_Cpp_Multi_Array_Test;
 
 namespace realization {
 
@@ -844,6 +845,7 @@ namespace realization {
         int primary_module_index = -1;
 
         friend Bmi_Multi_Formulation_Test;
+        friend class ::Bmi_Cpp_Multi_Array_Test;
 
     };
 }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -484,9 +484,22 @@ namespace realization {
             
             // If not found ...
             if (availableData.empty() || availableData.find(output_name) == availableData.end()) {
-                throw runtime_error(get_formulation_type() + " cannot get output value for unknown " + output_name);
+                throw runtime_error(get_formulation_type() + " cannot get output value for unknown " + output_name + SOURCE_LOC);
             }
             return availableData[output_name]->get_value(CatchmentAggrDataSelector("",output_name, init_time, duration_s, output_units), m);
+        }
+
+        std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
+        {
+            std::string output_name = selector.get_variable_name();
+            time_t init_time = selector.get_init_time();
+            long duration_s = selector.get_duration_secs();
+            std::string output_units = selector.get_output_units();
+
+            if (availableData.empty() || availableData.find(output_name) == availableData.end()) {
+                throw runtime_error(get_formulation_type() + " cannot get output values for unknown " + output_name + SOURCE_LOC);
+            }
+            return availableData[output_name]->get_values(CatchmentAggrDataSelector("",output_name, init_time, duration_s, output_units), m);
         }
 
         bool is_bmi_input_variable(const string &var_name) override;

--- a/include/utilities/bmi_utilities.hpp
+++ b/include/utilities/bmi_utilities.hpp
@@ -48,6 +48,9 @@ namespace models {
             
             //C++ form of malloc
             void* data = ::operator new(total_mem);
+            // Use smart pointer to ensure cleanup on throw/out of scope...
+            // This works, and is relatively cheap since the lambda is stateless, only one instance should be created.
+            auto sptr = std::shared_ptr<void>(data, [](void *p) { ::operator delete(p); });
             //Delegate to specific adapter's GetValue()
             //Note, may be able to optimize this furthur using GetValuePtr
             //which would avoid copying in the BMI model and copying again here
@@ -100,8 +103,6 @@ namespace models {
                 throw std::runtime_error("Unable to get value of variable " + name +
                                 " as " + boost::typeindex::type_id<T>().pretty_name() + ": no logic for converting variable type " + type);
             }
-            //clean up the temporary data
-            ::operator delete(data); 
             return result;
         }
     }

--- a/include/utilities/bmi_utilities.hpp
+++ b/include/utilities/bmi_utilities.hpp
@@ -1,0 +1,110 @@
+#ifndef NGEN_BMI_UTILITIES_HPP
+#define NGEN_BMI_UTILITIES_HPP
+
+#include <string>
+#include <vector>
+#include <boost/type_index.hpp>
+#include "Bmi_Adapter.hpp"
+
+namespace models {
+    namespace bmi {
+        namespace helper {
+
+            /**
+             * @brief make a vector of type @tparam TO of size @param count. Copy elements of @tparam FROM type in data into the vector.
+             * 
+             * This function relies on the std library to cast data approriately during the construction of the vector.
+             * 
+             * @tparam TO data type to cast elements of the data pointer to
+             * @tparam FROM data type of the pointer data is extracted from
+             * @param data pointer to @param count number of @tparam FROM type elements
+             * @param count number of elements in the @param data pointer
+             * @return std::vector<TO> vector filled with @param count number of elements extracted from @param data
+             */
+            template<typename TO, typename FROM>
+            static inline std::vector<TO> make_vector(const FROM* data, const size_t& count){
+                //Let Return Value Optimization (move semantics) help here (no copy of vector)
+                return std::vector<TO>(data, data+count);
+            }
+        }
+
+        /**
+         * @brief Copy values from a BMI model adapter and box them into a vector.
+         * 
+         * @tparam T Type to cast data from the BMI model to
+         * @tparam A Bmi model type
+         * @param model Bmi model adapter that interfaces to @tparam A bmi
+         * @param name Bmi variable name to query the model for
+         * @return std::vector<T> Copy of data from the BMI model for variable @param name
+         */
+        template <typename T, typename A>
+        std::vector<T> GetValue(Bmi_Adapter<A>& model, const std::string& name) {
+            //TODO make model const ref
+            int total_mem = model.GetVarNbytes(name);
+            int item_size = model.GetVarItemsize(name);
+            int num_items = total_mem/item_size;
+            //Determine what type we need to cast from
+            std::string type = model.get_analogous_cxx_type(model.GetVarType(name), item_size);
+            
+            //C++ form of malloc
+            void* data = ::operator new(total_mem);
+            //Delegate to specific adapter's GetValue()
+            //Note, may be able to optimize this furthur using GetValuePtr
+            //which would avoid copying in the BMI model and copying again here
+            model.GetValue(name, data);
+            std::vector<T> result;
+
+            /*
+            * Allows the std::vector constructor to type cast the values as it copies them.
+            * I don't see any other way around the typing issue other than an explicit copy of each...
+            * Now there is an early optimization that allows types that align to pass through uncopied
+            * but that also only works if GetValuePtr returns a compatible pointer that can iterate
+            * on the recieving side correctly.  This may be tricky for certain langague adapters (Fortran?)
+            * Untill this becomes burdensome on memory/time, I suggest copying and converting each value
+            */
+
+            if (type == "long double"){
+                result = helper::make_vector<T>( (long double*) data, num_items);
+            }
+            else if (type == "double"){
+                result = helper::make_vector<T>( (double*) data, num_items);
+            }
+            else if (type == "float"){
+                result = helper::make_vector<T>( (float*) data, num_items);
+            }
+            else if (type == "short" || type == "short int" || type == "signed short" || type == "signed short int"){
+                result = helper::make_vector<T>( (short*) data, num_items);
+            }
+            else if (type == "unsigned short" || type == "unsigned short int"){
+                result = helper::make_vector<T>( (unsigned short*) data, num_items);
+            }
+            else if (type == "int" || type == "signed" || type == "signed int"){
+                result = helper::make_vector<T>( (int*) data, num_items);
+            }
+            else if (type == "unsigned" || type == "unsigned int"){
+                result = helper::make_vector<T>( (unsigned int*) data, num_items);
+            }
+            else if (type == "long" || type == "long int" || type == "signed long" || type == "signed long int"){
+                result = helper::make_vector<T>( (long*) data, num_items);
+            }
+            else if (type == "unsigned long" || type == "unsigned long int"){
+                result = helper::make_vector<T>( (unsigned long*) data, num_items);
+            }
+            else if (type == "long long" || type == "long long int" || type == "signed long long" || type == "signed long long int"){
+                result = helper::make_vector<T>( (long long*) data, num_items);
+            }
+            else if (type == "unsigned long long" || type == "unsigned long long int"){
+                result = helper::make_vector<T>( (unsigned long long*) data, num_items);
+            }
+            else{
+                throw std::runtime_error("Unable to get value of variable " + name +
+                                " as " + boost::typeindex::type_id<T>().pretty_name() + ": no logic for converting variable type " + type);
+            }
+            //clean up the temporary data
+            ::operator delete(data); 
+            return result;
+        }
+    }
+}
+
+#endif //NGEN_BMI_UTILITIES_HPP

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -1,4 +1,5 @@
 #include "UnitsHelper.hpp"
+#include <cstring>
 
 ut_system* UnitsHelper::unit_system;
 std::once_flag UnitsHelper::unit_system_inited;
@@ -45,19 +46,25 @@ double UnitsHelper::get_converted_value(const std::string &in_units, const doubl
     return r;
 }
 
-double* UnitsHelper::get_converted_values(const std::string &in_units, double* values, const std::string &out_units, const size_t& count)
+double* UnitsHelper::convert_values(const std::string &in_units, double* in_values, const std::string &out_units, double* out_values, const size_t& count)
 {
     if(in_units == out_units){
-        return values; // Early-out optimization
+        // Early-out optimization
+        if(in_values == out_values){
+            return in_values;
+        } else {
+            memcpy(out_values, in_values, sizeof(double)*count);
+            return out_values;
+        }
     }
     std::call_once(unit_system_inited, init_unit_system);
     ut_unit* to = NULL;
     ut_unit* from = NULL;
     cv_converter* conv = get_converter(in_units, out_units, to, from);
     
-    cv_convert_doubles(conv, values, count, values);
+    cv_convert_doubles(conv, in_values, count, out_values);
     ut_free(from);
     ut_free(to);
     cv_free(conv);
-    return values;
+    return out_values;
 }

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -3,21 +3,17 @@
 ut_system* UnitsHelper::unit_system;
 std::once_flag UnitsHelper::unit_system_inited;
 
-double UnitsHelper::get_converted_value(const std::string &in_units, double value, const std::string &out_units)
+cv_converter* UnitsHelper::get_converter(const std::string &in_units, const std::string& out_units, ut_unit*& to, ut_unit*& from)
 {
-    if(in_units == out_units){
-        return value; // Early-out optimization
-    }
     if(in_units == "" || out_units == ""){
         throw std::runtime_error("Unable to process empty units value for pairing \"" + in_units + "\" \"" + out_units + "\"");
     }
-    std::call_once(unit_system_inited, init_unit_system);
-    ut_unit* from = ut_parse(unit_system, in_units.c_str(), UT_UTF8);
+    from = ut_parse(unit_system, in_units.c_str(), UT_UTF8);
     if (from == NULL)
     {
         throw std::runtime_error("Unable to parse in_units value " + in_units);
     }
-    ut_unit* to = ut_parse(unit_system, out_units.c_str(), UT_UTF8);
+    to = ut_parse(unit_system, out_units.c_str(), UT_UTF8);
     if (to == NULL)
     {
         ut_free(from);
@@ -30,6 +26,18 @@ double UnitsHelper::get_converted_value(const std::string &in_units, double valu
         ut_free(to);
         throw std::runtime_error("Unable to convert " + in_units + " to " + out_units);
     }
+    return conv;
+}
+
+double UnitsHelper::get_converted_value(const std::string &in_units, const double &value, const std::string &out_units)
+{
+    if(in_units == out_units){
+        return value; // Early-out optimization
+    }
+    std::call_once(unit_system_inited, init_unit_system);
+    ut_unit* to = NULL;
+    ut_unit* from = NULL;
+    cv_converter* conv = get_converter(in_units, out_units, to, from);
     double r = cv_convert_double(conv, value);
     ut_free(from);
     ut_free(to);

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -44,3 +44,20 @@ double UnitsHelper::get_converted_value(const std::string &in_units, const doubl
     cv_free(conv);
     return r;
 }
+
+double* UnitsHelper::get_converted_values(const std::string &in_units, double* values, const std::string &out_units, const size_t& count)
+{
+    if(in_units == out_units){
+        return values; // Early-out optimization
+    }
+    std::call_once(unit_system_inited, init_unit_system);
+    ut_unit* to = NULL;
+    ut_unit* from = NULL;
+    cv_converter* conv = get_converter(in_units, out_units, to, from);
+    
+    cv_convert_doubles(conv, values, count, values);
+    ut_free(from);
+    ut_free(to);
+    cv_free(conv);
+    return values;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -195,8 +195,9 @@ endif()
 ########################## BMI Multi Tests
 add_test(
         test_bmi_multi
-        1
+        2
         realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+        realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
         NGen::core
         NGen::realizations_catchment
         NGen::core_mediator

--- a/test/core/mediator/UnitsHelper_Tests.cpp
+++ b/test/core/mediator/UnitsHelper_Tests.cpp
@@ -28,7 +28,36 @@ TEST_F(UnitsHelper_Test, TestConvertArray){
     std::vector<double> data = {1,2,3,4};
     std::vector<double> expected = {1000, 2000, 3000, 4000};
     //Call the converter, updates data in place
-    UnitsHelper::get_converted_values("m", data.data(), "mm", data.size());
+    UnitsHelper::convert_values("m", data.data(), "mm", data.data(), data.size());
     ASSERT_EQ( expected,  data);
 
+}
+
+// For coverage completeness...
+TEST_F(UnitsHelper_Test, TestConvertArrayNoOp){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> expected = {1, 2, 3, 4};
+    //Call the converter, updates data in place
+    UnitsHelper::convert_values("m", data.data(), "m", data.data(), data.size());
+    ASSERT_EQ( expected,  data);
+}
+
+TEST_F(UnitsHelper_Test, TestConvertArrayDontModifyInput){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> data2 = {2,4,6,8};
+    std::vector<double> expected = {1000, 2000, 3000, 4000};
+    //Call the converter, updates data in place
+    UnitsHelper::convert_values("m", data.data(), "mm", data2.data(), data.size());
+    ASSERT_EQ( expected,  data2);
+    ASSERT_EQ( data.at(2), 3);
+}
+
+TEST_F(UnitsHelper_Test, TestConvertArrayDontModifyInputNoOp){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> data2 = {2,4,6,8};
+    std::vector<double> expected = {1, 2, 3, 4};
+    //Call the converter, updates data in place
+    UnitsHelper::convert_values("m", data.data(), "m", data2.data(), data.size());
+    ASSERT_EQ( expected,  data2);
+    ASSERT_EQ( data.at(2), 3);
 }

--- a/test/core/mediator/UnitsHelper_Tests.cpp
+++ b/test/core/mediator/UnitsHelper_Tests.cpp
@@ -24,3 +24,11 @@ TEST_F(UnitsHelper_Test, TestDoAConversion){
 
 }
 
+TEST_F(UnitsHelper_Test, TestConvertArray){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> expected = {1000, 2000, 3000, 4000};
+    //Call the converter, updates data in place
+    UnitsHelper::get_converted_values("m", data.data(), "mm", data.size());
+    ASSERT_EQ( expected,  data);
+
+}

--- a/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_0.txt
+++ b/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_0.txt
@@ -1,0 +1,3 @@
+epoch_start_time=1448949600
+num_time_steps=720
+use_output_array

--- a/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_1.txt
+++ b/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_1.txt
@@ -1,0 +1,3 @@
+epoch_start_time=1448949600
+num_time_steps=720
+use_input_array

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -47,6 +47,11 @@ namespace data_access {
             double get_value(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override {
                 return (selector.get_variable_name() == OUTPUT_NAME_1) ? OUTPUT_VALUE_1 : 0.0;
             }
+	   
+            std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
+            {
+                return std::vector<double>(1, get_value(selector, m));
+            }
 
             bool is_property_sum_over_time_step(const string &name) override {
                 return true;

--- a/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
@@ -31,7 +31,7 @@ protected:
         return formulation.get_bmi_main_output_var();
     }
 
-    static const std::vector<std::shared_ptr<forcing::OptionalWrappedProvider>> &get_friend_deferred_providers(
+    static const std::vector<std::shared_ptr<data_access::OptionalWrappedProvider>> &get_friend_deferred_providers(
             const Bmi_Multi_Formulation& formulation)
     {
         return formulation.deferredProviders;
@@ -52,7 +52,8 @@ protected:
     template <class N, class M>
     static std::vector<double> get_friend_nested_var_values(const Bmi_Multi_Formulation& formulation, const int mod_index,
                                          const std::string& var_name) {
-        std::shared_ptr<N> nested = std::static_pointer_cast<N>( std::static_pointer_cast<M>(formulation.modules[mod_index])->get_bmi_model());
+        std::shared_ptr<M> module_formulation = std::static_pointer_cast<M>(formulation.modules[mod_index]);
+        std::shared_ptr<N> nested = std::static_pointer_cast<N>( module_formulation->get_bmi_model());
         //return (*nested).template GetValue<double>(var_name);
         return models::bmi::GetValue<double>(*nested.get(), var_name);
     }

--- a/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
@@ -1,0 +1,410 @@
+#ifndef NGEN_Bmi_Cpp_Multi_Array_Test_CPP
+#define NGEN_Bmi_Cpp_Multi_Array_Test_CPP
+
+#ifdef NGEN_BMI_CPP_LIB_TESTS_ACTIVE
+
+#include "Bmi_Testing_Util.hpp"
+#include <exception>
+#include <map>
+#include <vector>
+#include "gtest/gtest.h"
+#include "Bmi_Multi_Formulation.hpp"
+#include "Bmi_Module_Formulation.hpp"
+#include "CsvPerFeatureForcingProvider.hpp"
+#include "ConfigurationException.hpp"
+#include "FileChecker.h"
+#include "Formulation_Manager.hpp"
+
+using namespace realization;
+
+class Bmi_Cpp_Multi_Array_Test : public ::testing::Test {
+protected:
+
+    static std::string find_file(std::vector<std::string> dir_opts, const std::string& basename) {
+        std::vector<std::string> file_opts(dir_opts.size());
+        for (int i = 0; i < dir_opts.size(); ++i)
+            file_opts[i] = dir_opts[i] + basename;
+        return utils::FileChecker::find_first_readable(file_opts);
+    }
+
+    static std::string get_friend_bmi_main_output_var(const Bmi_Multi_Formulation& formulation) {
+        return formulation.get_bmi_main_output_var();
+    }
+
+    static const std::vector<std::shared_ptr<forcing::OptionalWrappedProvider>> &get_friend_deferred_providers(
+            const Bmi_Multi_Formulation& formulation)
+    {
+        return formulation.deferredProviders;
+    }
+
+    static std::string get_friend_nested_module_main_output_variable(const Bmi_Multi_Formulation& formulation,
+                                                                     const int nested_index) {
+        return formulation.modules[nested_index]->get_bmi_main_output_var();
+    }
+
+    template <class N>
+    static double get_friend_nested_var_value(const Bmi_Multi_Formulation& formulation, const int mod_index,
+                                         const std::string& var_name) {
+        std::shared_ptr<N> nested = std::static_pointer_cast<N>(formulation.modules[mod_index]);
+        return nested->get_var_value_as_double(var_name);
+    }
+
+    template <class N, class M>
+    static std::vector<double> get_friend_nested_var_values(const Bmi_Multi_Formulation& formulation, const int mod_index,
+                                         const std::string& var_name) {
+        std::shared_ptr<N> nested = std::static_pointer_cast<N>( std::static_pointer_cast<M>(formulation.modules[mod_index])->get_bmi_model());
+        //return (*nested).template GetValue<double>(var_name);
+        return models::bmi::GetValue<double>(*nested.get(), var_name);
+    }
+
+    template <class N, class M>
+    static std::shared_ptr<M> get_friend_bmi_model(N& nested_formulation) {
+        return nested_formulation.get_bmi_model();
+    }
+
+    template <class N, class M>
+    static std::shared_ptr<M> get_friend_nested_bmi_model(const Bmi_Multi_Formulation& formulation, const int mod_index) {
+        std::shared_ptr<N> nested_formulation = std::static_pointer_cast<N>(formulation.modules[mod_index]);
+        return nested_formulation.get_bmi_model();
+    }
+
+    static time_t get_friend_bmi_model_start_time_forcing_offset_s(Bmi_Multi_Formulation& formulation) {
+        return formulation.get_bmi_model_start_time_forcing_offset_s();
+    }
+
+    static std::string get_friend_forcing_file_path(const Bmi_Multi_Formulation& formulation) {
+        return formulation.get_forcing_file_path();
+    }
+
+    static bool get_friend_is_bmi_using_forcing_file(const Bmi_Multi_Formulation& formulation) {
+        return formulation.is_bmi_using_forcing_file();
+    }
+
+    static std::string get_friend_nested_module_model_type_name(Bmi_Multi_Formulation& formulation,
+                                                                const int nested_index) {
+        return formulation.modules[nested_index]->get_model_type_name();
+    }
+
+    void SetUp() override;
+
+    static void SetUpTestSuite();
+
+    void TearDown() override;
+
+    ngen::test::Bmi_Testing_Util testUtil;
+    /** The number of nested modules for each test example scenario. */
+    std::vector<int> example_module_depth;
+    /** Formulation config for each example, as JSON strings. */
+    std::vector<std::string> config_json;
+    /** Catchment id value for each example. */
+    std::vector<std::string> catchment_ids;
+    std::vector<std::string> example_forcing_files;
+    /** Main output variables for the outter formulation in each example. */
+    std::vector<std::string> main_output_variables;
+    /** Collections of lib/package files names for nested modules of each example, in the order of the nested modules. */
+    std::vector<std::vector<std::string>> nested_module_file_lists;
+    /** Collections of model types for each example, in the order of the nested modules. */
+    std::vector<std::vector<std::string>> nested_module_lists;
+    /** Main output variables for the nested formulations of each example. */
+    std::vector<std::vector<std::string>> nested_module_main_output_variables;
+    /** Collections of model type names for each example, in the order of the nested modules. */
+    std::vector<std::vector<std::string>> nested_module_type_name_lists;
+    /** Collections of init config files names for nested modules of each example, in the order of the nested modules. */
+    std::vector<std::vector<std::string>> nested_init_config_lists;
+    /** Collections of names of the registrations config files names for nested modules of each example, in the order of the nested modules. */
+    std::vector<std::vector<std::string>> nested_registration_function_lists;
+    std::vector<bool> uses_forcing_file;
+    std::vector<std::shared_ptr<forcing_params>> forcing_params_examples;
+    std::vector<boost::property_tree::ptree> config_prop_ptree;
+
+private:
+
+    /**
+     * Initialize members for holding required input, setup, and result test data for individual example scenarios.
+     */
+    inline void setupExampleDataCollections() {
+        const int EX_COUNT = example_module_depth.size();
+        config_json = std::vector<std::string>(EX_COUNT);
+        catchment_ids = std::vector<std::string>(EX_COUNT);
+        example_forcing_files = std::vector<std::string>(EX_COUNT);
+        main_output_variables  = std::vector<std::string>(EX_COUNT);
+        uses_forcing_file = std::vector<bool>(EX_COUNT);
+        forcing_params_examples = std::vector<std::shared_ptr<forcing_params>>(EX_COUNT);
+        config_prop_ptree = std::vector<boost::property_tree::ptree>(EX_COUNT);
+
+        nested_module_lists = std::vector<std::vector<std::string>>(EX_COUNT);
+        nested_module_type_name_lists = std::vector<std::vector<std::string>>(EX_COUNT);
+        nested_module_main_output_variables = std::vector<std::vector<std::string>>(EX_COUNT);
+        nested_module_file_lists = std::vector<std::vector<std::string>>(EX_COUNT);
+        nested_init_config_lists = std::vector<std::vector<std::string>>(EX_COUNT);
+        nested_registration_function_lists = std::vector<std::vector<std::string>>(EX_COUNT);
+
+        for (int i = 0; i < EX_COUNT; ++i) {
+            int nested_depth = example_module_depth[i];
+            nested_module_lists[i] = std::vector<std::string>(nested_depth);
+            nested_module_type_name_lists[i] = std::vector<std::string>(nested_depth);
+            nested_module_main_output_variables[i] = std::vector<std::string>(nested_depth);
+            nested_module_file_lists[i] = std::vector<std::string>(nested_depth);
+            nested_init_config_lists[i] = std::vector<std::string>(nested_depth);
+            nested_registration_function_lists[i] = std::vector<std::string>(nested_depth);
+        }
+    }
+
+    inline std::string buildNested(const int ex_index, const int nested_index) {
+        std::string nested_index_str = std::to_string(nested_index);
+        std::string input_var_alias = determineNestedInputAliasValue(ex_index, nested_index);
+        std::string array_alias = nested_index == 1 ? "OUTPUT_VAR_3" : AORC_FIELD_NAME_PRECIP_RATE;
+        return  "                        {\n"
+                "                            \"name\": \"" + std::string(BMI_CPP_TYPE) + "\",\n"
+                "                            \"params\": {\n"
+                "                                \"model_type_name\": \"" + nested_module_type_name_lists[ex_index][nested_index] + "\",\n"
+                "                                \"forcing_file\": \"\",\n"
+                "                                \"init_config\": \"" + nested_init_config_lists[ex_index][nested_index] + "\",\n"
+                "                                \"allow_exceed_end_time\": true,\n"
+                "                                \"main_output_variable\": \"" + nested_module_main_output_variables[ex_index][nested_index] + "\",\n"
+                "                                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6,\n"
+
+                "                                \"library_file\": \"" + nested_module_file_lists[ex_index][nested_index] + "\",\n"
+                "                                \"registration_function\": \"" + nested_registration_function_lists[ex_index][nested_index] + "\",\n"
+
+                "                                \"variables_names_map\": {\n"
+                "                                    \"OUTPUT_VAR_2\": \"OUTPUT_VAR_2__" + nested_index_str + "\",\n"
+                "                                    \"OUTPUT_VAR_1\": \"OUTPUT_VAR_1__" + nested_index_str + "\",\n"
+                "                                    \"INPUT_VAR_2\": \"" + CSDMS_STD_NAME_SURFACE_AIR_PRESSURE + "\",\n"
+                "                                    \"INPUT_VAR_1\": \"" + input_var_alias + "\",\n"
+                "                                    \"INPUT_VAR_3\": \"" + array_alias + "\"\n"
+                "                                },\n"
+                "                                \"uses_forcing_file\": " + (uses_forcing_file[ex_index] ? "true" : "false") + "\n"
+                "                            }\n"
+                "                        }";
+    }
+
+    /**
+     * Properly determine the mapped alias of one of the inputs, depending on the situation
+     *
+     * @param ex_index The index of the example config, corresponding to other index-specific saved values.
+     * @param nested_index The index of the particular module within the overall example config
+     * @return The appropriate input alias value for the example config being generated.
+     */
+    inline std::string determineNestedInputAliasValue(const int ex_index, const int nested_index) {
+        // For the first two examples (i.e. not 3 or 4), have an input of all but 1st module be an output of a prior
+        if (ex_index < 2) {
+            if (nested_index == 0)  return AORC_FIELD_NAME_PRECIP_RATE;
+            else                    return "OUTPUT_VAR_1__" + std::to_string(nested_index - 1);
+        }
+        // For the third, have the alias be a completely bogus value
+        else if (ex_index == 2) {
+            return "a_completely_bogus_value";
+        }
+        // For fourth, have alias for 1st module be an output from the 2nd module, to test lookback/deferred provided
+        else if (ex_index == 3) {
+            if (nested_index == 0)  return "OUTPUT_VAR_2__1";
+            else                    return AORC_FIELD_NAME_PRECIP_RATE;
+        }
+            // This isn't a case that is expected, so ...
+        else {
+            throw std::runtime_error("Unexpected example index in config setup for BMI Multi Formulation tests");
+        }
+    }
+
+    inline void buildExampleConfig(const int ex_index) {
+        std::string config =
+                "{\n"
+                "    \"global\": {},\n"
+                "    \"catchments\": {\n"
+                "        \"" + catchment_ids[ex_index] + "\": {\n"
+                "            \"formulations\": [\n"
+                "                {\n"
+                "                    \"name\": \"" + std::string(BMI_MULTI_TYPE) + "\",\n"
+                "                    \"params\": {\n"
+                "                        \"model_type_name\": \"bmi_multi_test\",\n"
+                "                        \"forcing_file\": \"\",\n"
+                "                        \"init_config\": \"\",\n"
+                "                        \"allow_exceed_end_time\": true,\n"
+                "                        \"main_output_variable\": \"" + main_output_variables[ex_index] + "\",\n"
+                "                        \"modules\": [\n"
+                + buildNested(ex_index, 0) + ",\n"
+                + buildNested(ex_index, 1) + "\n"
+                "                        ],\n"
+                "                        \"uses_forcing_file\": false\n"
+                "                    }\n"
+                "                }\n"
+                "            ],\n"
+                "            \"forcing\": {\n"
+                "                \"path\": \"" + example_forcing_files[ex_index] + "\",\n"
+                "                \"provider\": \"CsvPerFeature\"\n"
+                "            }\n"
+                "        }\n"
+                "    },\n"
+                "    \"time\": {\n"
+                "        \"start_time\": \"2012-05-01 00:00:00\",\n"
+                "        \"end_time\": \"2012-05-31 23:00:00\",\n"
+                "        \"output_interval\": 3600\n"
+                "    }\n"
+                "}";
+
+        config_json[ex_index] = config;
+
+        std::stringstream stream;
+        stream << config_json[ex_index];
+
+        boost::property_tree::ptree loaded_tree;
+        boost::property_tree::json_parser::read_json(stream, loaded_tree);
+        config_prop_ptree[ex_index] = loaded_tree.get_child("catchments").get_child(catchment_ids[ex_index]).get_child(
+                "formulations").begin()->second.get_child("params");
+    }
+
+    inline void initializeTestExample(const int ex_index, const std::string &cat_id,
+                                      const std::vector<std::string> &nested_types) {
+        catchment_ids[ex_index] = cat_id;
+        example_forcing_files[ex_index] = testUtil.getForcingFilePath(cat_id);
+        uses_forcing_file[ex_index] = false;
+
+        // TODO: re-implement things to have these be retrieved from the testing util object
+        forcing_params_examples[ex_index] = std::make_shared<forcing_params>(
+                forcing_params(example_forcing_files[0], "CsvPerFeature", "2015-12-01 00:00:00", "2015-12-30 23:00:00"));
+
+        std::string typeKey;
+
+        for (int j = 0; j < nested_module_lists[ex_index].size(); ++j) {
+            typeKey = nested_types[j];
+            nested_module_lists[ex_index][j] = nested_types[j];
+            nested_module_type_name_lists[ex_index][j] = testUtil.bmiFormulationConfigNames.at(typeKey);
+            nested_module_file_lists[ex_index][j] = testUtil.getModuleFilePath(typeKey);
+            nested_init_config_lists[ex_index][j] = testUtil.getBmiInitConfigFilePath(typeKey, j);
+            // TODO: look at setting this a different way
+            nested_module_main_output_variables[ex_index][j] = "OUTPUT_VAR_1";
+            // For any Python modules, this isn't strictly correct, but it'll be ignored.
+            nested_registration_function_lists[ex_index][j] = "register_bmi";
+        }
+        //main_output_variables[ex_index] = "OUTPUT_VAR_1__" + std::to_string(example_module_depth[ex_index] - 1);
+        main_output_variables[ex_index] = nested_module_main_output_variables[ex_index][example_module_depth[ex_index] - 1];
+
+        buildExampleConfig(ex_index);
+    }
+};
+
+void Bmi_Cpp_Multi_Array_Test::SetUpTestSuite() {
+
+}
+
+void Bmi_Cpp_Multi_Array_Test::TearDown() {
+    testing::Test::TearDown();
+}
+
+void Bmi_Cpp_Multi_Array_Test::SetUp() {
+    testing::Test::SetUp();
+
+    // Define this manually to set how many nested modules per example, and implicitly how many examples.
+    // This means 1 example scenarios with 2 nested modules
+    example_module_depth = {2};
+
+    // Initialize the members for holding required input and result test data for individual example scenarios
+    setupExampleDataCollections();
+
+    initializeTestExample(0, "cat-27", {std::string(BMI_CPP_TYPE), std::string(BMI_CPP_TYPE)});
+}
+
+/** Simple test to make sure the model config from example 0 initializes. */
+TEST_F(Bmi_Cpp_Multi_Array_Test, Initialize_0_a) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    ASSERT_EQ(get_friend_nested_module_model_type_name(formulation, 0), nested_module_type_name_lists[ex_index][0]);
+    ASSERT_EQ(get_friend_nested_module_model_type_name(formulation, 1), nested_module_type_name_lists[ex_index][1]);
+    ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 0), nested_module_main_output_variables[ex_index][0]);
+    ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
+    ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
+    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
+}
+
+/** Test to make sure the model config from example 0 initializes no deferred providers. */
+TEST_F(Bmi_Cpp_Multi_Array_Test, Initialize_0_b) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    ASSERT_EQ(get_friend_deferred_providers(formulation).size(), 0);
+}
+
+/**
+ * Simple test of get response in example 0.
+ */
+TEST_F(Bmi_Cpp_Multi_Array_Test, GetResponse_0_a) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    double response = formulation.get_response(0, 3600);
+    ASSERT_EQ(response, 00);
+}
+
+/**
+ * Test of get response in example 0 after several iterations.
+ */
+TEST_F(Bmi_Cpp_Multi_Array_Test, GetResponse_0_b) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    double response;
+    for (int i = 0; i < 39; i++) {
+        response = formulation.get_response(i, 3600);
+    }
+    double expected = 2.7809780039160068e-08;
+    ASSERT_EQ(expected, response);
+}
+
+/** Test to ensure value array passes from one module into the next */
+TEST_F(Bmi_Cpp_Multi_Array_Test, Pass_Bmi_Array_0) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    formulation.get_response(0, 3600);
+    
+    std::vector<double> expected = {1000, 2000, 3000};
+    auto data = get_friend_nested_var_values<models::bmi::Bmi_Cpp_Adapter, Bmi_Cpp_Formulation>(formulation, 1, "INPUT_VAR_3");
+    ASSERT_EQ(data,  expected);
+}
+
+/**
+ * Simple test of output for example 0.
+ */
+TEST_F(Bmi_Cpp_Multi_Array_Test, GetOutputLineForTimestep_0_a) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    formulation.get_response(0, 3600);
+    std::string output = formulation.get_output_line_for_timestep(0, ",");
+    ASSERT_EQ(output, "0.000000,200620.000000");
+}
+
+/**
+ * Simple test of output for example 0 with modified variables, picking time step when there was non-zero rain rate.
+ */
+TEST_F(Bmi_Cpp_Multi_Array_Test, GetOutputLineForTimestep_0_b) {
+    int ex_index = 0;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    int i = 0;
+    while (i < 542)
+        formulation.get_response(i++, 3600);
+    formulation.get_response(i, 3600);
+    std::string output = formulation.get_output_line_for_timestep(i, ",");
+    ASSERT_EQ(output, "0.000001,199280.000000");
+}
+
+
+#endif // NGEN_BMI_CPP_LIB_TESTS_ACTIVE
+#endif // NGEN_Bmi_Cpp_Multi_Array_Test_CPP

--- a/test/realizations/catchments/Bmi_Testing_Util.hpp
+++ b/test/realizations/catchments/Bmi_Testing_Util.hpp
@@ -15,12 +15,20 @@
 #define BMI_TEST_C_LIB_NAME "libtestbmicmodel"
 #endif
 
+#ifndef BMI_TEST_CPP_LIB_NAME
+#define BMI_TEST_CPP_LIB_NAME "libtestbmicppmodel"
+#endif
+
 #ifndef BMI_TEST_FORTRAN_LIB_NAME
 #define BMI_TEST_FORTRAN_LIB_NAME "libtestbmifortranmodel"
 #endif
 
 #ifndef BMI_TEST_PYTHON_LIB_NAME
 #define BMI_TEST_PYTHON_LIB_NAME "test_bmi_py.bmi_model"
+#endif
+
+#ifndef BMI_CPP_TYPE
+#define BMI_CPP_TYPE "bmi_c++"
 #endif
 
 #ifndef BMI_C_TYPE
@@ -74,6 +82,7 @@ namespace ngen {
              * Config names for BMI formulation types.
              */
             const map<string, string> bmiFormulationConfigNames = {
+                    {BMI_CPP_TYPE, "test_bmi_cpp"},
                     {BMI_C_TYPE, "test_bmi_c"},
                     {BMI_FORTRAN_TYPE, "test_bmi_fortran"},
                     {BMI_PYTHON_TYPE, BMI_TEST_PYTHON_LIB_NAME}
@@ -97,6 +106,7 @@ namespace ngen {
              * Library/package names for BMI module formulation types.
              */
             const map<string, string> bmiFormulationLibNames = {
+                    {BMI_CPP_TYPE, BMI_TEST_CPP_LIB_NAME},
                     {BMI_C_TYPE, BMI_TEST_C_LIB_NAME},
                     {BMI_FORTRAN_TYPE, BMI_TEST_FORTRAN_LIB_NAME},
                     {BMI_PYTHON_TYPE, BMI_TEST_PYTHON_LIB_NAME}
@@ -106,6 +116,7 @@ namespace ngen {
              * Relative paths to the directories containing BMI init config examples, from the project root.
              */
             const map<string, string> bmiInitConfigDirRelativePaths = {
+                    {BMI_CPP_TYPE, "test/data/bmi/test_bmi_cpp/"},
                     {BMI_C_TYPE, "test/data/bmi/test_bmi_c/"},
                     {BMI_FORTRAN_TYPE, "test/data/bmi/test_bmi_fortran/"},
                     {BMI_PYTHON_TYPE, "test/data/bmi/test_bmi_python/"}
@@ -115,6 +126,7 @@ namespace ngen {
              * Init config example file basename pattern.
              */
             const map<string, string> bmiInitConfigBasenamePattern = {
+                    {BMI_CPP_TYPE, "test_bmi_cpp_config_"},
                     {BMI_C_TYPE, "test_bmi_c_config_"},
                     {BMI_FORTRAN_TYPE, "test_bmi_fortran_config_"},
                     {BMI_PYTHON_TYPE, "test_bmi_python_config_"}
@@ -124,6 +136,7 @@ namespace ngen {
              * Init config example file extensions.
              */
             const map<string, string> bmiInitConfigBasenameExtensions = {
+                    {BMI_CPP_TYPE, ".txt"},
                     {BMI_C_TYPE, ".txt"},
                     {BMI_FORTRAN_TYPE, ".txt"},
                     {BMI_PYTHON_TYPE, ".yml"}
@@ -133,6 +146,7 @@ namespace ngen {
              * Relative paths to the directories containing each testing BMI modules, from the project root.
              */
             const map<string, string> bmiModuleRelativePaths = {
+                    {BMI_CPP_TYPE, "extern/test_bmi_cpp/cmake_build/"},
                     {BMI_C_TYPE, "extern/test_bmi_c/cmake_build/"},
                     {BMI_FORTRAN_TYPE, "extern/test_bmi_fortran/cmake_build/"},
                     // TODO, this may need to just be extern/


### PR DESCRIPTION
This PR allows a BMI module to provide an array of values as a single 1D output which can then be passed/consumed by another BMI module in a Multi BMI configuration.

## Additions

- `get_values` function added to ForcingProvider, with a default implementation
- BMI Module Formulation custom override of `ForcingProvider::get_values`
- `get_converted_values` function added to unit helper for unit conversion of an array of values
- BMI utilities module with function to cast and copy values based on string type tags 
- Test module for testing setting/getting array of values across two C++ BMI modules

## Removals

- Deprecated templated `GetValue( std::string & )` overload from BMI adapters.  Functionality moved to BMI utilities free function.

## Changes

- `check_internal_providers` now returns a vector of values instead of a single value
- add new array variable to c++ bmi test model
- updated implementation `set_model_inputs_prior_to_update` which checks for array like values and handles them accordingly.

## Testing

1. New functionality tested, all existing tests passing locally

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
