### PR TITLE
Adds pthreads dependency for UnitsHelper

### DIFF
--- a/src/core/mediator/CMakeLists.txt
+++ b/src/core/mediator/CMakeLists.txt
@@ -9,6 +9,8 @@ if(UDUNITS_ACTIVE)
         target_link_libraries(core_mediator PUBLIC libudunits2)
 endif()
 
+find_package(Threads REQUIRED)
+
 target_include_directories(core_mediator PUBLIC
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/include/core
@@ -17,4 +19,5 @@ target_include_directories(core_mediator PUBLIC
 
 target_link_libraries(core_mediator PUBLIC
         Boost::boost                # Headers-only Boost
+        Threads::Threads
         )


### PR DESCRIPTION
Adds explicit dependency on threading for unit conversion (in core_mediator library). This eliminates "Unknown error -1" messages from the unit conversion code and makes output match between builds with _no_ MPI or Python enabled and builds with MPI or Python (or both) enabled. (Enabling Python or MPI causes pthreads to be linked implicitly.) Without this, all unit conversion fails if ngen is built without Python or MPI, which resulted in a mismatch in output between builds without Python/MPI and builds with either.

## Additions

- Added CMakeLists directives to require pthreads

## Removals

-

## Changes

-

## Testing

1. Manual tests on builds without Python or MPI, checking/comparing output with Python/MPI enabled builds. (Notably: GoogleTest builds with pthreads, so the automated tests pass without this fix!)

2. Checking binary dependencies with `ldd`

## Screenshots


## Notes

-

## Todos

- 

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. 

### Target Environment support

- [X] Linux
