### PR TITLE
Github action/workflow cleanup and refactor

### DIFF
--- a/.github/actions/clean-build/action.yaml
+++ b/.github/actions/clean-build/action.yaml
@@ -1,0 +1,24 @@
+name: 'Clean build directory'
+description: 'This action cleans up build artifacts'
+author: 'hellkite500'
+inputs:
+    build-dir:
+      required: false
+      description: 'name of the build directory to clean'
+      default: 'cmake_build'
+    remove-dir:
+      required: false
+      description: 'remove the build directory'
+      default: 'true'
+runs:
+    using: 'composite'
+    steps:
+      - name: Clean Target
+        if: inputs.remove-dir != 'true'
+        run: cmake --build ${{ inputs.build-dir }} --target clean
+        shell: bash
+
+      - name: Remove Build Directory
+        if: inputs.remove-dir == 'true'
+        run: rm -rf ${{ inputs.build-dir }}
+        shell: bash

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -1,0 +1,142 @@
+name: 'Checkout and build tests'
+description: 'This action checks out the commit, sets up Ngen environemnt.'
+author: 'hellkite500'
+inputs:
+    targets:
+        required: false
+        description: 'Build targets'
+        default: 'all'
+    build-cores:
+      required: false
+      description: 'Number of cores to use for parallel builds'
+      default: '1'
+    build-dir:
+      required: false
+      description: 'Name of the build directory to run cmake in'
+      default: 'cmake_build'
+    bmi_c:
+      required: false
+      description: 'Activate C BMI library support'
+      default: 'OFF'
+    bmi_fortran:
+      required: false
+      description: 'Activate Fortran BMI library support'
+      default: 'OFF'
+    use_python:
+      required: false
+      description: 'Activate Python integration and BMI support'
+      #A lot of things oddly fail when this is not on by default...
+      default: 'OFF'
+    additional_python_requirements:
+      required: false
+      description: 'Path to additional requirements.txt for python packages'
+      default: ''
+    use_udunits:
+      required: false
+      description: 'Use UDUNITS2 for unit conversion'
+      default: 'ON'
+    use_troute:
+      required: false
+      description: 'Enable t-route integration support'
+      default: 'OFF'
+    use_mpi:
+      required: false
+      description: 'Enable mpi support, only available for Linux runners'
+      default: 'OFF'
+outputs:
+  build-dir:
+    description: "Directory build was performed in"
+    value: ${{ steps.cmake_init.outputs.build-dir }}
+
+runs:
+    using: 'composite'
+    steps:
+
+        - name: Install MPI
+          #Only use this step if Linux/ubuntu is being used
+          if: |
+            inputs.use_mpi != 'OFF' &&
+            runner.os == 'Linux'
+          id: install-mpi
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y libopenmpi-dev openmpi-bin openmpi-common
+          shell: bash
+
+        - name: Init Submodules
+          run: git submodule update --init --recursive
+          shell: bash
+
+        - name: Cache Boost Dependency
+          id: cache-boost-dep
+          uses: actions/cache@v1
+          with:
+            path: boost_1_72_0
+            key: unix-boost-dep
+
+        - name: Get Boost Dependency
+          if: steps.cache-boost-dep.outputs.cache-hit != 'true'
+          run: |
+            curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+            tar xjf boost_1_72_0.tar.bz2
+          shell: bash
+
+        - name: Cache Python Dependencies
+          id: cache-py3-dependencies
+          uses: actions/cache@v1
+          with:
+            path: .venv
+            key: ${{ runner.os }}-python-deps
+
+        - name: Get Numpy Python Dependency
+          # Tried conditioning the cache/install of python with an extra check:
+          # inputs.use_python != 'OFF' &&
+          # but what happens is that a runner not requiring python will create an empty cache
+          # and future runners will pull that and then fail...
+          # What we could do is try to create a master `requirements.txt`
+          # and/or a `test_requirements.txt` file that we can build the hash key from
+          # and read it from the repo...but we still have to always initialize the cache
+          # regardless of whether a given runner uses it, to avoid another runner failing to 
+          # find it.  Or just initialize this minimum requirement of numpy, and let the venv
+          # grow based on other runners needs, effectively building the cache with each new addition
+          if: |
+            steps.cache-py3-dependencies.outputs.cache-hit != 'true'
+          run: |
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install pip
+            pip install numpy
+            deactivate
+          shell: bash
+
+        - name: Init Additional Python Dependencies
+          # Don't condition additonal installs on a cache hit
+          # What will happen, however, is that the venv will get updated
+          # and thus the cache will get updated
+          # so any pip install will find modules already installed...
+          # if: |
+          #   inputs.additional_python_requirements != '' &&
+          #   steps.cache-py3-dependencies.outputs.cache-hit != 'true'
+          if: |
+            inputs.additional_python_requirements != ''
+          run: |
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install -r ${{ inputs.additional_python_requirements }}
+            deactivate
+          shell: bash
+
+        - name: Cmake Initialization
+          id: cmake_init
+          run: |
+            export BOOST_ROOT="$(pwd)/boost_1_72_0"
+            [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
+            cmake -B ${{ inputs.build-dir }} -DBMI_C_LIB_ACTIVE:BOOL=${{ inputs.bmi_c }} -DNGEN_ACTIVATE_PYTHON:BOOL=${{ inputs.use_python }} -DUDUNITS_ACTIVE:BOOL=${{ inputs.use_udunits }} -DBMI_FORTRAN_ACTIVE:BOOL=${{ inputs.bmi_fortran }} -DNGEN_ACTIVATE_ROUTING:BOOL=${{ inputs.use_troute }} -DMPI_ACTIVE:BOOL=${{ inputs.use_mpi }} -S .
+            echo "::set-output name=build-dir::$(echo ${{ inputs.build-dir }})"
+          shell: bash
+
+        - name: Build Targets
+          #cmake >= 3.15 can build multiple targets
+          run: cmake --build ${{ inputs.build-dir }} --target ${{ inputs.targets }} -- -j  ${{ inputs.build-cores }}
+          shell: bash
+

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -63,6 +63,20 @@ runs:
             sudo apt-get install -y libopenmpi-dev openmpi-bin openmpi-common
           shell: bash
 
+        - name: Install NetCDF
+          run: |
+            if [ ${{ runner.os }} == 'Linux' ]
+            then
+              sudo apt-get install -y libnetcdf-dev libnetcdff-dev
+            elif [ ${{ runner.os }} == 'macOS' ]
+            then
+              brew install netcdf
+              echo "LIBRARY_PATH=/usr/local/lib/:$LIBRARY_PATH" >> $GITHUB_ENV
+              echo "LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+              echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV
+            fi
+          shell: bash
+
         - name: Init Submodules
           run: git submodule update --init --recursive
           shell: bash

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -83,7 +83,7 @@ runs:
 
         - name: Cache Boost Dependency
           id: cache-boost-dep
-          uses: actions/cache@v1
+          uses: actions/cache@v3
           with:
             path: boost_1_72_0
             key: unix-boost-dep
@@ -97,7 +97,7 @@ runs:
 
         - name: Cache Python Dependencies
           id: cache-py3-dependencies
-          uses: actions/cache@v1
+          uses: actions/cache@v3
           with:
             path: .venv
             key: ${{ runner.os }}-python-deps

--- a/.github/actions/ngen-submod-build/action.yaml
+++ b/.github/actions/ngen-submod-build/action.yaml
@@ -1,0 +1,49 @@
+name: 'Checkout and build tests'
+description: 'This action checks out the commit, sets up Ngen environemnt.'
+author: 'hellkite500'
+inputs:
+    targets:
+        required: false
+        description: 'Build targets'
+        default: 'all'
+    build-cores:
+      required: false
+      description: 'Number of cores to use for parallel builds'
+      default: '1'
+    build-dir:
+      required: false
+      description: 'Name of the build directory to run cmake in'
+      default: 'cmake_build'
+    mod-dir:
+      required: true
+      description: 'Path to the submodule with CMakeLists.txt to build'
+outputs:
+  build-dir:
+    description: "Directory build was performed in"
+    value: ${{ steps.cmake_init.outputs.build-dir }}
+runs:
+    using: 'composite'
+    steps:
+        #This may be redundant
+        - name: Init Submodules
+          run: git submodule update --init --recursive -- ${{ inputs.mod-dir }}
+          shell: bash
+
+        - name: Configure Fortran Compiler
+          if: |
+            runner.os == 'macOS'
+          run: |
+            echo "FC=gfortran-11" >> $GITHUB_ENV
+          shell: bash
+
+        - name: Cmake Initialization
+          id: cmake_init
+          run: |
+            cmake -B ${{ inputs.mod-dir}}/${{ inputs.build-dir }} -S ${{ inputs.mod-dir }}
+            echo "::set-output name=build-dir::$(echo ${{ inputs.mod-dir}}/${{ inputs.build-dir }})"
+          shell: bash
+
+        - name: Build Targets
+          #cmake >= 3.15 can build multiple targets
+          run: cmake --build ${{ inputs.mod-dir}}/${{ inputs.build-dir }} --target ${{ inputs.targets }} -- -j  ${{ inputs.build-cores }}
+          shell: bash

--- a/.github/actions/ngen-submod-build/action.yaml
+++ b/.github/actions/ngen-submod-build/action.yaml
@@ -45,5 +45,5 @@ runs:
 
         - name: Build Targets
           #cmake >= 3.15 can build multiple targets
-          run: cmake --build ${{ inputs.mod-dir}}/${{ inputs.build-dir }} --target ${{ inputs.targets }} -- -j  ${{ inputs.build-cores }}
+          run: cmake --build ${{ inputs.mod-dir}}/${{ inputs.build-dir }} --target ${{ inputs.targets }} -- -j  ${{ inputs.build-cores }} VERBOSE=1
           shell: bash

--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -1,4 +1,4 @@
-name: Testing and Validation
+name: Module Integration Tests
 
 # Controls when the action will run.
 on:
@@ -6,6 +6,7 @@ on:
     branches: [ master, dev, notreal ]
   pull_request:
     branches: [ master, dev, notreal ]
+  workflow_dispatch:
 
 env:
   # Obtained from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
@@ -18,126 +19,126 @@ jobs:
   # Run general unit tests in linux environment
   test_surfacebmi_plus_cfe:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+    
+      - name: Build Surfacebmi
+        id: submod_build_1
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: " extern/noah-owp-modular/"
+          targets: "surfacebmi"
       
-    - name: Init Submodules
-      run: git submodule update --init --recursive
+      - name: Build ISO C Fortran BMI
+        id: submod_build_2
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/iso_c_fortran_bmi/"
+      
+      - name: Build CFE
+        id: submod_build_3
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/cfe/"
+          targets: "cfebmi"
 
-    - name: Cache Boost Dependency
-      id: cache-boost-dep
-      uses: actions/cache@v1
-      with:
-        path: boost_1_72_0
-        key: unix-boost-dep
+      - name: Build Ngen
+        uses: ./.github/actions/ngen-build
+        with:
+          targets: "ngen"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          #is this required for this test?
+          bmi_c: 'ON'
+          bmi_fortran: 'ON'
+        timeout-minutes: 15
 
-    - name: Get Boost Dependency
-      if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-      run: |
-        curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-        tar xjf boost_1_72_0.tar.bz2
-
-    - name: Build surfacebmi module
-      run: |
-        cmake -B extern/noah-owp-modular/cmake_build cmake_build -S extern/noah-owp-modular
-        cmake --build extern/noah-owp-modular/cmake_build --target surfacebmi -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-
-    - name: Build cfebmi module
-      run: |
-        cmake -B extern/cfe/cmake_build -S extern/cfe/
-        cmake --build extern/cfe/cmake_build/ --target cfebmi -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-
-    - name: Build iso_c_fortran_bmi module
-      run: |
-        cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
-        cmake --build extern/iso_c_fortran_bmi/cmake_build --target iso_c_bmi -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-
-    - name: cmake_init_build
-      run: |
-        export BOOST_ROOT="$(pwd)/boost_1_72_0"
-        [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-        cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_FORTRAN_ACTIVE=ON -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -S .
-
-    - name: Build ngen
-      run: cmake --build cmake_build --target ngen -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-      timeout-minutes: 15
-
-    - name: Run surfacebmi plus cfebmi
-      run: ./cmake_build/ngen data/catchment_data.geojson "cat-27" data/nexus_data.geojson "nex-26" data/example_bmi_multi_realization_config.json
+      - name: Run surfacebmi plus cfebmi
+        run: |
+          inputfile='data/example_bmi_multi_realization_config.json'
+          if [ ${{ runner.os }} == 'macOS' ] 
+          then
+              inputfile=data/example_bmi_multi_realization_config__macos.json
+          fi
+          ./cmake_build/ngen data/catchment_data.geojson "cat-27" data/nexus_data.geojson "nex-26" $inputfile
 
 # Run t-route/pybind integration test
   test_troute_integration:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
-      
-    - name: Init Submodules
-      run: git submodule update --init --recursive
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
 
-    - name: Cache Boost Dependency
-      id: cache-boost-dep
-      uses: actions/cache@v1
-      with:
-        path: boost_1_72_0
-        key: unix-boost-dep
+      - name: Build Ngen
+        uses: ./.github/actions/ngen-build
+        with:
+          targets: "test_routing_pybind"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          #is this required for this test?
+          use_python: 'ON'
+          use_troute: 'ON'
+        timeout-minutes: 15
+      # Disabling this cache for the time being for a few reasons
+      # 1) t-route build/install can be tricky without pre-cythonized sources
+      # 2) may not want to use a cached version of t-route if we are testing its integration
+      #    we want to use the latest code in the submodule and make sure it works...a cached version
+      #    wouldn't be good for that...
+      #- name: Cache troute dependency
+      #  id: cache-linux-troute-dep
+      #  uses: actions/cache@v1
+      #  with:
+      #    path: .venv
+      #    key: linux-troute-dep-fixed
 
-    - name: Get Boost Dependency
-      if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-      run: |
-        curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-        tar xjf boost_1_72_0.tar.bz2
+      #This step should come after ngen build???
+      - name: Configure Fortran Compiler
+        run: |
+          if [ ${{ runner.os }} == 'macOS' ] 
+          then
+            sudo ln -s $(which gfortran-11) $(dirname $(which gfortran-11))/gfortran
+            export FC=gfortran-11
+            export F90=gfortran-11
+          fi
 
-    - name: Get netcdff library
-      run: |
-        sudo apt-get install -y libnetcdf-dev libnetcdff-dev
+      - name: Build T-route Dependency
+        #if: steps.cache-linux-troute-dep.outputs.cache-hit != 'true'
+        #MacOS pybind has issues with egg links, so install all packages without egg links on that os
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          cd extern/t-route
+          pip install pip
+          pip install -r requirements.txt
+          cd src
+          pip install nwm_routing/
+          pip install ngen_routing/
+          cd python_routing_v02
+          if [ ${{ runner.os }} == 'macOS' ] 
+          then
+            export LIBRARY_PATH=/usr/local/lib/gcc/11/
+            export LD_LIBRARY_PATH=/usr/local/lib/gcc/11/
+            sed -i'.bak' 's/pip install -e/pip install/g' compiler.sh
+          fi
+          
+          FC=gfortran F90=gfortran ./compiler.sh
+          deactivate
 
-    # Disabling this cache for the time being for a few reasons
-    # 1) t-route build/install can be tricky without pre-cythonized sources
-    # 2) may not want to use a cached version of t-route if we are testing its integration
-    #    we want to use the latest code in the submodule and make sure it works...a cached version
-    #    wouldn't be good for that...
-    #- name: Cache troute dependency
-    #  id: cache-linux-troute-dep
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: .venv
-    #    key: linux-troute-dep-fixed
-
-    - name: Build T-route Dependency
-      #if: steps.cache-linux-troute-dep.outputs.cache-hit != 'true'
-      run: |
-        python -m venv .venv
-        . .venv/bin/activate
-        cd extern/t-route
-        pip install pip
-        pip install -r requirements.txt
-        cd src
-        pip install -e nwm_routing/
-        pip install -e ngen_routing/
-        cd python_routing_v02
-        FC=gfortran ./compiler.sh
-        deactivate
-
-    - name: cmake_init_build
-      run: |
-        export BOOST_ROOT="$(pwd)/boost_1_72_0"
-        [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-        cmake -B cmake_build -DNGEN_ACTIVATE_ROUTING:BOOL=on -S .
-
-    - name: Build test
-      run: cmake --build cmake_build --target test_routing_pybind -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-      timeout-minutes: 15
-
-    - name: Run test
-      run: |
-        . .venv/bin/activate
-        ./cmake_build/test/test_routing_pybind
-        deactivate
+      - name: Run test
+        run: |
+          . .venv/bin/activate
+          ./cmake_build/test/test_routing_pybind
+          deactivate

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -19,9 +19,13 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Run general unit tests in linux environment
-  test_unit_ubuntu_latest:
+  test_unit:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -42,9 +46,13 @@ jobs:
       uses: ./.github/actions/clean-build
 
   # Test MPI remote nexus behavior in linux
-  test_mpi_remote_nexus_ubuntu_latest:
+  test_mpi_remote_nexus:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -67,9 +75,13 @@ jobs:
 
 
   # Run BMI C++ tests in linux environment
-  test_bmi_cpp_ubuntu_latest:
+  test_bmi_cpp:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -110,9 +122,13 @@ jobs:
           build-dir: ${{ steps.submod_build.outputs.build-dir }}
 
   # Run BMI C tests in linux environment, and separating to isolate
-  test_bmi_c_ubuntu_latest:
+  test_bmi_c:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -151,9 +167,13 @@ jobs:
           build-dir: ${{ steps.submod_build.outputs.build-dir }}
 
   # As with the BMI C ubuntu job, separate Fortran in linux tests to keep setups clean and cause of failures clear.
-  test_bmi_fortran_ubuntu_latest:
+  test_bmi_fortran:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -201,9 +221,13 @@ jobs:
           build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
 
   # As with the BMI C ubuntu job, separate Python in linux tests to keep setups clean and cause of failures clear.
-  test_bmi_python_ubuntu_latest:
+  test_bmi_python:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -231,9 +255,13 @@ jobs:
         uses: ./.github/actions/clean-build
 
   # As with the BMI C ubuntu job, separate multi BMI in linux tests to keep setups clean and cause of failures clear.
-  test_bmi_multi_ubuntu_latest:
+  test_bmi_multi:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -286,253 +314,6 @@ jobs:
       - uses: ./.github/actions/clean-build
         with:
           build-dir: ${{ steps.submod_build_3.outputs.build-dir }}
-
-
-  # Run general unit tests in MacOS environment
-  #Repeat all tests in macos environment
-  test_unit_macos_latest:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    - name: Checkout the commit
-      uses: actions/checkout@v2
-    
-    - name: Build Unit Tests
-      uses: ./.github/actions/ngen-build
-      with:
-        targets: "test_unit"
-        build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
-
-    - name: Run Tests
-      run: ./cmake_build/test/test_unit
-      timeout-minutes: 15
-    
-    - name: Clean Up
-      uses: ./.github/actions/clean-build
-
-  # Run BMI C++ tests in linux environment
-  test_bmi_cpp_macos_latest:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      #make sure cxx bmi is initialized/ready
-      - uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/bmi-cxx/"
-
-      - name: Build Submodules
-        id: submod_build
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/test_bmi_cpp/"
-          targets: "testbmicppmodel"
-
-      - name: Build Unit Tests
-        uses: ./.github/actions/ngen-build
-        with:
-          targets: "test_bmi_cpp"
-          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
-
-      - name: Run Tests
-        run: |
-          cd ./cmake_build/test/
-          ./test_bmi_cpp
-          cd ../../
-        timeout-minutes: 15
-
-      - name: Clean Up Unit Test Build
-        uses: ./.github/actions/clean-build
-
-      - name: Clean Up Submodule Build
-        uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build.outputs.build-dir }}
-
-  # Run BMI C tests in linux environment, and separating to isolate
-  test_bmi_c_macos_latest:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - name: Build Submodules
-        id: submod_build
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/test_bmi_c"
-          targets: "testbmicmodel"
-
-      - name: Build Unit Tests
-        uses: ./.github/actions/ngen-build
-        with:
-          targets: "test_bmi_c"
-          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
-          bmi_c: 'ON'
-          #Is this required for this test???
-          use_python: 'ON'
-
-      - name: run_bmi_c_tests
-        run: |
-          cd ./cmake_build/test/
-          ./test_bmi_c
-          cd ../../
-        timeout-minutes: 15
-
-      - name: Clean Up Unit Test Build
-        uses: ./.github/actions/clean-build
-
-      - name: Clean Up Submodule Build
-        uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build.outputs.build-dir }}
-
-  # As with the BMI C macos job, separate Fortran in linux tests to keep setups clean and cause of failures clear.
-  test_bmi_fortran_macos_latest:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - name: Build Submodules
-        id: submod_build_1
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/test_bmi_fortran/"
-      
-      - name: Build Submodules
-        id: submod_build_2
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/iso_c_fortran_bmi/"
-
-      - name: Build Unit Tests
-        uses: ./.github/actions/ngen-build
-        with:
-          targets: "test_bmi_fortran"
-          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
-          #is this required for this test?
-          bmi_c: 'ON'
-          bmi_fortran: 'ON'
-
-      - name: Run Unit Tests
-        run: |
-          cd ./cmake_build/test/
-          ./test_bmi_fortran
-          cd ../../
-        timeout-minutes: 15
-
-      - name: Clean Up Unit Test Build
-        uses: ./.github/actions/clean-build
-
-      - name: Clean Up Submodule Build
-        uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build_1.outputs.build-dir }}
-      - uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
-
-  # As with the BMI C macos job, separate Python in linux tests to keep setups clean and cause of failures clear.
-  test_bmi_python_macos_latest:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
-      - uses: actions/checkout@v2
-
-      - name: Build Unit Tests
-        uses: ./.github/actions/ngen-build
-        with:
-          targets: "test_bmi_python"
-          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
-          #is this required for this test?
-          bmi_c: 'ON'
-          use_python: 'ON'
-          additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
-
-      - name: run_bmi_python_tests
-        run: |
-          cd ./cmake_build/test/
-          ./test_bmi_python
-          cd ../../
-        timeout-minutes: 15
-
-      - name: Clean Up Unit Test Build
-        uses: ./.github/actions/clean-build
-
-  # As with the BMI C macos job, separate multi BMI in linux tests to keep setups clean and cause of failures clear.
-  test_bmi_multi_macos_latest:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - name: Build Submodules
-        id: submod_build_1
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/test_bmi_fortran/"
-
-      - name: Build Submodules
-        id: submod_build_2
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/iso_c_fortran_bmi/"
-
-      - name: Build Submodules
-        id: submod_build_3
-        uses: ./.github/actions/ngen-submod-build
-        with: 
-          mod-dir: "extern/test_bmi_c/"
-          targets: "testbmicmodel"
-
-      - name: Build Unit Tests
-        uses: ./.github/actions/ngen-build
-        with:
-          targets: "test_bmi_multi"
-          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
-          bmi_c: 'ON'
-          bmi_fortran: 'ON'
-          use_python: 'ON'
-          additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
-
-      - name: Run Unit Tests
-        run: ./cmake_build/test/test_bmi_multi
-        timeout-minutes: 15
-
-      - name: Clean Up Unit Test Build
-        uses: ./.github/actions/clean-build
-
-      - name: Clean Up Submodule Build
-        uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build_1.outputs.build-dir }}
-      - uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
-      - uses: ./.github/actions/clean-build
-        with:
-          build-dir: ${{ steps.submod_build_3.outputs.build-dir }}
-
-
 
   # TODO: fails due to compilation error, at least in large part due to use of POSIX functions not supported on Windows.
   # TODO: Need to determine whether Windows support (in particular, development environment support) is necessary.

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master, dev, notreal ]
   pull_request:
     branches: [ master, dev, notreal ]
