### PR TITLE
Fix NetCDFPerFeatureDataProvider returning the same forcing for all catchments

### DIFF
--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1118,7 +1118,7 @@ namespace realization {
                                                                            varItemSize);
                 if (varItemSize != get_bmi_model()->GetVarNbytes(var_name)) {
                     //more than a single value needed for var_name
-                    auto values = provider->get_values(CatchmentAggrDataSelector("",var_map_alias, model_epoch_time, t_delta,
+                    auto values = provider->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
                     //need to marshal data types to the reciever as well
                     //this could be done a little more elegantly if the provider interface were
@@ -1127,7 +1127,7 @@ namespace realization {
 
                 } else {
                     //scalar value
-                    double value = provider->get_value(CatchmentAggrDataSelector("",var_map_alias, model_epoch_time, t_delta,
+                    double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
                     value_ptr = get_value_as_type(type, value);      
                 }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -486,7 +486,7 @@ namespace realization {
             if (availableData.empty() || availableData.find(output_name) == availableData.end()) {
                 throw runtime_error(get_formulation_type() + " cannot get output value for unknown " + output_name + SOURCE_LOC);
             }
-            return availableData[output_name]->get_value(CatchmentAggrDataSelector("",output_name, init_time, duration_s, output_units), m);
+            return availableData[output_name]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),output_name, init_time, duration_s, output_units), m);
         }
 
         std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
@@ -499,7 +499,7 @@ namespace realization {
             if (availableData.empty() || availableData.find(output_name) == availableData.end()) {
                 throw runtime_error(get_formulation_type() + " cannot get output values for unknown " + output_name + SOURCE_LOC);
             }
-            return availableData[output_name]->get_values(CatchmentAggrDataSelector("",output_name, init_time, duration_s, output_units), m);
+            return availableData[output_name]->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),output_name, init_time, duration_s, output_units), m);
         }
 
         bool is_bmi_input_variable(const string &var_name) override;
