### PR TITLE
Change default forcing provider to CsvPerFeature, deprecate `Forcing` class

### DIFF
--- a/include/forcing/Forcing.h
+++ b/include/forcing/Forcing.h
@@ -33,7 +33,7 @@
 /**
  * @brief Forcing class providing time-series precipiation forcing data to the model.
  */
-class Forcing : public data_access::GenericDataProvider
+class [[deprecated("Legacy Forcing object will be removed soon.")]] Forcing : public data_access::GenericDataProvider
 {
     public:
 

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -95,13 +95,13 @@ namespace realization {
         }
 
         //TODO: VERY BAD JUJU...the following two members are an ugly hack to avoid having to gut the legacy C/C++ realizations for now.
-        Forcing legacy_forcing;
+        Forcing* legacy_forcing;
         // Use this a a deprecation chokepoint to get rid of Forcing when ready.
         [[deprecated]]
         void _link_legacy_forcing()
         {
             void* f { this->forcing.get() };
-            legacy_forcing = *((Forcing *)f);
+            legacy_forcing = ((Forcing *)f);
         }
     };
 }

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -70,12 +70,11 @@ namespace realization {
     ) {
         constructor formulation_constructor = formulations.at(formulation_type);
         std::shared_ptr<data_access::GenericDataProvider> fp;
-        if (formulation_type == "tshirt" || formulation_type == "tshirt_c"  || formulation_type == "lstm" // These formulations are still using the legacy interface!
-            || forcing_config.provider == "" || forcing_config.provider == "legacy" // Permit legacy Forcing class with BMI formulations and simple_lumped--don't break old configs
+        if (formulation_type == "tshirt"  || formulation_type == "tshirt_c"  || formulation_type == "lstm" // These formulations are still using the legacy interface!
             ){
             fp = std::make_shared<Forcing>(forcing_config);
         }
-        else if (forcing_config.provider == "CsvPerFeature"){
+        else if (forcing_config.provider == "CsvPerFeature" || forcing_config.provider == ""){
             fp = std::make_shared<CsvPerFeatureForcingProvider>(forcing_config);
         }
 #ifdef NETCDF_ACTIVE

--- a/src/realizations/catchment/Tshirt_C_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_C_Realization.cpp
@@ -434,7 +434,7 @@ double Tshirt_C_Realization::get_response(time_step_t t_index, time_step_t t_del
     //  forcing.  It may actually belong within the forcing object.
 
     // TODO: it also needs to account for getting the right precip data point (i.e., t_index may not be "next")
-    double precip = this->legacy_forcing.get_next_hourly_precipitation_meters_per_second();
+    double precip = this->legacy_forcing->get_next_hourly_precipitation_meters_per_second();
     int response_result = run_formulation_for_timestep(precip, t_delta_s);
     // TODO: check t_index is the next expected time step to be calculated
 

--- a/src/realizations/catchment/Tshirt_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_Realization.cpp
@@ -92,7 +92,7 @@ double Tshirt_Realization::get_response(time_step_t t_index, time_step_t t_delta
     //FIXME doesn't do anything, don't call???
     //add_time(t+1, params.nash_n);
     // TODO: this is problematic, because what happens if the wrong t_index is passed?
-    double precip = this->legacy_forcing.get_next_hourly_precipitation_meters_per_second();
+    double precip = this->legacy_forcing->get_next_hourly_precipitation_meters_per_second();
     //FIXME should this run "daily" or hourly (t) which should really be dt
     //Do we keep an "internal dt" i.e. this->dt and reconcile with t?
     int error = model->run(t_index, precip * t_delta_s / 1000, get_et_params_ptr());


### PR DESCRIPTION
Change default forcing provider to CsvPerFeature, deprecate `Forcing` class. `Tshirt_Realization` and `Tshirt_C_Realization` still require it, and so probably does `LSTM_Realization`.

## Additions

-

## Removals

- Deprecates `Forcing` class (but does not remove it)

## Changes

- Changes the default `DataProvider` that is used and assigned to the `forcing` member of `HY_CatchmentArea` from `Forcing` to `CsvPerFeatureForcingProvider` when the `"provider"` key in the blank is missing (or when `"legacy"` is provided, which now effectively does nothing).
- Changes the way `link_legacy_forcing` works so that the `legacy_forcing` member is a pointer instead of a value--which was creating an empty object--which:
  - Cluttered traces if you were trying to figure out where `Forcing` was still used
  - Created an empty object that would return `0`'s for values, which caused legacy models to "work" and look like they were fine even if `link_legacy_forcing` didn't!

## Testing

1. All existing tests passing. Validated that disabling 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
