### PR TITLE
Geojson optimization

### DIFF
--- a/include/geojson/FeatureCollection.hpp
+++ b/include/geojson/FeatureCollection.hpp
@@ -31,6 +31,16 @@ namespace geojson {
                 }
             }
 
+             /**
+             * Move Constructor
+             * 
+             * @param new_features An overall list of features
+             * @param bounding_box A set of bounds for all features
+             */
+            FeatureCollection(FeatureList &&new_features, std::vector<double> &&bounding_box) :features(new_features), bounding_box(bounding_box)
+            {
+            }
+
             FeatureCollection() {}
 
             /**
@@ -60,10 +70,10 @@ namespace geojson {
                 {
                     idset.insert(*it);
                 }
-                for (Feature feature : feature_collection) {
+                for (const Feature& feature : feature_collection) {
                     auto id = feature->get_id();
                     if (idset.count(id)) {
-                        features.push_back(feature);
+                        features.push_back(std::move(feature));
                     }
                 }
                 this->update_ids();

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -15,6 +15,11 @@ namespace geojson {
     //Forward declare variant types
     struct List;
     struct Object;
+    /**
+     * Shorthand for a mapping between strings and properties
+     */
+    typedef std::map<std::string, JSONProperty> PropertyMap;
+
     using PropertyVariant = boost::variant<boost::blank, 
                                            long, 
                                            double, 
@@ -76,11 +81,6 @@ namespace geojson {
                 return "Object";
         }
     }
-
-    /**
-     * Shorthand for a mapping between strings and properties
-     */
-    typedef std::map<std::string, JSONProperty> PropertyMap;
 
     /** @TODO: Convert JSONProperty into a variant of the supported types  */
     /**

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -41,13 +41,11 @@ namespace geojson {
 
         public:
         /**
-         * @brief Set the values pointed to by this List
+         * @brief Construct a new List and set its values pointer to values
          * 
-         * @param values a pointer to the vector holding the List's JSONProperties
+         * @param values 
          */
-        void set_values(std::vector<JSONProperty>* values){
-            this->values = values;
-        }
+        List (std::vector<JSONProperty>* values): values(values){}
 
         /**
          * @brief Get the pointer to the values vector
@@ -204,15 +202,13 @@ namespace geojson {
                 }
                 else {
                     // This isn't a terminal node, therefore represents an object or array
-                    List tmp_list;
                     Object tmp_obj;
                     //TODO unit test these construction paths...
                     for (auto &property : property_tree) {
                         if (property.first.empty()) {
                             type = PropertyType::List;
                             value_list.push_back(std::move(JSONProperty(value_key, property.second)));
-                            tmp_list.set_values( & value_list );
-                            data = tmp_list;
+                            data = List(& value_list );
                         }
                         else {
                             type = PropertyType::Object;
@@ -359,11 +355,8 @@ namespace geojson {
             }
 
             JSONProperty(std::string value_key, std::vector<JSONProperty> properties) : type(PropertyType::List), key(std::move(value_key)), value_list(std::move(properties))  {
-                List tmp;
-                for(const auto& p : properties){
-                    tmp.push_back(p);
-                }
-                data = tmp;
+                std::cout<<"Building json list: "<<value_list.size()<<std::endl;
+                data = List( &value_list );
             }
 
             // JSONProperty(const JSONProperty &&original){

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -351,7 +351,6 @@ namespace geojson {
             }
 
             JSONProperty(std::string value_key, std::vector<JSONProperty> properties) : type(PropertyType::List), key(std::move(value_key)), value_list(std::move(properties))  {
-                std::cout<<"Building json list: "<<value_list.size()<<std::endl;
                 data = List( &value_list );
             }
 

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -89,8 +89,8 @@ namespace geojson {
     class JSONProperty {
         public:
             
-            JSONProperty(std::string value_key, const boost::property_tree::ptree& property_tree) {
-                key = value_key;
+            JSONProperty(std::string value_key, const boost::property_tree::ptree& property_tree):
+            key(std::move(value_key)) {
 
                 if (property_tree.empty() && !property_tree.data().empty()) {
                     // This is a terminal node and has a raw value
@@ -222,12 +222,12 @@ namespace geojson {
              * @param value_key: The name of the key that stores this value
              * @param value: The text that will be stored
              */