@@ -644,7 +644,7 @@ namespace realization {
                 std::shared_ptr <data_access::GenericDataProvider> nested_module =
                         std::dynamic_pointer_cast<data_access::GenericDataProvider>(data_provider_iter->second);
                 long nested_module_time = nested_module->get_data_start_time() + ( this->get_model_current_time() - this->get_model_start_time() );
-                auto selector = CatchmentAggrDataSelector("",var_name,nested_module_time,this->record_duration(),"1");
+                auto selector = CatchmentAggrDataSelector(this->get_catchment_id(),var_name,nested_module_time,this->record_duration(),"1");
                 //TODO: After merge PR#405, try re-adding support for index
                 return nested_module->get_value(selector);
             }

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -14,9 +14,17 @@ namespace realization {
     class Catchment_Formulation : public Formulation, public HY_CatchmentArea, public Et_Accountable {
         public:
             Catchment_Formulation(std::string id, std::shared_ptr<data_access::GenericDataProvider> forcing, utils::StreamHandler output_stream)
-                : Formulation(id), HY_CatchmentArea(forcing, output_stream) { };
+                : Formulation(id), HY_CatchmentArea(forcing, output_stream) { 
+                    // Assume the catchment ID is equal to or embedded in the formulation `id`
+                    size_t idx = id.find(".");
+                    cat_id = ( idx == std::string::npos ? id : id.substr(0, idx) );
+                };
 
-            Catchment_Formulation(std::string id) : Formulation(id){};
+            Catchment_Formulation(std::string id) : Formulation(id){
+                    // Assume the catchment ID is equal to or embedded in the formulation `id`
+                    size_t idx = id.find(".");
+                    cat_id = ( idx == std::string::npos ? id : id.substr(0, idx) );
+            };
 
         /**
          * Perform in-place substitution on the given config property item, if the item and the pattern are present.
@@ -103,6 +111,8 @@ namespace realization {
             void* f { this->forcing.get() };
             legacy_forcing = ((Forcing *)f);
         }
+    private:
+        std::string cat_id;
     };
 }
 #endif // CATCHMENT_FORMULATION_H

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -17,13 +17,13 @@ namespace realization {
                 : Formulation(id), HY_CatchmentArea(forcing, output_stream) { 
                     // Assume the catchment ID is equal to or embedded in the formulation `id`
                     size_t idx = id.find(".");
-                    cat_id = ( idx == std::string::npos ? id : id.substr(0, idx) );
+                    set_catchment_id( idx == std::string::npos ? id : id.substr(0, idx) );
                 };
 
             Catchment_Formulation(std::string id) : Formulation(id){
                     // Assume the catchment ID is equal to or embedded in the formulation `id`
                     size_t idx = id.find(".");
-                    cat_id = ( idx == std::string::npos ? id : id.substr(0, idx) );
+                    set_catchment_id( idx == std::string::npos ? id : id.substr(0, idx) );
             };
 
         /**
@@ -95,11 +95,11 @@ namespace realization {
 
     protected:
         std::string get_catchment_id() override {
-            return id;
+            return this->cat_id;
         }
 
         void set_catchment_id(std::string cat_id) override {
-            id = cat_id;
+            this->cat_id = cat_id;
         }
 
         //TODO: VERY BAD JUJU...the following two members are an ugly hack to avoid having to gut the legacy C/C++ realizations for now.

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -63,6 +63,16 @@ protected:
         return nested->get_var_value_as_double(var_name);
     }
 
+    static std::string get_friend_catchment_id(Bmi_Multi_Formulation& formulation){
+        return formulation.get_catchment_id();
+    }
+
+    template <class N>
+    static std::string get_friend_nested_catchment_id(const Bmi_Multi_Formulation& formulation, const int mod_index) {
+        std::shared_ptr<N> nested = std::static_pointer_cast<N>(formulation.modules[mod_index]);
+        return nested->get_catchment_id();
+    }
+
     /*
     static std::vector<nested_module_ptr> get_friend_nested_formulations(Bmi_Multi_Formulation& formulation) {
         return formulation.get_bmi_model();
@@ -787,6 +797,19 @@ TEST_F(Bmi_Multi_Formulation_Test, GetOutputLineForTimestep_3_a) {
     ASSERT_EQ(output, "0.000001112,199280.000000000,199240.000000000,199280.000000000,0.000000000,0.000001001");
 }
 
+/**
+ * Test if Catchment Ids of submodules correctly trim any suffix
+ */
+TEST_F(Bmi_Multi_Formulation_Test, GetIdAndCatchmentId) {
+    int ex_index = 3;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+    ASSERT_EQ(formulation.get_id(), "cat-27");
+    ASSERT_EQ(get_friend_catchment_id(formulation), "cat-27");
+    ASSERT_EQ(get_friend_nested_catchment_id<Bmi_Fortran_Formulation>(formulation, 0), "cat-27");
+    //ASSERT_EQ(formulation.get_catchment_id(), "id");
+}
 #endif // NGEN_BMI_C_LIB_ACTIVE || NGEN_BMI_FORTRAN_ACTIVE || ACTIVATE_PYTHON
 
 #endif // NGEN_BMI_MULTI_FORMULATION_TEST_CPP


### PR DESCRIPTION
The catchment ID was not being passed through to the selector. Rectified.

## Additions

- Made the value of `Catchment_Formulation::get_catchment_id()` be passed to selector constructors in `Bmi_Module_Formulation` and `Bmi_Multi_Formulation`

## Removals

-

## Changes

- Made `get_catchment_id()` trim any `.N` suffix from the realization IDs in the case of nested formulations.

## Testing

1. Minimal test added for the change to `get_catchment_id()`... some more work tests would probably be good for the whole pipeline, but that's either an integration test or would require more mocks.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. Additional test added as described above. All automated tests passing.

### Target Environment support

- [X] Linux
