### PR TITLE
Fix output_variables

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -67,6 +67,7 @@ runs:
           run: |
             if [ ${{ runner.os }} == 'Linux' ]
             then
+              sudo apt-get update
               sudo apt-get install -y --fix-missing libnetcdf-dev libnetcdff-dev
             elif [ ${{ runner.os }} == 'macOS' ]
             then

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -282,7 +282,7 @@ namespace realization {
          */
         long get_data_start_time() override
         {
-            throw runtime_error("Bmi_Modular_Formulation does not yet implement get_data_start_time");
+            return this->get_bmi_model()->GetStartTime();
         }
 
         /**

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -619,8 +619,7 @@ namespace realization {
             // Otherwise, we have a provider, and we can cast it based on the documented assumptions
             try {
                 std::shared_ptr <Bmi_Module_Formulation<bmi::Bmi>> nested_module =
-                        std::dynamic_pointer_cast < Bmi_Module_Formulation <
-                                bmi::Bmi >> (data_provider_iter->second);
+                        std::reinterpret_pointer_cast<Bmi_Module_Formulation<bmi::Bmi>>(data_provider_iter->second);
                 return nested_module->get_var_value_as_double(index, var_name);
             }
             // If there was any problem with the cast and extraction of the value, throw runtime error

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -422,6 +422,15 @@ namespace realization {
             return modules[get_index_for_primary_module()]->get_model_end_time();
         }
 
+        /**
+         * Get the end time for the primary nested BMI model in its native format and units.
+         *
+         * @return The end time for the primary nested BMI model in its native format and units.
+         */
+        const double get_model_start_time() {
+            return modules[get_index_for_primary_module()]->get_data_start_time();
+        }
+
         string get_output_line_for_timestep(int timestep, std::string delimiter) override;
 
         double get_response(time_step_t t_index, time_step_t t_delta) override;
@@ -620,7 +629,17 @@ namespace realization {
             try {
                 std::shared_ptr <data_access::GenericDataProvider> nested_module =
                         std::dynamic_pointer_cast<data_access::GenericDataProvider>(data_provider_iter->second);
-                auto selector = CatchmentAggrDataSelector("",var_name,this->get_model_current_time(),this->record_duration(),"1");
+                long nested_module_time = nested_module->get_data_start_time() + ( this->get_model_current_time() - this->get_model_start_time() );
+                cerr<<"nested_module start: "<< nested_module->get_data_start_time() << " multibmi start: "<< this->get_data_start_time() <<std::endl;
+                cerr<<"this->get_data_start_time():    "<< this->get_data_start_time() << std::endl
+                    <<"      get_data_stop_time():     "<< this->get_data_stop_time() << std::endl
+                    <<"      get_model_current_time(): "<< this->get_model_current_time() << std::endl
+                    <<"      get_model_start_time():   "<< this->get_model_start_time() << std::endl
+                    <<"      get_model_end_time():     "<< this->get_model_end_time() << std::endl
+                    <<"      convert_model_time(...):  "<< this->convert_model_time(this->get_model_current_time()) << std::endl
+                    <<"      get_bmi_model_start_time_forcing_offset_s():  "<< this->get_bmi_model_start_time_forcing_offset_s() << std::endl
+                    <<"so, nested_module_time = " << nested_module_time << std::endl;
+                auto selector = CatchmentAggrDataSelector("",var_name,nested_module_time,this->record_duration(),"1");
                 //TODO: After merge PR#405, try re-adding support for index
                 return nested_module->get_value(selector);
             }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -630,15 +630,6 @@ namespace realization {
                 std::shared_ptr <data_access::GenericDataProvider> nested_module =
                         std::dynamic_pointer_cast<data_access::GenericDataProvider>(data_provider_iter->second);
                 long nested_module_time = nested_module->get_data_start_time() + ( this->get_model_current_time() - this->get_model_start_time() );
-                cerr<<"nested_module start: "<< nested_module->get_data_start_time() << " multibmi start: "<< this->get_data_start_time() <<std::endl;
-                cerr<<"this->get_data_start_time():    "<< this->get_data_start_time() << std::endl
-                    <<"      get_data_stop_time():     "<< this->get_data_stop_time() << std::endl
-                    <<"      get_model_current_time(): "<< this->get_model_current_time() << std::endl
-                    <<"      get_model_start_time():   "<< this->get_model_start_time() << std::endl
-                    <<"      get_model_end_time():     "<< this->get_model_end_time() << std::endl
-                    <<"      convert_model_time(...):  "<< this->convert_model_time(this->get_model_current_time()) << std::endl
-                    <<"      get_bmi_model_start_time_forcing_offset_s():  "<< this->get_bmi_model_start_time_forcing_offset_s() << std::endl
-                    <<"so, nested_module_time = " << nested_module_time << std::endl;
                 auto selector = CatchmentAggrDataSelector("",var_name,nested_module_time,this->record_duration(),"1");
                 //TODO: After merge PR#405, try re-adding support for index
                 return nested_module->get_value(selector);


### PR DESCRIPTION
Fixes a crash when using `"output_variables"` key in `Bmi_Multi_Formulation` caused by failing static cast of templated classes. Switches the implementation to use `DataProvider` interface which requires simpler casts--and allows for inclusion of fields from forcing data as well.

## Additions

- 

## Removals

-

## Changes

- Fixed `get_var_value_as_double(std::string)` method

## Testing

1. Automated test `GetOutputLineForTimestep_3_a` added, passes.

## Screenshots


## Notes

-

## Todos

- Compution of time offsets is a little brute-forced... there may be a more elegant (or complete) way to do it, but this seems to function.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. See workflow runner output

### Target Environment support

- [x] Linux