+  workflow_dispatch:
 
 env:
   # Obtained from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
@@ -24,44 +25,21 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
-      
-    - name: Init Submodules
-      run: git submodule update --init --recursive
-
-    - name: Cache Boost Dependency
-      id: cache-boost-dep
-      uses: actions/cache@v1
-      with:
-        path: boost_1_72_0
-        key: unix-boost-dep
-
-    - name: Get Boost Dependency
-      if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-      run: |
-        curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-        tar xjf boost_1_72_0.tar.bz2
-
-    - name: cmake_init_build
-      run: |
-        export BOOST_ROOT="$(pwd)/boost_1_72_0"
-        [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-        cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=OFF -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -DUDUNITS_ACTIVE:BOOL=ON -S .
+    - name: Checkout the commit
+      uses: actions/checkout@v2
     
-    - name: build_tests
-      run: cmake --build cmake_build --target test_unit -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-      timeout-minutes: 15
-      
-    - name: run_tests
+    - name: Build Unit Tests
+      uses: ./.github/actions/ngen-build
+      with:
+        targets: "test_unit"
+        build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+
+    - name: Run Tests
       run: ./cmake_build/test/test_unit
       timeout-minutes: 15
     
-    - name: clean_build
-      run: cmake --build cmake_build --target clean
-    
-    - name: cleanup_dir
-      run: rm -rf cmake_build
+    - name: Clean Up
+      uses: ./.github/actions/clean-build
 
   # Test MPI remote nexus behavior in linux
   test_mpi_remote_nexus_ubuntu_latest:
@@ -73,47 +51,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: Install MPI
-        id: install-mpi
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopenmpi-dev openmpi-bin openmpi-common
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DMPI_ACTIVE:BOOL=ON -DBMI_C_LIB_ACTIVE:BOOL=OFF -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_tests
-        run: cmake --build cmake_build --target test_remote_nexus -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-        timeout-minutes: 15
+          targets: "test_remote_nexus"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          use_mpi: 'ON'
 
       - name: run_tests
         run: mpirun --allow-run-as-root -np 2 ./cmake_build/test/test_remote_nexus
         timeout-minutes: 15
 
-      - name: clean_build
-        run: cmake --build cmake_build --target clean
-
-      - name: cleanup_dir
-        run: rm -rf cmake_build
+      - name: Clean Up
+        uses: ./.github/actions/clean-build
 
 
   # Run BMI C++ tests in linux environment
@@ -126,56 +76,38 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+      #make sure cxx bmi is initialized/ready
+      - uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/bmi-cxx/"
 
-      - name: cmake_init_shared_lib_build
-        run: cmake -B extern/test_bmi_cpp/cmake_build -S extern/test_bmi_cpp 
+      - name: Build Submodules
+        id: submod_build
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_cpp/"
+          targets: "testbmicppmodel"
 
-      - name: build_test_bmi_cpp_shared_lib
-        run: cmake --build extern/test_bmi_cpp/cmake_build --target testbmicppmodel
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: boost_1_72_0
-          key: unix-boost-dep
+          targets: "test_bmi_cpp"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
 
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -S .
-
-      - name: build_bmi_c++_tests
-        run: cmake --build cmake_build --target test_bmi_cpp -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_bmi_c++_tests
+      - name: Run Tests
         run: |
           cd ./cmake_build/test/
           ./test_bmi_cpp
           cd ../../
         timeout-minutes: 15
 
-      - name: clean_build
-        run: cmake --build cmake_build --target clean
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
-      - name: clean_shared_lib_build
-        run: cmake --build extern/test_bmi_cpp/cmake_build --target clean
-
-      - name: cleanup_dir
-        run: rm -rf cmake_build
-
-      - name: cleanup_dir
-        run: rm -rf extern/test_bmi_cpp/cmake_build
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build.outputs.build-dir }}
 
   # Run BMI C tests in linux environment, and separating to isolate
   test_bmi_c_ubuntu_latest:
