### PR TITLE
Partition optimization

### DIFF
--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -332,8 +332,8 @@ int find_remote_rank(const std::string& id, const PartitionVSet& catchment_parti
 int find_partition_connections(const std::string& nexus, const PartitionVSet& catchment_partitions, const int& partition_number,  const std::vector<std::string>& origin_ids_to_find, const std::vector<std::string>& destination_ids_to_find, RemoteConnectionVec& remote_connections )
 {
 
-    const std::string origination_cat_to_nex = "orig_cat-to-nex";
-    const std::string nex_to_destination_cat = "nex-to-dest_cat";
+    const static std::string origination_cat_to_nex = "orig_cat-to-nex";
+    const static std::string nex_to_destination_cat = "nex-to-dest_cat";
 
     if( partition_number < 0 || partition_number >= catchment_partitions.size() ){
         throw std::invalid_argument("find_partition_connections: partition_number not valid for catchment_partitions of size "+

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -252,19 +252,31 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
             cat_id_vec.push_back(it);
         }
     }
-
-    int i, j;
-    for (i = 0; i < cat_id_vec.size(); ++i) {
-        if (i%1000 == 0)
-            std::cout << "i = " << i << std::endl;
-        for (j = i+1; j < cat_id_vec.size(); ++j) {
-            if ( cat_id_vec[i] == cat_id_vec[j] )
-            {
-                std::cout << "catchment duplication" << std::endl;
-                exit(-1);
-            }
+    //sort ids
+    std::sort(cat_id_vec.begin(), cat_id_vec.end());
+    //create set of uniqe ids
+    std::set<std::string> unique(cat_id_vec.begin(), cat_id_vec.end());
+    std::set<std::string> duplicates;
+    //use set difference to identify all duplicates
+    std::set_difference(cat_id_vec.begin(), cat_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
+    if( duplicates.size() > 0 ){
+        for( auto& id: duplicates){
+            std::cout << "catchment "<<id<<" is duplicated!"<<std::endl;
         }
     }
+    //NJF Replace this O(n^2) duplication check with the above set difference algorithm (which should be O(n log n))
+    // int i, j;
+    // for (i = 0; i < cat_id_vec.size(); ++i) {
+    //     if (i%1000 == 0)
+    //         std::cout << "i = " << i << std::endl;
+    //     for (j = i+1; j < cat_id_vec.size(); ++j) {
+    //         if ( cat_id_vec[i] == cat_id_vec[j] )
+    //         {
+    //             std::cout << "catchment duplication" << std::endl;
+    //             exit(-1);
+    //         }
+    //     }
+    // }
     std::cout << "\nNumber of catchments is: " << cat_id_vec.size();
     std::cout << "\nCatchment validation completed" << std::endl;
 }

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -38,9 +38,9 @@ using RemoteConnectionVec = std::vector< RemoteConnection >;
  * @param num_part 
  * @param outFile 
  */
-void write_remote_connections(PartitionVSet catchment_part, PartitionVSet nexus_part,
-                 std::vector<RemoteConnectionVec> remote_connections_vec,
-                 int num_part, std::ofstream& outFile)
+void write_remote_connections(const PartitionVSet& catchment_part, const PartitionVSet& nexus_part,
+                 const std::vector<RemoteConnectionVec>& remote_connections_vec,
+                 const int& num_part, std::ofstream& outFile)
 {
     outFile<<"{"<<std::endl;
     outFile<<"    \"partitions\":["<<std::endl;
@@ -276,7 +276,7 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
  * 
  * @throws runtime_error if no partition contains the requested id
  */
-int find_remote_rank(std::string id, PartitionVSet catchment_partitions)
+int find_remote_rank(const std::string& id, const PartitionVSet& catchment_partitions)
 {
     int pos = -1;
     for ( int i = 0; i < catchment_partitions.size(); ++i )
@@ -327,7 +327,7 @@ int find_remote_rank(std::string id, PartitionVSet catchment_partitions)
  * 
  * @throws invalid_argument if the partition_number is not in the range of valid partition numbers (size of catchment_partitions)
  */
-int find_partition_connections(std::string nexus, PartitionVSet catchment_partitions, int partition_number,  std::vector<std::string>& origin_ids_to_find, std::vector<std::string>& destination_ids_to_find, RemoteConnectionVec& remote_connections )
+int find_partition_connections(const std::string& nexus, const PartitionVSet& catchment_partitions, const int& partition_number,  const std::vector<std::string>& origin_ids_to_find, const std::vector<std::string>& destination_ids_to_find, RemoteConnectionVec& remote_connections )
 {
 
     const std::string origination_cat_to_nex = "orig_cat-to-nex";

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -53,7 +53,7 @@ void write_remote_connections(const PartitionVSet& catchment_part, const Partiti
     {
         // write catchments
         outFile<<"        {\"id\":" << id <<",\n        \"cat-ids\":[";
-        std::unordered_set<std::string> cat_set = catchment_part[i];
+        const std::unordered_set<std::string>& cat_set = catchment_part[i];
         // iterate over elements in catchment set
         for (auto it = cat_set.begin(); it != cat_set.end(); it++) {
             std::string catchment_id = *it;
@@ -64,7 +64,7 @@ void write_remote_connections(const PartitionVSet& catchment_part, const Partiti
 
         // write nexuses
         outFile<<"        \"nex-ids\":[";
-        std::unordered_set<std::string> nex_set = nexus_part[i];
+        const std::unordered_set<std::string>& nex_set = nexus_part[i];
         // loop over elements in nexus set
         for (auto it = nex_set.begin(); it != nex_set.end(); it++) {
             std::string nexus_id = *it;
@@ -74,8 +74,7 @@ void write_remote_connections(const PartitionVSet& catchment_part, const Partiti
         outFile<<"],\n";
 
         // wrtie remote_connections
-        RemoteConnectionVec remote_conn_vec;
-        remote_conn_vec = remote_connections_vec[i];
+        const RemoteConnectionVec& remote_conn_vec = remote_connections_vec[i];
 
         outFile<<"        \"remote-connections\":[";
         int vec_size = remote_conn_vec.size();
@@ -244,7 +243,7 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
     std::cout << "Validating catchments..." << std::endl;
     std::vector<std::string> cat_id_vec;
     for (int i =0; i < catchment_part.size(); ++i) {
-        std::unordered_set<std::string> cat_set = catchment_part[i];
+        std::unordered_set<std::string>& cat_set = catchment_part[i];
         // convert unordered_set to vector
         for (const auto &it: cat_set) {
             cat_id_vec.push_back(it);
@@ -337,7 +336,7 @@ int find_partition_connections(const std::string& nexus, const PartitionVSet& ca
         throw std::invalid_argument("find_partition_connections: partition_number not valid for catchment_partitions of size "+
                                      std::to_string( catchment_partitions.size()) + ".");
     }
-    std::unordered_set<std::string> catchments = catchment_partitions[partition_number];
+    const std::unordered_set<std::string> & catchments = catchment_partitions[partition_number];
     int remote_catchments = 0;
 
     //Find senders
@@ -505,8 +504,8 @@ int main(int argc, char* argv[])
         RemoteConnectionVec remote_connections;
 
         //std::vector<std::string> local_cat_ids = catchment_part[ipart]["cat-ids"];
-        std::unordered_set<std::string> local_cat_set = catchment_part[ipart];
-        std::unordered_set<std::string> local_nex_set = nexus_part[ipart];
+        std::unordered_set<std::string> & local_cat_set = catchment_part[ipart];
+        std::unordered_set<std::string> & local_nex_set = nexus_part[ipart];
         std::unordered_set<std::string> local_node_set;
         
         std::merge(local_cat_set.begin(), local_cat_set.end(),

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -144,6 +144,9 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
     std::cout << "remainder:" << remainder << std::endl;
     **/
     std::unordered_set<std::string> catchment_set, nexus_set;
+    //We know we want ~partition_size catchments in the set, so reserve enough space for that to avoid a lot of realloction/rehash
+    catchment_set.reserve(partition_size);
+    nexus_set.reserve(partition_size);
     std::string part_id, partition_str;
     std::vector<std::string> part_ids;
 


### PR DESCRIPTION
Significant performance concerns were raised when attempting to use the `partitionGenerator` on a CONUS hydrofabric.  After a cursory look at the code, some significant optimizations are possible by simply reducing the amount of copying that happens, especially when functions are called inside of large loops.  This PR addresses some low hanging fruit for optimizing the `partitionGenerator` by simply using references instead of copies/values.

Preliminary analysis shows these changes decrease runtime by nearly 50% on VPU 6, and now most all the run time in that run is in reading the initial catchment data. (20 seconds of the total 23.6 seconds).

@mattw-nws this should help a bit with your CONUS partitioning.

EDIT:
Was able to run the conus partitioning on my macbook in ~15 minutes (after doing a little more memory efficiency in the geojson reader keep from crashing when I ran out of swap and RAM...I'll push those edits in another PR).

I will also note that to get to that speed, I was using a RELEASE build, not a DEBUG build.  The boost ptree reading is highly sensitive to that!

`cmake -DCMAKE_BUILD_TYPE=Release` makes reading the geojson significantly faster!

## Additions

-

## Removals

-

## Changes

-  Pass as many variables as possible by `const` reference
- Refactor the validation algorithm from a `O(n^2)` to `O(n log n)` implementation.

## Testing

1.

## Screenshots


## Notes

- The `Network` could be passed by reference, but not `const` reference due to many nested functions that were not const qualified.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. Tested on VPU 06 

### Target Environment support

- [x] Linux
- [x] MacOs