-            JSONProperty(std::string value_key, const char *value) {
-                type = PropertyType::String;
-                key = std::move(value_key);
-                string = value;
-                data = string;
-            }
+            JSONProperty(std::string value_key, const char *value):
+                type(PropertyType::String),
+                key(std::move(value_key)),
+                string(value),
+                data(std::string(value))
+            {}
 
             /**
              * Create a JSONProperty that stores text
@@ -341,12 +341,12 @@ namespace geojson {
              * @param value_key: The name of the key that stores this value
              * @param value: The true or false value that will be stored
              */
-            JSONProperty(std::string value_key, bool value) {
-                type = PropertyType::Boolean;
-                key = std::move(value_key);
-                boolean = value;
-                data = boolean;
-            }
+            JSONProperty(std::string value_key, bool value):
+                type(PropertyType::Boolean),
+                key(std::move(value_key)),
+                boolean(value),
+                data(value)
+            {}
 
             /**
              * Create a JSONProperty that stores a nested map of properties

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -104,28 +104,26 @@ namespace geojson {
                         }
                         else {
                           //Try natural number first since double cant cast to int/long
-                          try{
-                            natural_number = boost::lexical_cast<long>(value);
+                        long casted_long_data;
+                        double casted_double_data;
+                        if( boost::conversion::try_lexical_convert<long>(value, casted_long_data) ){
                             type = PropertyType::Natural;
-                            data = natural_number;
-                          }
-                          catch (boost::bad_lexical_cast &e)
-                          {
-                            try {
-                              //Try to cast to double/real next
-                              real_number = boost::lexical_cast<double>(value);
-                              type = PropertyType::Real;
-                              data = real_number;
-                            }
-                            catch (boost::bad_lexical_cast & e)
-                            {
-                              //At this point, we are left with string option
-                              string = value;
-                              type = PropertyType::String;
-                              data = string;
-                            }
-                          }
+                            natural_number = casted_long_data;
+                            data = casted_long_data;
                         }
+                        else if( boost::conversion::try_lexical_convert<double>(value, casted_double_data) ){
+                            //Try to cast to double/real next
+                            type = PropertyType::Real;
+                            real_number = casted_double_data;
+                            data = casted_double_data;
+                        }
+                        else{
+                            //At this point, we are left with string option
+                            //string = value;
+                            type = PropertyType::String;
+                            data = std::move(value);
+                        }
+                    }
                 }
                 else {
                     // This isn't a terminal node, therefore represents an object or array

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -485,7 +485,7 @@ namespace geojson {
              */
             template <typename T>
             void as_vector(std::vector<T>& vector) const{
-                PropertyVisitor<T> visitor(vector);
+                AsVectorVisitor<T> visitor(vector);
                 boost::apply_visitor(visitor, data);
             }
 