@@ -187,53 +119,21 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+      - name: Build Submodules
+        id: submod_build
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_c"
+          targets: "testbmicmodel"
 
-      - name: Cache Numpy Python Dependency
-        id: cache-linux-numpy-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: .venv
-          key: linux-numpy-dep
-
-      - name: Get Numpy Python Dependency
-        if: steps.cache-linux-numpy-dep.outputs.cache-hit != 'true'
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install pip
-          pip install numpy
-          deactivate
-
-      - name: cmake_init_shared_lib_build
-        run: cmake -B extern/test_bmi_c/cmake_build -S extern/test_bmi_c 
-
-      - name: build_test_bmi_c_shared_lib
-        run: cmake --build extern/test_bmi_c/cmake_build --target testbmicmodel
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=ON -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_c_tests
-        run: cmake --build cmake_build --target test_bmi_c -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-        timeout-minutes: 15
+          targets: "test_bmi_c"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          bmi_c: 'ON'
+          #Is this required for this test???
+          use_python: 'ON'
 
       - name: run_bmi_c_tests
         run: |
@@ -242,17 +142,13 @@ jobs:
           cd ../../
         timeout-minutes: 15
 
-      - name: clean_build
-        run: cmake --build cmake_build --target clean
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
-      - name: clean_shared_lib_build
-        run: cmake --build extern/test_bmi_c/cmake_build --target clean
-
-      - name: cleanup_dir
-        run: rm -rf cmake_build
-
-      - name: cleanup_dir
-        run: rm -rf extern/test_bmi_c/cmake_build
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build.outputs.build-dir }}
 
   # As with the BMI C ubuntu job, separate Fortran in linux tests to keep setups clean and cause of failures clear.
   test_bmi_fortran_ubuntu_latest:
@@ -264,59 +160,45 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+      - name: Build Submodules
+        id: submod_build_1
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_fortran/"
+      
+      - name: Build Submodules
+        id: submod_build_2
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/iso_c_fortran_bmi/"
 
-      - name: cmake_init_test_lib_build
-        run: cmake -B extern/test_bmi_fortran/cmake_build -S extern/test_bmi_fortran
-
-      - name: build_test_bmi_fortran_shared_lib
-        run: |
-          cd extern/test_bmi_fortran/cmake_build
-          make
-          cd ../../../
-
-      - name: cmake_init_fortran_iso_c_lib_build
-        run: cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
-
-      - name: build_test_fortran_iso_c_shared_lib
-        run: |
-          cd extern/iso_c_fortran_bmi/cmake_build
-          make
-          cd ../../../
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: boost_1_72_0
-          key: unix-boost-dep
+          targets: "test_bmi_fortran"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          #is this required for this test?
+          bmi_c: 'ON'
+          bmi_fortran: 'ON'
 
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_FORTRAN_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_fortran_tests
-        run: cmake --build cmake_build --target test_bmi_fortran -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_bmi_fortran_tests
+      - name: Run Unit Tests
         run: |
           cd ./cmake_build/test/
           ./test_bmi_fortran
           cd ../../
         timeout-minutes: 15
 
