### PR TITLE
Unit Conversion and Logging Tuneup

### DIFF
--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -163,7 +163,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         }
         catch (const std::runtime_error& e){
             #ifndef UDUNITS_QUIET
-            std::cerr<<"Unit conversion error: "<<std::endl<<e.what()<<std::endl<<"Returning unconverted value!"<<std::endl;
+            std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
             #endif
             return value;
         }

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -471,7 +471,7 @@ namespace data_access
             catch (const std::runtime_error& e)
             {
                 #ifndef UDUNITS_QUIET
-                std::cerr<<"Unit conversion error: "<<std::endl<<e.what()<<std::endl<<"Returning unconverted value!"<<std::endl;
+                std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
                 #endif
                 return rvalue;
             }

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -426,7 +426,9 @@ namespace realization {
                     return values;
                 }
                 catch (const std::runtime_error& e){
-                    std::cerr<<"Unit conversion error: "<<std::endl<<e.what()<<std::endl<<"Returning unconverted value!"<<std::endl;
+                    #ifndef UDUNITS_QUIET
+                    std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
+                    #endif
                     return values;
                 }
             }
@@ -487,7 +489,9 @@ namespace realization {
                     return UnitsHelper::get_converted_value(native_units, value, output_units);
                 }
                 catch (const std::runtime_error& e){
-                    std::cerr<<"Unit conversion error: "<<std::endl<<e.what()<<std::endl<<"Returning unconverted value!"<<std::endl;
+                    #ifndef UDUNITS_QUIET
+                    std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
+                    #endif
                     return value;
                 }
             }
@@ -835,12 +839,16 @@ namespace realization {
                         case geojson::PropertyType::Natural:
                             param.second.as_vector(long_vec);
                             value_ptr = get_values_as_type(type, long_vec.begin(), long_vec.end());
+                            #ifndef NGEN_QUIET
                             std::cout<<"NAT VALUE: "<<long_vec[0]<<std::endl;
+                            #endif
                             break;
                         case geojson::PropertyType::Real:
                             param.second.as_vector(double_vec);
                             value_ptr = get_values_as_type(type, double_vec.begin(), double_vec.end());
+                            #ifndef NGEN_QUIET
                             std::cout<<"REAL VALUE: "<<double_vec[0]<<std::endl;
+                            #endif
                             break;
                         /* Not currently supporting string parameter values
                         case geojson::PropertyType::String:

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -16,6 +16,10 @@ std::shared_ptr<cv_converter> UnitsHelper::get_converter(const std::string& in_u
 
     std::string key = in_units + "|" + out_units; //Better solution? Good enough? Bother with nested maps?
     if(converters.count(key) == 1){
+        if(converters[key] == nullptr){
+            // same as last throw below
+            throw std::runtime_error("Unable to convert " + in_units + " to " + out_units);
+        }
         return converters[key];
     } else {
         ut_unit* from = ut_parse(unit_system, in_units.c_str(), in_encoding);
@@ -34,6 +38,7 @@ std::shared_ptr<cv_converter> UnitsHelper::get_converter(const std::string& in_u
         {
             ut_free(from);
             ut_free(to);
+            converters[key] = nullptr;
             throw std::runtime_error("Unable to convert " + in_units + " to " + out_units);
         }
         auto c = std::shared_ptr<cv_converter>(


### PR DESCRIPTION
Improves performance in unconvertable scenarios and cleans up logging and `-DQUIET` compliance.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

- Conversions between incompatible units now have a `nullptr` "cached"... so the warning will happen faster without parsing the units strings again.
- Compressed unit conversion failure warnings into one line (from three), reducing effective noise level
- Unit conversion failures now explicitly say `WARN:` and do not include the word "error"... hopefully alleviating some confusion going forward.
- Caught a few more unit conversion messages that didn't respect `-DQUIET`
- Small tweak to non-units-related log messages that should be squelchable with `-DQUIET`.

## Testing

1. Re-ran all existing tests

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
