### PR TITLE
Deal with shared lib file not found failures due to OS file extension mismatch

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -63,10 +63,6 @@ jobs:
       - name: Run surfacebmi plus cfebmi
         run: |
           inputfile='data/example_bmi_multi_realization_config.json'
-          if [ ${{ runner.os }} == 'macOS' ] 
-          then
-              inputfile=data/example_bmi_multi_realization_config__macos.json
-          fi
           ./cmake_build/ngen data/catchment_data.geojson "cat-27" data/nexus_data.geojson "nex-26" $inputfile
 
 # Run t-route/pybind integration test

--- a/data/example_bmi_multi_realization_config.json
+++ b/data/example_bmi_multi_realization_config.json
@@ -14,7 +14,7 @@
                             "name": "bmi_fortran",
                             "params": {
                                 "model_type_name": "bmi_fortran_noahowp",
-                                "library_file": "./extern/noah-owp-modular/cmake_build/libsurfacebmi.so",
+                                "library_file": "./extern/noah-owp-modular/cmake_build/libsurfacebmi",
                                 "forcing_file": "",
                                 "init_config": "./data/bmi/fortran/noah-owp-modular-init-{{id}}.namelist.input",
                                 "allow_exceed_end_time": true,
@@ -36,7 +36,7 @@
                             "name": "bmi_c",
                             "params": {
                                 "model_type_name": "bmi_c_cfe",
-                                "library_file": "./extern/cfe/cmake_build/libcfebmi.so",
+                                "library_file": "./extern/cfe/cmake_build/libcfebmi",
                                 "forcing_file": "",
                                 "init_config": "./data/bmi/c/cfe/{{id}}_bmi_config.ini",
                                 "allow_exceed_end_time": true,

--- a/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
+++ b/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
@@ -94,9 +94,19 @@ namespace models {
                     std::string alt_bmi_lib_file;                    
                     if(bmi_lib_file.substr(idx) == ".so"){
                         alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".dylib";
-                    } else {
+                    } else if(bmi_lib_file.substr(idx) == ".dylib"){
                         alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".so";
+                    } else {
+                        // Try appending instead of replacing...
+                        #ifdef __APPLE__
+                        alt_bmi_lib_file = bmi_lib_file + ".dylib";
+                        #else
+                        #ifdef __GNUC__
+                        alt_bmi_lib_file = bmi_lib_file + ".so";
+                        #endif // __GNUC__
+                        #endif // __APPLE__
                     }
+                    //TODO: Try looking in e.g. /usr/lib, /usr/local/lib, $LD_LIBRARY_PATH... try pre-pending "lib"...
                     if (utils::FileChecker::file_is_readable(alt_bmi_lib_file)) {
                         bmi_lib_file = alt_bmi_lib_file;
                     } else {

--- a/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
+++ b/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
@@ -89,9 +89,22 @@ namespace models {
                     return;
                 }
                 if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {
-                    this->init_exception_msg =
-                            "Can't init " + this->model_name + "; unreadable shared library file '" + bmi_lib_file + "'";
-                    throw std::runtime_error(this->init_exception_msg);
+                    //Try alternative extension...
+                    size_t idx = bmi_lib_file.rfind(".");
+                    std::string alt_bmi_lib_file;                    
+                    if(bmi_lib_file.substr(idx) == ".so"){
+                        alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".dylib";
+                    } else {
+                        alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".so";
+                    }
+                    if (utils::FileChecker::file_is_readable(alt_bmi_lib_file)) {
+                        bmi_lib_file = alt_bmi_lib_file;
+                    } else {
+                        this->init_exception_msg =
+                                "Can't init " + this->model_name + "; unreadable shared library file '" + bmi_lib_file + "'";
+                        throw std::runtime_error(this->init_exception_msg);
+                    }
+
                 }
 
                 // Call first to ensure any previous error is cleared before trying to load the symbol


### PR DESCRIPTION
Causes  `AbstractCLibBmiAdapter.hpp` to add the appropriate extension if missing (`.so` or .`dylib`) *or* try the alternative extension, for a `library_file` if the path provided was not readable.  This lets us collapse at least some places in tests that require multiple files/code just to get around this OS difference.

## Additions

- Fallback handler in `AbstractCLibBmiAdapter.hpp`

## Removals

- 

## Changes

- Removed use of `__macos` realization file from `Run surfacebmi plus cfebmi` test... does not delete this realization file... should we?

## Testing

1. Test `Run surfacebmi plus cfebmi` now uses the Linux realization file (with <strike>`.so`</strike> extensionless path to dylib file) on macOS and Linux tests and succeeds.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. 

### Target Environment support

- [X] Linux