-      - name: cleanup_builds
-        run: find . -name cmake_build -type d -prune -exec rm -rf {} \;
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
+
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_1.outputs.build-dir }}
+
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
 
   # As with the BMI C ubuntu job, separate Python in linux tests to keep setups clean and cause of failures clear.
   test_bmi_python_ubuntu_latest:
@@ -328,48 +210,15 @@ jobs:
       # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
-
-      - name: Cache Python Dependencies
-        id: cache-linux-py3-dependencies
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: .venv
-          key: linux-py3-dependencies
-
-      - name: Init Python Dependencies
-        if: steps.cache-linux-py3-dependencies.outputs.cache-hit != 'true'
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install pip
-          pip install numpy
-          pip install -r extern/test_bmi_py/requirements.txt
-          deactivate
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DCMAKE_BUILD_TYPE=Debug -DBMI_C_LIB_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=ON -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_python_tests
-        run: cmake --build cmake_build --target test_bmi_python -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-        timeout-minutes: 15
+          targets: "test_bmi_python"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          #is this required for this test?
+          bmi_c: 'ON'
+          use_python: 'ON'
+          additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
 
       - name: run_bmi_python_tests
         run: |
@@ -378,8 +227,8 @@ jobs:
           cd ../../
         timeout-minutes: 15
 
-      - name: cleanup
-        run: rm -rf cmake_build
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
   # As with the BMI C ubuntu job, separate multi BMI in linux tests to keep setups clean and cause of failures clear.
   test_bmi_multi_ubuntu_latest:
@@ -391,131 +240,79 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Cache Python Dependencies
-        id: cache-linux-py3-dependencies
-        uses: actions/cache@v1
+      - name: Build Submodules
+        id: submod_build_1
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_fortran/"
+
+      - name: Build Submodules
+        id: submod_build_2
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/iso_c_fortran_bmi/"
+
+      - name: Build Submodules
+        id: submod_build_3
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_c/"
+          targets: "testbmicmodel"
+
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: .venv
-          key: linux-py3-dependencies
+          targets: "test_bmi_multi"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          bmi_c: 'ON'
+          bmi_fortran: 'ON'
+          use_python: 'ON'
+          additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
 
