### PR TITLE
allow the use of "all" to define catchment and nexus subsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ If the software is configurable, describe it in detail, either here or in other 
 
 To run the *ngen* engine, the following command line positional arguments are supported:
 - _catchment_data_path_ -- path to catchment data geojson input file.
-- _catchment subset ids_ -- list of comma separated ids (NO SPACES!!!) to subset the catchment data, i.e. 'cat-0,cat-1'
+- _catchment subset ids_ -- list of comma separated ids (NO SPACES!!!) to subset the catchment data, i.e. 'cat-0,cat-1', an empty string or "all" will use all catchments in the hydrofabric
 - _nexus_data_path_ -- path to nexus data geojson input file
-- _nexus subset ids_ -- list of comma separated ids (NO SPACES!!!) to subset the nexus data, i.e. 'nex-0,nex-1'
+- _nexus subset ids_ -- list of comma separated ids (NO SPACES!!!) to subset the nexus data, i.e. 'nex-0,nex-1', an empty string or "all" will use all nexus points
 - _realization_config_path_ -- path to json configuration file for realization/formulations associated with the hydrofabric inputs
 - _partition_config_path_ -- path to the partition json config file, when using the driver with [distributed processing](doc/DISTRIBUTED_PROCESSING.md).
 - `--subdivided-hydrofabric` -- an explicit, optional flag, when using the driver with [distributed processing](doc/DISTRIBUTED_PROCESSING.md), to indicate to the driver processes that they should operate on process-specific subdivided hydrofabric files.
@@ -57,8 +57,9 @@ To run the *ngen* engine, the following command line positional arguments are su
 An example of a complete invocation to run a subset of a hydrofabric.  If the realization configuration doesn't contain catchment definitions for the subset keys provided, the default `global` configuration is used.  Alternatively, if the realization configuration contains definitions that are not in the subset (or hydrofabric) keys, then a warning is produced and the formulation isn't created.
 `./cmake-build-debug/ngen ./data/catchment_data.geojson "cat-27,cat-52" ./data/nexus_data.geojson "nex-26,nex-34" ./data/example_realization_config.json`
 
-To simulate every catchment in the input hydrofabric, leave the subset lists empty, i.e.:
+To simulate every catchment in the input hydrofabric, leave the subset lists empty, or use "all" i.e.:
 `ngen ./data/catchment_data.geojson "" ./data/nexus_data.geojson "" ./data/refactored_example_realization_config.json`
+`ngen ./data/catchment_data.geojson "all" ./data/nexus_data.geojson "all" ./data/refactored_example_realization_config.json`
 
 Examples specific to running with with distributed processing can be found [here](doc/DISTRIBUTED_PROCESSING.md#examples).
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -78,9 +78,9 @@ int main(int argc, char *argv[]) {
     //Use "positional args"
     //arg 0 is program name
     //arg 1 is catchment_data file path
-    //arg 2 is catchment subset ids, comma seperated string of ids (no spaces!), "" for all
+    //arg 2 is catchment subset ids, comma seperated string of ids (no spaces!), "all" for all
     //arg 3 is nexus_data file path
-    //arg 4 is nexus subset ids, comma seperated string of ids (no spaces!), "" for all
+    //arg 4 is nexus subset ids, comma seperated string of ids (no spaces!), "all" for all
     //arg 5 is realization config path
     //arg 7 is the partition file path
     //arg 8 is an optional flag that driver should, if not already preprocessed this way, subdivided the hydrofabric
@@ -176,7 +176,11 @@ int main(int argc, char *argv[]) {
 
         //split the subset strings into vectors
         boost::split(catchment_subset_ids, argv[2], [](char c){return c == ','; } );
+        if( catchment_subset_ids.size() == 1 && catchment_subset_ids[0] == "all")
+          catchment_subset_ids.pop_back();
         boost::split(nexus_subset_ids, argv[4], [](char c){return c == ','; } );
+        if( nexus_subset_ids.size() == 1 && nexus_subset_ids[0] == "all")
+          nexus_subset_ids.pop_back();
         //If a single id or no id is passed, the subset vector will have size 1 and be the id or the ""
         //if we get an empy string, pop it from the subset list.
         if(nexus_subset_ids.size() == 1 && nexus_subset_ids[0] == "") nexus_subset_ids.pop_back();


### PR DESCRIPTION
Due to various shell handling of empty strings, using this as an input to ngen can become complicated.  This PR allows the string "all" to be used as an input for catchment and nexus subsets to indicate the use of the entire hydrofabric.

## Changes

- - option to use `all` as an input string for catchment and nexus subsets.  Empty strings still work as well.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS