### PR TITLE
Optimize unit conversion by reusing `cv_converters`

### DIFF
--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -1,4 +1,6 @@
 #include <udunits2.h>
+#include <map>
+#include <memory>
 #include <mutex>
 #include "all.h"
 
@@ -14,9 +16,13 @@ class UnitsHelper {
     static double* convert_values(const std::string &in_units, double* values, const std::string &out_units, double* out_values, const size_t & count);
 
     private:
-    static cv_converter* get_converter(const std::string &in_units, const std::string& out_units, ut_unit*& to, ut_unit*& from);
+     
     // Theoretically thread-safe. //TODO: Test?
     static ut_system* unit_system;
+
+    static std::map<std::string, std::shared_ptr<cv_converter>> converters;
+    static std::mutex converters_mutex;
+
     static std::once_flag unit_system_inited;
     static void init_unit_system(){
         #ifdef NGEN_UDUNITS2_XML_PATH
@@ -32,6 +38,8 @@ class UnitsHelper {
         ut_set_error_message_handler(ut_ignore);
         #endif
     }
+
+    static std::shared_ptr<cv_converter> get_converter(const std::string& in_units, const std::string& out_units, utEncoding in_encoding = UT_UTF8, utEncoding out_encoding = UT_UTF8 );
 
 };
 


### PR DESCRIPTION
Callgrind analysis showed a >10% of runtime spent in `get_converted_value` largely because of `ut_parse` when creating unit representations. This was a known unoptimized point, but the impact was higher than expected. This PR optimizes the unit conversion pipeline.

## Additions

- Adds a static/global cache of converters that are reused instead of recreated. Basic thread safety is attempted for future-proofing.

## Removals

-

## Changes

-

## Testing

1. Automated tests are passing. No API surface changes.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