-      - name: Init Python Dependencies
-        if: steps.cache-linux-py3-dependencies.outputs.cache-hit != 'true'
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install pip
-          pip install numpy
-          pip install -r extern/test_bmi_py/requirements.txt
-          deactivate
-
-      - name: Init Submodules
-        run: git submodule update --init --recursive
-
-      - name: cmake_init_test_lib_build
-        run: cmake -B extern/test_bmi_fortran/cmake_build -S extern/test_bmi_fortran
-
-      - name: build_test_bmi_fortran_shared_lib
-        run: |
-          cd extern/test_bmi_fortran/cmake_build
-          make
-          cd ../../../
-
-      - name: cmake_init_fortran_iso_c_lib_build
-        run: cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
-
-      - name: build_test_fortran_iso_c_shared_lib
-        run: |
-          cd extern/iso_c_fortran_bmi/cmake_build
-          make
-          cd ../../../
-
-      - name: cmake_init_shared_lib_build
-        run: cmake -B extern/test_bmi_c/cmake_build -S extern/test_bmi_c
-
-      - name: build_test_bmi_c_shared_lib
-        run: cmake --build extern/test_bmi_c/cmake_build --target testbmicmodel
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_FORTRAN_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=ON -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_multi_tests
-        run: cmake --build cmake_build --target test_bmi_multi -- -j ${{ env.LINUX_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_bmi_multi_tests
+      - name: Run Unit Tests
         run: ./cmake_build/test/test_bmi_multi
         timeout-minutes: 15
 
-      - name: cleanup_builds
-        run: find . -name cmake_build -type d -prune -exec rm -rf {} \;
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
+
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_1.outputs.build-dir }}
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_3.outputs.build-dir }}
 
 
   # Run general unit tests in MacOS environment
+  #Repeat all tests in macos environment
   test_unit_macos_latest:
     # The type of runner that the job will run on
     runs-on: macos-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+    - name: Checkout the commit
+      uses: actions/checkout@v2
+    
+    - name: Build Unit Tests
+      uses: ./.github/actions/ngen-build
+      with:
+        targets: "test_unit"
+        build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+    - name: Run Tests
+      run: ./cmake_build/test/test_unit
+      timeout-minutes: 15
+    
+    - name: Clean Up
+      uses: ./.github/actions/clean-build
 
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: Install automake (for UDUNITS2)
-        run: brew install automake
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=OFF -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_tests
-        run: cmake --build cmake_build --target test_unit -- -j ${{ env.MACOS_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_tests
-        run: ./cmake_build/test/test_unit
-        timeout-minutes: 15
-
-      - name: clean_build
-        run: cmake --build cmake_build --target clean
-
-      - name: cleanup_dir
-        run: rm -rf cmake_build
-
-  # Run BMI C++ tests in macOS environment
+  # Run BMI C++ tests in linux environment
   test_bmi_cpp_macos_latest:
     # The type of runner that the job will run on
     runs-on: macos-latest
@@ -525,58 +322,40 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+      #make sure cxx bmi is initialized/ready
+      - uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/bmi-cxx/"
 
-      - name: cmake_init_shared_lib_build
-        run: cmake -B extern/test_bmi_cpp/cmake_build -S extern/test_bmi_cpp
+      - name: Build Submodules
+        id: submod_build
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_cpp/"
+          targets: "testbmicppmodel"
 
-      - name: build_test_bmi_cpp_shared_lib
-        run: cmake --build extern/test_bmi_cpp/cmake_build --target testbmicppmodel
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: boost_1_72_0
-          key: unix-boost-dep
+          targets: "test_bmi_cpp"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
 
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -S .
-
-      - name: build_bmi_c++_tests
-        run: cmake --build cmake_build --target test_bmi_cpp -- -j ${{ env.MACOS_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_bmi_c++_tests
+      - name: Run Tests
         run: |
           cd ./cmake_build/test/
           ./test_bmi_cpp
           cd ../../
         timeout-minutes: 15
 
-      - name: clean_build
-        run: cmake --build cmake_build --target clean
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
-      - name: clean_shared_lib_build
-        run: cmake --build extern/test_bmi_cpp/cmake_build --target clean
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build.outputs.build-dir }}
 
-      - name: cleanup_dir
-        run: rm -rf cmake_build
-
-      - name: cleanup_shared_lib_dir
-        run: rm -rf extern/test_bmi_cpp/cmake_build
-
-  # Run BMI C tests in MacOS environment, and separating to isolate
+  # Run BMI C tests in linux environment, and separating to isolate
   test_bmi_c_macos_latest:
     # The type of runner that the job will run on
     runs-on: macos-latest
@@ -586,53 +365,21 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+      - name: Build Submodules
+        id: submod_build
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_c"
+          targets: "testbmicmodel"
 
-      - name: Cache Numpy Python Dependency
-        id: cache-numpy-py3-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: .venv
-          key: unix-numpy-py3-dep
-
-      - name: Get Numpy Python Dependency
-        if: steps.cache-numpy-py3-dep.outputs.cache-hit != 'true'
-        run: |
-          python3 -m venv .venv
-          . .venv/bin/activate
-          pip install pip
-          pip install numpy
-          deactivate
-
-      - name: cmake_init_shared_lib_build
-        run: cmake -B extern/test_bmi_c/cmake_build -S extern/test_bmi_c
-
-      - name: build_test_bmi_c_shared_lib
-        run: cmake --build extern/test_bmi_c/cmake_build --target testbmicmodel
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=ON -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_c_tests
-        run: cmake --build cmake_build --target test_bmi_c -- -j ${{ env.MACOS_NUM_PROC_CORES }}
-        timeout-minutes: 15
+          targets: "test_bmi_c"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          bmi_c: 'ON'
+          #Is this required for this test???
+          use_python: 'ON'
 
       - name: run_bmi_c_tests
         run: |
@@ -641,19 +388,15 @@ jobs:
           cd ../../
         timeout-minutes: 15
 
-      - name: clean_build
-        run: cmake --build cmake_build --target clean
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
-      - name: clean_shared_lib_build
-        run: cmake --build extern/test_bmi_c/cmake_build --target clean
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build.outputs.build-dir }}
 
-      - name: cleanup_dir
-        run: rm -rf cmake_build
-
-      - name: cleanup_shared_lib_dir
-        run: rm -rf extern/test_bmi_c/cmake_build
-
-  # As with the BMI C MacOS job, separate Fortran in MacOS tests to keep setups clean and cause of failures clear.
+  # As with the BMI C macos job, separate Fortran in linux tests to keep setups clean and cause of failures clear.
   test_bmi_fortran_macos_latest:
     # The type of runner that the job will run on
     runs-on: macos-latest
