### PR TITLE
Set tag to rockylinux:8 explicitly

### DIFF
--- a/docker/CENTOS_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_NGEN_RUN.dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux as builder
+FROM rockylinux:8 as builder
 
 RUN yum update -y \
     && yum install -y dnf-plugins-core \


### PR DESCRIPTION
This sets the tag that was getting chosen explicitly as `latest`, looks like they dropped `latest` when they added the `9` version tag.

## Additions

-

## Removals

-

## Changes

- Explicitly set tag to `:8`

## Testing

1.  Fixes test runner

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