@@ -559,20 +559,26 @@ namespace geojson {
              * @tparam T 
              */
             template<typename T>
-            struct PropertyVisitor : public boost::static_visitor<>
+            struct AsVectorVisitor : public boost::static_visitor<>
             {
-                //PropertyVisitor takes a templated vector and stores the vector
+                //AsVectorVisitor takes a templated vector and stores the vector
                 //reference in the struct
-                PropertyVisitor(std::vector<T>& v) : vec(v) {}
+                AsVectorVisitor(std::vector<T>& v) : vec(v) {}
                 //Vistor operators, first is generic template operator
                 template<typename Variant>
                 void operator () (const Variant& value) {
                     //This is a no-op for all types that are not T
                 }
-     
+
                 //Visitor operator for type T, adds T types to vector
                 void operator () (const T& value)
                 {
+                    vec.push_back(value);
+                }
+
+                //Enable this conversion only if the original template param is floating point, so there is no loss
+                template <typename Floating = T, std::enable_if_t<std::is_floating_point<Floating>::value, bool> = true >
+                void operator () (const long& value){
                     vec.push_back(value);
                 }
 

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -94,7 +94,7 @@ namespace geojson {
 
                 if (property_tree.empty() && !property_tree.data().empty()) {
                     // This is a terminal node and has a raw value
-                        // TODO: Add handling for nested objects by determining if property.second is another ptree
+
                         std::string value = property_tree.data();
 
                         if (value == "true" || value == "false") {

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -65,7 +65,7 @@ namespace geojson {
         Object      /*!< Represents a nested map of properties */
     };
 
-    static inline std::string get_propertytype_name(PropertyType property_type) {
+    static inline std::string get_propertytype_name(PropertyType&& property_type) {
         switch(property_type) {
             case PropertyType::Natural:
                 return "Natural";

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -159,7 +159,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, short value)
                 : type(PropertyType::Natural),
-                    key(value_key),
+                    key(std::move(value_key)),
                     natural_number(long(value)),
                     data(long(value))
             {}
@@ -172,7 +172,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, int value)
                 : type(PropertyType::Natural),
-                    key(value_key),
+                    key(std::move(value_key)),
                     natural_number(long(value)),
                     data(long(value))
             {}
@@ -185,7 +185,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, long value)
                 : type(PropertyType::Natural),
-                    key(value_key),
+                    key(std::move(value_key)),
                     natural_number(value),
                     data(value)
             {}
@@ -198,7 +198,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, float value)
                 : type(PropertyType::Real),
-                    key(value_key),
+                    key(std::move(value_key)),
                     real_number(double(value)),
                     data(double(value))
             {}
@@ -211,7 +211,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, double value)
                 : type(PropertyType::Real),
-                    key(value_key),
+                    key(std::move(value_key)),
                     real_number(value),
                     data(value)
             {}
@@ -224,7 +224,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, const char *value) {
                 type = PropertyType::String;
-                key = value_key;
+                key = std::move(value_key);
                 string = value;
                 data = string;
             }
@@ -235,8 +235,7 @@ namespace geojson {
              * @param value_key: The name of the key that stores this value
              * @param value: The text that will be stored
              */
-            JSONProperty(std::string value_key, std::string value) {
-                key = value_key;
+            JSONProperty(std::string value_key, std::string value):key(std::move(value_key)) {
                 string = value;
 
                 if (value == "true" || value == "false") {
@@ -294,7 +293,7 @@ namespace geojson {
                 }
             }
 
-            JSONProperty(std::string value_key, std::vector<JSONProperty> properties) : type(PropertyType::List), key(value_key), value_list(properties) {
+            JSONProperty(std::string value_key, std::vector<JSONProperty> properties) : type(PropertyType::List), key(std::move(value_key)), value_list(std::move(properties))  {
                 List tmp;
                 for(const auto& p : properties){
                     tmp.values.push_back(p.data);
@@ -344,7 +343,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, bool value) {
                 type = PropertyType::Boolean;
-                key = value_key;
+                key = std::move(value_key);
                 boolean = value;
                 data = boolean;
             }
@@ -357,7 +356,7 @@ namespace geojson {
              */
             JSONProperty(std::string value_key, PropertyMap &value)
                 : type(PropertyType::Object),
-                    key(value_key),
+                    key(std::move(value_key)),
                     values(value)
             {   
                 Object tmp;

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -99,13 +99,11 @@ namespace geojson {
 
         public:
         /**
-         * @brief Set the values pointed to by the object
+         * @brief Construct a new Object and set its values pointer to values
          * 
-         * @param values a pointer to the \ref PropertyMap holding the Object's JSONProperty nested objects
+         * @param values 
          */
-        void set_values(PropertyMap* values){
-            this->values = values;
-        }
+        Object (PropertyMap* values): values(values){}
 
         /**
          * @brief A stream overload to represent this type as an Object
@@ -202,7 +200,6 @@ namespace geojson {
                 }
                 else {
                     // This isn't a terminal node, therefore represents an object or array
-                    Object tmp_obj;
                     //TODO unit test these construction paths...
                     for (auto &property : property_tree) {
                         if (property.first.empty()) {
@@ -213,8 +210,7 @@ namespace geojson {
                         else {
                             type = PropertyType::Object;
                             values.emplace(property.first, std::move(JSONProperty(property.first, property.second)));
-                            tmp_obj.set_values( & values );
-                            data = tmp_obj;
+                            data = Object( & values );
                         }
                     }
                 }
@@ -424,9 +420,7 @@ namespace geojson {
                     key(std::move(value_key)),
                     values(value)
             {   
-                Object tmp;
-                tmp.set_values( &values );
-                data = tmp;
+                data = Object( &values );
             }
 
             /**

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -355,40 +355,25 @@ namespace geojson {
                 data = List( &value_list );
             }
 
-            // JSONProperty(const JSONProperty &&original){
-            //     type = original.type;
-            //     key = original.key;
-            //     data = original.data;
-            //     switch (type) {
-            //         case PropertyType::Boolean:
-            //             boolean = original.boolean;
-            //             break;
-            //         case PropertyType::Natural:
-            //             natural_number = original.natural_number;
-            //             break;
-            //         case PropertyType::Real:
-            //             real_number = original.real_number;
-            //             break;
-            //         case PropertyType::String:
-            //             string = original.string;
-            //             break;
-            //         case PropertyType::List:
-            //             for (const JSONProperty& property : original.value_list) {
-            //                 value_list.push_back(std::move(property));
-            //             }
-            //             break;
-            //         default:
-            //             for (std::pair<std::string, const JSONProperty& > pair : original.values) {
-            //                 values.emplace(pair.first, std::move(pair.second));
-            //             }
-            //     }
-            // };
-
             JSONProperty(const JSONProperty &original) {
                 if( this != &original){
                     type = original.type;
                     key = original.key;
-                    data = original.data;
+                    switch (type) {
+                        case PropertyType::List:
+                            for (const JSONProperty& property : original.value_list) {
+                                value_list.push_back(std::move(property));
+                            }
+                            data = List( &value_list );
+                            break;
+                        case PropertyType::Object:
+                            for (std::pair<std::string, const JSONProperty& > pair : original.values) {
+                                values.emplace(pair.first, std::move(pair.second));
+                            }
+                            data = Object( &values );
+                        default:
+                            data = original.data;
+                    }
                 }
             }
 

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -168,7 +168,18 @@ namespace geojson {
             JSONProperty(std::string value_key, const boost::property_tree::ptree& property_tree):
             key(std::move(value_key)) {
 
-                if (property_tree.empty() && !property_tree.data().empty()) {
+                if(property_tree.empty() && property_tree.data().empty()) {
+                    //Since property trees don't represent empty strings, list, or objects, they are all just `empty`
+                    //so we can trap that case with `property_tree.data().empty()`, and the best we can do is make it an
+                    //empty string
+                    type = PropertyType::String;
+                    //Also note that a boost::variant assigned to the static empty string "" like this
+                    //`data = "";`
+                    //will cause `data` to actually become a bool type, not the std::string. 
+                    //So use a default string to intialize the empty data
+                    data = std::string();
+                }
+                else if (property_tree.empty() && !property_tree.data().empty()) {
                     // This is a terminal node and has a raw value
 
                     const std::string& value = property_tree.data();
@@ -370,6 +381,7 @@ namespace geojson {
                                 values.emplace(pair.first, std::move(pair.second));
                             }
                             data = Object( &values );
+                            break;
                         default:
                             data = original.data;
                     }

--- a/include/geojson/features/FeatureBase.hpp
+++ b/include/geojson/features/FeatureBase.hpp
@@ -76,7 +76,7 @@ namespace geojson {
                 std::vector<FeatureBase*> destination_features = std::vector<FeatureBase*>(),
                 PropertyMap members = PropertyMap()
             ) {
-                id = new_id;
+                id = std::move(new_id);
 
                 for (auto& feature : origination_features) {
                     this->add_origination_feature(feature);
@@ -86,9 +86,9 @@ namespace geojson {
                     this->add_destination_feature(feature);
                 }
                 
-                foreign_members = members;
-                bounding_box = new_bounding_box;
-                properties = new_properties;
+                foreign_members = std::move(members);
+                bounding_box = std::move(new_bounding_box);
+                properties = std::move(new_properties);
             }
 
         public:

--- a/include/geojson/features/MultiPolygonFeature.hpp
+++ b/include/geojson/features/MultiPolygonFeature.hpp
@@ -28,8 +28,8 @@ namespace geojson {
                 std::vector<FeatureBase*> upstream_features = std::vector<FeatureBase*>(),
                 std::vector<FeatureBase*> downstream_features = std::vector<FeatureBase*>(),
                 std::map<std::string, JSONProperty> members = std::map<std::string, JSONProperty>()
-            ) : FeatureBase(new_id, new_properties, new_bounding_box, upstream_features, downstream_features, members) {
-                this->geom = multipolygon;
+            ) : FeatureBase(std::move(new_id), std::move(new_properties), std::move(new_bounding_box), std::move(upstream_features), std::move(downstream_features), std::move(members)) {
+                this->geom = std::move(multipolygon);
                 this->type = geojson::FeatureType::MultiPolygon;
             }
 

--- a/include/geojson/features/PointFeature.hpp
+++ b/include/geojson/features/PointFeature.hpp
@@ -29,7 +29,7 @@ namespace geojson {
                 std::vector<FeatureBase*> upstream_features = std::vector<FeatureBase*>(),
                 std::vector<FeatureBase*> downstream_features = std::vector<FeatureBase*>(),
                 std::map<std::string, JSONProperty> members = std::map<std::string, JSONProperty>()
-            ) : FeatureBase(new_id, new_properties, new_bounding_box, upstream_features, downstream_features, members) {
+            ) : FeatureBase(std::move(new_id), std::move(new_properties), std::move(new_bounding_box), std::move(upstream_features), std::move(downstream_features), std::move(members)) {
                 this->geom = coordinate;
                 this->type = geojson::FeatureType::Point;
             }

--- a/include/geojson/features/PolygonFeature.hpp
+++ b/include/geojson/features/PolygonFeature.hpp
@@ -41,8 +41,8 @@ namespace geojson {
                 std::vector<FeatureBase*> upstream_features = std::vector<FeatureBase*>(),
                 std::vector<FeatureBase*> downstream_features = std::vector<FeatureBase*>(),
                 PropertyMap members = std::map<std::string, JSONProperty>()
-            ) : FeatureBase(new_id, new_properties, new_bounding_box, upstream_features, downstream_features, members) {
-                this->geom = polygon;
+            ) : FeatureBase(std::move(new_id), std::move(new_properties), std::move(new_bounding_box), std::move(upstream_features), std::move(downstream_features), std::move(members)) {
+                this->geom = std::move(polygon);
                 this->type = geojson::FeatureType::Polygon;
             }
 

--- a/src/geojson/FeatureCollection.cpp
+++ b/src/geojson/FeatureCollection.cpp
@@ -252,7 +252,7 @@ void FeatureCollection::update_ids() {
 
 void FeatureCollection::add_feature_id(std::string id, Feature feature) {
     if (id != "") {
-        feature_by_id.emplace(id, feature);
+        feature_by_id.emplace(id, std::move(feature));
     }
     else {
         throw std::invalid_argument("id");

--- a/src/geojson/JSONProperty.cpp
+++ b/src/geojson/JSONProperty.cpp
@@ -181,10 +181,3 @@ bool JSONProperty::has_key(std::string key) const {
 std::string JSONProperty::get_key() const {
     return key;
 }
-
-namespace geojson{
-    //Template specialization
-    template<> template<> void JSONProperty::PropertyVisitor<double>::operator ()<long>(const long& value){
-                        vec.push_back(static_cast<double>(value));
-        }
-}

--- a/src/geojson/JSONProperty.cpp
+++ b/src/geojson/JSONProperty.cpp
@@ -55,8 +55,7 @@ std::vector<JSONProperty> JSONProperty::as_list() const {
     std::vector<JSONProperty> copy;
 
     if (type == PropertyType::List) {
-       auto values = *boost::get<List>(data).get_values();
-       for( auto & val : values){
+       for( auto & val : value_list){
             copy.push_back(JSONProperty(val));
        }
        return copy;
@@ -118,11 +117,10 @@ std::string JSONProperty::as_string() const {
     }
     else if (type == PropertyType::List) {
         std::string list_description = "[";
-        auto values = *boost::get<List>(data).get_values();
-        for (int list_index = 0; list_index < values.size(); list_index++) {
-            list_description += values[list_index].as_string();
+        for (int list_index = 0; list_index < value_list.size(); list_index++) {
+            list_description += value_list[list_index].as_string();
 
-            if (list_index < values.size() - 1) {
+            if (list_index < value_list.size() - 1) {
                 list_description += ",";
             }
         }

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -459,7 +459,7 @@ int main(int argc, char* argv[])
     outFile.open(partitionOutFile, std::ios::trunc);
 
     //Get the feature collecion for the given hydrofabric
-    geojson::GeoJSON catchment_collection = geojson::read(catchmentDataFile, catchment_subset_ids);
+    geojson::GeoJSON catchment_collection = std::move( geojson::read(catchmentDataFile, catchment_subset_ids) );
     int num_catchments = catchment_collection->get_size();
     std::cout<<"Partitioning "<<num_catchments<<" catchments into "<<num_partitions<<" partitions."<<std::endl;
     std::string link_key = "toid";
@@ -472,7 +472,7 @@ int main(int argc, char* argv[])
 
     //build the remote connections from network
     // read the nexus hydrofabric, reuse the catchments
-    geojson::GeoJSON global_nexus_collection = geojson::read(nexusDataFile, nexus_subset_ids);
+    geojson::GeoJSON global_nexus_collection = std::move( geojson::read(nexusDataFile, nexus_subset_ids) );
 
     //Now read the collection of catchments, iterate it and add them to the nexus collection
     //also link them by to->id

--- a/test/geojson/JSONProperty_Test.cpp
+++ b/test/geojson/JSONProperty_Test.cpp
@@ -73,12 +73,25 @@ TEST_F(JSONProperty_Test, list_property_test) {
     properties.push_back(geojson::JSONProperty("string", "test_string"));
     properties.push_back(geojson::JSONProperty("boolean", true));
 
+    //Also, dump an object in the list, for fun
+    geojson::PropertyMap object;
+    
+    object.emplace("natural", geojson::JSONProperty("natural", 4));
+    object.emplace("real", geojson::JSONProperty("real", 3.0));
+    object.emplace("string", geojson::JSONProperty("string", "test_string"));
+    object.emplace("boolean", geojson::JSONProperty("boolean", true));
+
+    geojson::JSONProperty object_property("object", object);
+    properties.push_back(object_property);
+
     geojson::JSONProperty list_property("list_property", properties);
 
     ASSERT_EQ(list_property.as_list()[0].as_natural_number(), properties[0].as_natural_number());
     ASSERT_EQ(list_property.as_list()[1].as_real_number(), properties[1].as_real_number());
     ASSERT_EQ(list_property.as_list()[2].as_string(), properties[2].as_string());
     ASSERT_EQ(list_property.as_list()[3].as_boolean(), properties[3].as_boolean());
+    //test the object extracted from the list
+    ASSERT_EQ(list_property.as_list()[4].at("real").as_real_number(), object.at("real").as_real_number());
 }
 
 TEST_F(JSONProperty_Test, natural_vector_test) {
@@ -153,13 +166,42 @@ TEST_F(JSONProperty_Test, string_vector_test) {
     ASSERT_EQ(values[2], "three");
 }
 
+TEST_F(JSONProperty_Test, ptree_empty_test){
+    std::string empties = "{ "
+                          "\"empty_string\": \"\", "
+                          "\"empty_list\": [], "
+                          "\"empty_object\": {} }";
+
+    std::stringstream stream;
+    stream << empties;
+    boost::property_tree::ptree tree;
+    boost::property_tree::json_parser::read_json(stream, tree);
+    std::vector<geojson::JSONProperty> properties;
+    for(auto &pair : tree) {
+        properties.push_back(geojson::JSONProperty(pair.first, pair.second));
+    }
+    
+    ASSERT_EQ(properties.size(), 3);
+
+    ASSERT_EQ(properties[0].get_type(), geojson::PropertyType::String);
+    ASSERT_EQ(properties[0].as_string(), "");
+    //Not supported by property trees
+    //ASSERT_EQ(properties[1].get_type(), geojson::PropertyType::List);
+    //ASSERT_EQ(properties[1].as_list().size(), 0);
+
+    //ASSERT_EQ(properties[2].get_type(), geojson::PropertyType::Object);
+    //ASSERT_EQ(properties[2].get_values().size(), 0);
+}
+
 TEST_F(JSONProperty_Test, ptree_test) {
     std::string data = "{ "
                "\"type\": \"LineString\", "
                "\"coordinates\": [0.0,1.0,3.0], "
                "\"boolean_value\": true, " 
                "\"natural_value\": 4, "
-               "\"real_value\": 4.3123 "
+               "\"real_value\": 4.3123, "
+               "\"object\": { \"nested\": true, "
+               "\"deep_nested\": {\"nested\": \"deep\" } } "
            "}";
 
     std::stringstream stream;
@@ -172,7 +214,7 @@ TEST_F(JSONProperty_Test, ptree_test) {
         properties.push_back(geojson::JSONProperty(pair.first, pair.second));
     }
 
-    ASSERT_EQ(properties.size(), 5);
+    ASSERT_EQ(properties.size(), 6);
     ASSERT_EQ(properties[0].get_type(), geojson::PropertyType::String);
     ASSERT_EQ(properties[0].as_string(), "LineString");
 
@@ -185,6 +227,9 @@ TEST_F(JSONProperty_Test, ptree_test) {
     ASSERT_EQ(properties[2].get_type(), geojson::PropertyType::Boolean);
     ASSERT_EQ(properties[3].get_type(), geojson::PropertyType::Natural);
     ASSERT_EQ(properties[4].get_type(), geojson::PropertyType::Real);
+    ASSERT_EQ(properties[5].get_type(), geojson::PropertyType::Object);
+    ASSERT_EQ(properties[5].at("nested").as_boolean(), true);
+    ASSERT_EQ(properties[5].at("deep_nested").at("nested").as_string(), "deep");
 }
 
 TEST_F(JSONProperty_Test, test_as_vector_natural){


### PR DESCRIPTION
After looking through #443, it became clear that a large part of the initialization overhead in `FeatureCollection` was due to an excessive amount of copies of strings (and some other data).  This PR utilized `std::move` to reduce the amount of copies of data that go through the system.  Also, I took the opportunity to finish implementing the `JSONProperty` using the `boost::variant` for all data types.

This work when used on the partition generator with the optimization in #443 was able to reduce the runtime of the conus run to about 8 minutes.

I noticed a point of diminishing returns working on this code, and investigated briefely.  Turns out, on my machine, I'll likely never get better than about 8 minutes on the conus run.  It literally takes about 5 minutes just to DESTRUCT the property tree as the stack unrolls.  This is because I was pushing ~56GB RAM out of my 16GB phsical memory, so the swapping was intense.

To test this idea a bit, I replaced all geometries in the `catchment_data.geosjon` with a simple `Point` geometry, instead of a `MultiPolygon`.  I then ran the partitioning using that input, and completed the entire thing in 1 minute and 20 seconds!

## Additions

-

## Removals

-

## Changes

- A lot of resource stealing using `std::move`
- Finish implementing `JSONProperty` using the `boost::variant` that was introduced to utilize `List` parameters in `ngen`

## Testing

1. Ran many partition runs

## Notes

- May want to consider implementing move constructors for `JSONProperty` and the various `Feature` types.

## Todos

- Actually was able to remove one from the code this time!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