@@ -663,112 +406,64 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
+      - name: Build Submodules
+        id: submod_build_1
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_fortran/"
+      
+      - name: Build Submodules
+        id: submod_build_2
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/iso_c_fortran_bmi/"
 
-      - name: cmake_init_test_lib_build
-        run: cmake -B extern/test_bmi_fortran/cmake_build -DCMAKE_Fortran_COMPILER:FILEPATH=$(which gfortran-11) -S extern/test_bmi_fortran
-
-      - name: build_test_bmi_fortran_shared_lib
-        run: |
-          cd extern/test_bmi_fortran/cmake_build
-          make
-          cd ../../../
-
-      - name: cmake_init_fortran_iso_c_lib_build
-        run: cmake -B extern/iso_c_fortran_bmi/cmake_build -DCMAKE_Fortran_COMPILER:FILEPATH=$(which gfortran-11) -S extern/iso_c_fortran_bmi
-
-      - name: build_test_fortran_iso_c_shared_lib
-        run: |
-          cd extern/iso_c_fortran_bmi/cmake_build
-          make
-          cd ../../../
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: boost_1_72_0
-          key: unix-boost-dep
+          targets: "test_bmi_fortran"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          #is this required for this test?
+          bmi_c: 'ON'
+          bmi_fortran: 'ON'
 
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_FORTRAN_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=OFF -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_fortran_tests
-        run: cmake --build cmake_build --target test_bmi_fortran -- -j ${{ env.MACOS_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_bmi_fortran_tests
+      - name: Run Unit Tests
         run: |
           cd ./cmake_build/test/
           ./test_bmi_fortran
           cd ../../
         timeout-minutes: 15
 
-      - name: cleanup_builds
-        run: find . -name cmake_build -type d -delete
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
-  # As with the BMI C MacOS job, separate Python in MacOS tests to keep setups clean and cause of failures clear.
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_1.outputs.build-dir }}
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
+
+  # As with the BMI C macos job, separate Python in linux tests to keep setups clean and cause of failures clear.
   test_bmi_python_macos_latest:
     # The type of runner that the job will run on
     runs-on: macos-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
       - uses: actions/checkout@v2
 
-      - name: Init Submodules
-        run: git submodule update --init --recursive
-
-      - name: Cache Python Dependencies
-        id: cache-unix-py3-dependencies
-        uses: actions/cache@v1
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: .venv
-          key: unix-py3-dependencies
-
-      - name: Init Python Dependencies
-        if: steps.cache-unix-py3-dependencies.outputs.cache-hit != 'true'
-        run: |
-          python3 -m venv .venv
-          . .venv/bin/activate
-          pip install pip
-          pip install numpy
-          pip install -r extern/test_bmi_py/requirements.txt
-          deactivate
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DCMAKE_BUILD_TYPE=Debug -DBMI_C_LIB_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=ON -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_python_tests
-        run: cmake --build cmake_build --target test_bmi_python -- -j ${{ env.MACOS_NUM_PROC_CORES }}
-        timeout-minutes: 15
+          targets: "test_bmi_python"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          #is this required for this test?
+          bmi_c: 'ON'
+          use_python: 'ON'
+          additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
 
       - name: run_bmi_python_tests
         run: |
@@ -777,11 +472,10 @@ jobs:
           cd ../../
         timeout-minutes: 15
 
-      - name: cleanup
-        run: find . -name cmake_build -type d -delete
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
 
-
-  # As with the BMI C MacOS job, separate multi BMI in linux tests to keep setups clean and cause of failures clear.
+  # As with the BMI C macos job, separate multi BMI in linux tests to keep setups clean and cause of failures clear.
   test_bmi_multi_macos_latest:
     # The type of runner that the job will run on
     runs-on: macos-latest
@@ -791,79 +485,54 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Cache Python Dependencies
-        id: cache-unix-py3-dependencies
-        uses: actions/cache@v1
+      - name: Build Submodules
+        id: submod_build_1
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_fortran/"
+
+      - name: Build Submodules
+        id: submod_build_2
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/iso_c_fortran_bmi/"
+
+      - name: Build Submodules
+        id: submod_build_3
+        uses: ./.github/actions/ngen-submod-build
+        with: 
+          mod-dir: "extern/test_bmi_c/"
+          targets: "testbmicmodel"
+
+      - name: Build Unit Tests
+        uses: ./.github/actions/ngen-build
         with:
-          path: .venv
-          key: unix-py3-dependencies
+          targets: "test_bmi_multi"
+          build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
+          bmi_c: 'ON'
+          bmi_fortran: 'ON'
+          use_python: 'ON'
+          additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
 
-      - name: Init Python Dependencies
-        if: steps.cache-unix-py3-dependencies.outputs.cache-hit != 'true'
-        run: |
-          python3 -m venv .venv
-          . .venv/bin/activate
-          pip install pip
-          pip install numpy
-          pip install -r extern/test_bmi_py/requirements.txt
-          deactivate
-
-      - name: Init Submodules
-        run: git submodule update --init --recursive
-
-      - name: cmake_init_test_lib_build
-        run: cmake -B extern/test_bmi_fortran/cmake_build -DCMAKE_Fortran_COMPILER:FILEPATH=$(which gfortran-11) -S extern/test_bmi_fortran
-
-      - name: build_test_bmi_fortran_shared_lib
-        run: |
-          cd extern/test_bmi_fortran/cmake_build
-          make
-          cd ../../../
-
-      - name: cmake_init_fortran_iso_c_lib_build
-        run: cmake -B extern/iso_c_fortran_bmi/cmake_build -DCMAKE_Fortran_COMPILER:FILEPATH=$(which gfortran-11) -S extern/iso_c_fortran_bmi
-
-      - name: build_test_fortran_iso_c_shared_lib
-        run: |
-          cd extern/iso_c_fortran_bmi/cmake_build
-          make
-          cd ../../../
-
-      - name: cmake_init_shared_lib_build
-        run: cmake -B extern/test_bmi_c/cmake_build -S extern/test_bmi_c
-
-      - name: build_test_bmi_c_shared_lib
-        run: cmake --build extern/test_bmi_c/cmake_build --target testbmicmodel
-
-      - name: Cache Boost Dependency
-        id: cache-boost-dep
-        uses: actions/cache@v1
-        with:
-          path: boost_1_72_0
-          key: unix-boost-dep
-
-      - name: Get Boost Dependency
-        if: steps.cache-boost-dep.outputs.cache-hit != 'true'
-        run: |
-          curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
-          tar xjf boost_1_72_0.tar.bz2
-
-      - name: cmake_init_build
-        run: |
-          export BOOST_ROOT="$(pwd)/boost_1_72_0"
-          [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
-          cmake -B cmake_build -DBMI_C_LIB_ACTIVE:BOOL=ON -DBMI_FORTRAN_ACTIVE:BOOL=ON -DNGEN_ACTIVATE_PYTHON:BOOL=ON -DUDUNITS_ACTIVE:BOOL=ON -S .
-
-      - name: build_bmi_multi_tests
-        run: cmake --build cmake_build --target test_bmi_multi -- -j ${{ env.MACOS_NUM_PROC_CORES }}
-        timeout-minutes: 15
-
-      - name: run_bmi_multi_tests
+      - name: Run Unit Tests
         run: ./cmake_build/test/test_bmi_multi
         timeout-minutes: 15
 
-      - name: cleanup_builds
-        run: find . -name cmake_build -type d -delete
+      - name: Clean Up Unit Test Build
+        uses: ./.github/actions/clean-build
+
+      - name: Clean Up Submodule Build
+        uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_1.outputs.build-dir }}
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_2.outputs.build-dir }}
+      - uses: ./.github/actions/clean-build
+        with:
+          build-dir: ${{ steps.submod_build_3.outputs.build-dir }}
+
+
 
   # TODO: fails due to compilation error, at least in large part due to use of POSIX functions not supported on Windows.
   # TODO: Need to determine whether Windows support (in particular, development environment support) is necessary.

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,8 @@
 	url = https://github.com/pybind/pybind11
 [submodule "extern/t-route"]
 	path = extern/t-route
-	url = https://github.com/jdmattern-noaa/t-route.git
-  branch = ngen-routing2
+	url = https://github.com/noaa-owp/t-route.git
+  branch = ngen
 [submodule "extern/cfe/cfe"]
 	path = extern/cfe/cfe
 	url = https://github.com/NOAA-OWP/cfe.git

--- a/data/example_bmi_multi_realization_config__macos.json
+++ b/data/example_bmi_multi_realization_config__macos.json
@@ -1,0 +1,74 @@
+{
+    "global": {
+        "formulations": [
+            {
+                "name": "bmi_multi",
+                "params": {
+                    "model_type_name": "bmi_multi_noahowp_cfe",
+                    "forcing_file": "",
+                    "init_config": "",
+                    "allow_exceed_end_time": true,
+                    "main_output_variable": "Q_OUT",
+                    "modules": [
+                        {
+                            "name": "bmi_fortran",
+                            "params": {
+                                "model_type_name": "bmi_fortran_noahowp",
+                                "library_file": "./extern/noah-owp-modular/cmake_build/libsurfacebmi.dylib",
+                                "forcing_file": "",
+                                "init_config": "./data/bmi/fortran/noah-owp-modular-init-{{id}}.namelist.input",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "QINSUR",
+                                "variables_names_map": {
+                                    "PRCPNONC": "atmosphere_water__liquid_equivalent_precipitation_rate",
+                                    "Q2": "atmosphere_air_water~vapor__relative_saturation",
+                                    "SFCTMP": "land_surface_air__temperature",
+                                    "UU": "land_surface_wind__x_component_of_velocity",
+                                    "VV": "land_surface_wind__y_component_of_velocity",
+                                    "LWDN": "land_surface_radiation~incoming~longwave__energy_flux",
+                                    "SOLDN": "land_surface_radiation~incoming~shortwave__energy_flux",
+                                    "SFCPRS": "land_surface_air__pressure"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_cfe",
+                                "library_file": "./extern/cfe/cmake_build/libcfebmi.dylib",
+                                "forcing_file": "",
+                                "init_config": "./data/bmi/c/cfe/{{id}}_bmi_config.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "Q_OUT",
+                                "registration_function": "register_bmi_cfe",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "ETRAN",
+                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
+                                    "land_surface_air__temperature": "TMP_2maboveground",
+                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
+                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
+                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
+                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
+                                    "land_surface_air__pressure": "PRES_surface"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        }
+                    ],
+                    "uses_forcing_file": false
+                }
+            }
+        ],
+        "forcing": {
+            "file_pattern": ".*{{id}}.*..csv",
+            "path": "./data/forcing/",
+            "provider": "CsvPerFeature"
+        }
+    },
+    "time": {
+        "start_time": "2015-12-01 00:00:00",
+        "end_time": "2015-12-30 23:00:00",
+        "output_interval": 3600
+    }
+}

--- a/extern/test_bmi_cpp/CMakeLists.txt
+++ b/extern/test_bmi_cpp/CMakeLists.txt
@@ -15,6 +15,8 @@ else()
 endif()
 
 target_include_directories(testbmicppmodel PRIVATE include)
+#Where to look for bmi header, depending on where cmake is run from
+target_include_directories(testbmicppmodel PRIVATE ../bmi-cxx/ )
 
 set_target_properties(testbmicppmodel PROPERTIES VERSION ${PROJECT_VERSION})
 

--- a/extern/test_bmi_cpp/extern/bmi-cxx/bmi.hxx
+++ b/extern/test_bmi_cpp/extern/bmi-cxx/bmi.hxx
@@ -1,4 +1,0 @@
-//Since test_bmi_cpp is currently part of the ngen repo, this will just refer to its submodule
-//for now. If this ever gets broken out into its own project, this directory should be replaced
-//with a git submodule checkout of bmi-cxx.
-#include "../../../bmi-cxx/bmi.hxx"

--- a/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
+++ b/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include "../extern/bmi-cxx/bmi.hxx"
+#include "bmi.hxx"
 
 #define TRUE 1
 #define FALSE 0

--- a/src/routing/Routing_Py_Adapter.cpp
+++ b/src/routing/Routing_Py_Adapter.cpp
@@ -11,7 +11,7 @@ Routing_Py_Adapter::Routing_Py_Adapter(std::string t_route_config_file_with_path
   t_route_config_path(t_route_config_file_with_path){
   //Import ngen_main.  Will throw error if module isn't available
   //in the embedded interperters PYTHON_PATH
-  this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("ngen_main");
+  this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("ngen_routing.ngen_main");
   }
 
 void Routing_Py_Adapter::route(int number_of_timesteps, int delta_time,


### PR DESCRIPTION
To better manage the expansion of unit and integration tests, a cleanup of the CI workflows and actions was required.

## Additions

- An `ngen-build` composite action
- An `ngen-submod-build` composite action
- A `clean-build` composite action

## Changes

- Refactor tests to reuse the composite actions, parametrize appropriately based on runner/strategy

## Testing

1. All actions tested on my fork

## Todos

- Clean up caching???

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- GitHub CI
