### PR TITLE
gcc-12 namespace fixes

### DIFF
--- a/include/forcing/AorcForcing.hpp
+++ b/include/forcing/AorcForcing.hpp
@@ -28,7 +28,7 @@
 
 #include <map>
 
-using namespace std;
+//using namespace std// causes build error on gcc-12 with boost::geometry
 
 /**
  * @brief forcing_params providing configuration information for forcing time period and source.

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -237,7 +237,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         {
             forcing_vector_index = 0;
             /// \todo: Return appropriate warning
-            cout << "WARNING: Forcing vector index is less than zero. Therefore, setting index to zero." << endl;
+            std::cout << "WARNING: Forcing vector index is less than zero. Therefore, setting index to zero." << std::endl;
         }
 
         //Check if forcing index is greater than or equal to the size of the size of the time vector and if so, set to zero.
@@ -245,7 +245,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         {
             forcing_vector_index = time_epoch_vector.size() - 1;
             /// \todo: Return appropriate warning
-            cout << "WARNING: Reached beyond the size of the forcing vector. Therefore, setting index to last value of the vector." << endl;
+            std::cout << "WARNING: Reached beyond the size of the forcing vector. Therefore, setting index to last value of the vector." << std::endl;
         }
 
         return;
@@ -282,7 +282,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
      * Reads only data within the specified model start and end date-times.
      * @param file_name Forcing file name
      */
-    void read_csv(string file_name)
+    void read_csv(std::string file_name)
     {
         int time_col_index = 0;
         //std::map<std::string, int> col_indices;
@@ -332,7 +332,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
             std::vector<std::string>& vec = data_list[i];
 
             struct tm current_row_date_time_utc = tm();
-            string time_str = vec[time_col_index];
+            std::string time_str = vec[time_col_index];
             //TODO: Support more time string formats? This is basically ISO8601 but not complete, support TZ?
             strptime(time_str.c_str(), "%Y-%m-%d %H:%M:%S", &current_row_date_time_utc);
 
@@ -372,7 +372,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         if (i <= 1 || current_row_date_time_epoch < end_date_time_epoch)
         {
             /// \todo TODO: Return appropriate error
-            cout << "WARNING: Forcing data ends before the model end time." << endl;
+            std::cout << "WARNING: Forcing data ends before the model end time." << std::endl;
             //throw std::runtime_error("Error: Forcing data ends before the model end time.");
         }
     }
@@ -384,7 +384,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
     std::unordered_map<std::string, std::vector<double>> forcing_vectors;
 
     /// \todo: Consider making epoch time the iterator
-    vector<time_t> time_epoch_vector;     
+    std::vector<time_t> time_epoch_vector;     
     int forcing_vector_index;
 
     /// \todo: Are these used?
@@ -395,7 +395,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
     double longitude; //longitude (degrees_east)
     int catchment_id;
     int day_of_year;
-    string forcing_file_name;
+    std::string forcing_file_name;
 
     std::shared_ptr<time_type> start_date_time;
     std::shared_ptr<time_type> end_date_time;

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -402,7 +402,7 @@ namespace data_access
             size_t cache_slices_t_n = read_len / cache_slice_t_size; // Integer division!
             // For reference: https://stackoverflow.com/a/72030286
             for( size_t i = 0; i < cache_slices_t_n; i++ ) {
-                shared_ptr<std::vector<double>> cached;
+                std::shared_ptr<std::vector<double>> cached;
                 int cache_t_idx = (idx1 - (idx1 % cache_slice_t_size) + i);
                 std::string key = ncvar.getName() + "|" + std::to_string(cache_t_idx);
                 if(value_cache.contains(key)){

--- a/include/realizations/catchment/Tshirt_C_Realization.hpp
+++ b/include/realizations/catchment/Tshirt_C_Realization.hpp
@@ -327,7 +327,7 @@ namespace realization {
                 "giuh"
         };
 
-        function<double(tshirt_c_result_fluxes)> get_output_var_flux_extraction_func(const std::string& var_name);
+        std::function<double(tshirt_c_result_fluxes)> get_output_var_flux_extraction_func(const std::string& var_name);
 
         const std::vector<std::string>& get_required_parameters() override;
 

--- a/src/realizations/catchment/Tshirt_C_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_C_Realization.cpp
@@ -18,7 +18,7 @@ Tshirt_C_Realization::Tshirt_C_Realization(forcing_params forcing_config,
                                            std::string catchment_id,
                                            giuh::GiuhJsonReader &giuh_json_reader,
                                            tshirt::tshirt_params params,
-                                           const vector<double> &nash_storage)
+                                           const std::vector<double> &nash_storage)
         : Tshirt_C_Realization::Tshirt_C_Realization(std::move(forcing_config), output_stream, soil_storage,
                                                      groundwater_storage, storage_values_are_ratios,
                                                      std::move(catchment_id),
@@ -36,7 +36,7 @@ Tshirt_C_Realization::Tshirt_C_Realization(forcing_params forcing_config,
                                            std::string catchment_id,
                                            std::vector<double> giuh_ordinates,
                                            tshirt::tshirt_params params,
-                                           const vector<double> &nash_storage)
+                                           const std::vector<double> &nash_storage)
         //: Catchment_Formulation(catchment_id, std::move(std::make_unique<Forcing>(forcing_config)), output_stream), catchment_id(std::move(catchment_id)),
         : Catchment_Formulation(catchment_id, std::move(std::make_unique<CsvPerFeatureForcingProvider>(forcing_config)), output_stream), catchment_id(std::move(catchment_id)),
           giuh_cdf_ordinates(std::move(giuh_ordinates)), params(std::make_shared<tshirt_params>(params)), nash_storage(nash_storage), c_soil_params(NWM_soil_parameters()),
@@ -89,7 +89,7 @@ Tshirt_C_Realization::Tshirt_C_Realization(forcing_params forcing_config,
                                            double Cgw,
                                            double expon,
                                            double max_gw_storage,
-                                           const vector<double> &nash_storage)
+                                           const std::vector<double> &nash_storage)
            : Tshirt_C_Realization::Tshirt_C_Realization(std::move(forcing_config), output_stream, soil_storage,
                                                         groundwater_storage, storage_values_are_ratios,
                                                         std::move(catchment_id), giuh_json_reader,
@@ -388,7 +388,7 @@ std::string Tshirt_C_Realization::get_output_line_for_timestep(int timestep, std
     tshirt_c_result_fluxes flux_for_timestep = *fluxes[timestep];
     for (const std::string& name : get_output_var_names()) {
         // Get a lambda that takes a fluxes struct and returns the right (double) member value from it from the name
-        function<double(tshirt_c_result_fluxes)> get_val_func = get_output_var_flux_extraction_func(name);
+        std::function<double(tshirt_c_result_fluxes)> get_val_func = get_output_var_flux_extraction_func(name);
         double output_var_value = get_val_func(flux_for_timestep);
         output_str += output_str.empty() ? std::to_string(output_var_value) : "," + std::to_string(output_var_value);
     }
@@ -455,7 +455,7 @@ double Tshirt_C_Realization::get_response(time_step_t t_index, time_step_t t_del
     return fluxes.back()->Qout_m;
 }
 
-function<double(tshirt_c_result_fluxes)>
+std::function<double(tshirt_c_result_fluxes)>
 Tshirt_C_Realization::get_output_var_flux_extraction_func(const std::string& var_name) {
     // TODO: think about making this a lazily initialized member map
     if (var_name == OUT_VAR_BASE_FLOW) {
@@ -489,7 +489,7 @@ Tshirt_C_Realization::get_output_var_flux_extraction_func(const std::string& var
  */
 std::vector<double> Tshirt_C_Realization::get_value(const std::string& name) {
     // Generate a lambda that takes a fluxes struct and returns the right (double) member value from it from the name
-    function<double(tshirt_c_result_fluxes)> get_val_func = get_output_var_flux_extraction_func(name);
+    std::function<double(tshirt_c_result_fluxes)> get_val_func = get_output_var_flux_extraction_func(name);
     // Then, assuming we don't bail, use the lambda to build the result array
     std::vector<double> outputs = std::vector<double>(fluxes.size());
     for (int i = 0; i < fluxes.size(); ++i) {

--- a/test/core/nexus/NexusRemoteTests.cpp
+++ b/test/core/nexus/NexusRemoteTests.cpp
@@ -71,8 +71,8 @@ TEST_F(Nexus_Remote_Test, TestInit0)
     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
 
     std::shared_ptr<HY_PointHydroNexusRemote> nexus;
-    std::vector<string> upstream_catchments = {"cat-26"};
-    std::vector<string> downstream_catchments = {"cat-27"};
+    std::vector<std::string> upstream_catchments = {"cat-26"};
+    std::vector<std::string> downstream_catchments = {"cat-27"};
 
     // create a nexus at both ranks
     if ( mpi_rank == 0)
@@ -131,8 +131,8 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders)
     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
 
     std::shared_ptr<HY_PointHydroNexusRemote> nexus;
-    std::vector<string> upstream_catchments;
-    std::vector<string> downstream_catchments = {"cat-27"};
+    std::vector<std::string> upstream_catchments;
+    std::vector<std::string> downstream_catchments = {"cat-27"};
     // create a nexus at both ranks
     if ( mpi_rank == 0)
     {
@@ -211,8 +211,8 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders1LocalSender)
     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
 
     std::shared_ptr<HY_PointHydroNexusRemote> nexus;
-    std::vector<string> upstream_catchments;
-    std::vector<string> downstream_catchments = {"cat-27"};
+    std::vector<std::string> upstream_catchments;
+    std::vector<std::string> downstream_catchments = {"cat-27"};
     // create a nexus at both ranks
     if ( mpi_rank == 0)
     {
@@ -293,8 +293,8 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
 
     std::shared_ptr<HY_PointHydroNexusRemote> nexus;
-    std::vector<string> upstream_catchments;
-    std::vector<string> downstream_catchments = {"cat-27"};
+    std::vector<std::string> upstream_catchments;
+    std::vector<std::string> downstream_catchments = {"cat-27"};
     // create a nexus at both ranks
     if ( mpi_rank == 0)
     {
@@ -418,8 +418,8 @@ TEST_F(Nexus_Remote_Test, TestDeadlock1)
     double recieved_flow;
     long ts = 0;
 
-    std::vector<string> downstream_catchments;
-    std::vector<string> upstream_catchments;
+    std::vector<std::string> downstream_catchments;
+    std::vector<std::string> upstream_catchments;
 
     // In this test both processes send before recieving. If communciation are synchronus this will dead lock
 
@@ -437,7 +437,7 @@ TEST_F(Nexus_Remote_Test, TestDeadlock1)
         nexus1->add_upstream_flow(200.0,"cat-25",ts);						// sending to rank 1
                               
         recieved_flow = nexus2->get_downstream_flow("cat-26",ts,100);       // get the recieved flow
-        cout << "rank 0 recieved a flow of " << recieved_flow << "\n";
+        std::cout << "rank 0 recieved a flow of " << recieved_flow << "\n";
     }
     else if ( mpi_rank == 1)
     {
@@ -452,7 +452,7 @@ TEST_F(Nexus_Remote_Test, TestDeadlock1)
         nexus1->add_upstream_flow(200.0,"cat-26",ts);						// sending to rank 0
                               
         recieved_flow = nexus2->get_downstream_flow("cat-25",ts,100);       // get the recieved flow
-        cout << "rank 1 recieved a flow of " << recieved_flow << "\n";
+        std::cout << "rank 1 recieved a flow of " << recieved_flow << "\n";
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -477,7 +477,7 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
         int target_rank = static_cast<int>(i / nodes_per_rank);
         if ( target_rank != mpi_rank )
         {
-            loc_map[string("cat-"+std::to_string(i))] = target_rank;
+            loc_map[std::string("cat-"+std::to_string(i))] = target_rank;
         }
         else
         {

--- a/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
+++ b/test/realizations/catchments/Tshirt_C_Realization_Test.cpp
@@ -290,8 +290,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
-
+    std::string line;
     int timestep = 0;
 
     while (getline(standalone_data_ingest_stream, line)) {
@@ -301,8 +300,8 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1a) {
         double input_storage = std::stod(result_vector[1]) / 1000 / 3600;
 
         // Output the line essentially
-        //copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
-        //cout << "\n";
+        //copy(result_vector.begin(), result_vector.end(), std::ostream_iterator<std::string>(std::cout, "|"));
+        //std::cout << "\n";
 
         tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         timestep++;
@@ -349,7 +348,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep1b) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     int timestep = 0;
 
@@ -404,7 +403,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep2a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     for (int timestep = 0; timestep < 5; ++timestep) {
         tshirt_c_real.get_response(timestep, 3600);
@@ -453,7 +452,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetOutputLineForTimestep2b) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     for (int timestep = 0; timestep < 5; ++timestep) {
         tshirt_c_real.get_response(timestep, 3600);
@@ -614,7 +613,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetValue1a) {
 
     std::vector<std::string> result_vector;
     std::vector<double> values_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -661,7 +660,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGetValue1b) {
 
     std::vector<std::string> result_vector;
     std::vector<double> values_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -707,7 +706,7 @@ TEST_F(Tshirt_C_Realization_Test, TestSurfaceRunoffCalc1a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -730,8 +729,8 @@ TEST_F(Tshirt_C_Realization_Test, TestSurfaceRunoffCalc1a) {
         expected /= 1000;
 
         // Output the line essentially
-        copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
-        cout << "\n";
+        copy(result_vector.begin(), result_vector.end(), std::ostream_iterator<std::string>(std::cout, "|"));
+        std::cout << "\n";
 
         tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
 
@@ -785,7 +784,7 @@ TEST_F(Tshirt_C_Realization_Test, TestGiuhRunoffCalc1a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -808,8 +807,8 @@ TEST_F(Tshirt_C_Realization_Test, TestGiuhRunoffCalc1a) {
         expected /= 1000;
 
         // Output the line essentially
-        copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
-        cout << "\n";
+        copy(result_vector.begin(), result_vector.end(), std::ostream_iterator<std::string>(std::cout, "|"));
+        std::cout << "\n";
 
         tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_giuh_runoff();
@@ -875,7 +874,7 @@ TEST_F(Tshirt_C_Realization_Test, TestLateralFlowCalc1a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -898,8 +897,8 @@ TEST_F(Tshirt_C_Realization_Test, TestLateralFlowCalc1a) {
         expected /= 1000;
 
         // Output the line essentially
-        copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
-        cout << "\n";
+        copy(result_vector.begin(), result_vector.end(), std::ostream_iterator<std::string>(std::cout, "|"));
+        std::cout << "\n";
 
         tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_lateral_flow();
@@ -954,7 +953,7 @@ TEST_F(Tshirt_C_Realization_Test, TestBaseFlowCalc1a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -977,8 +976,8 @@ TEST_F(Tshirt_C_Realization_Test, TestBaseFlowCalc1a) {
         expected /= 1000;
 
         // Output the line essentially
-        copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
-        cout << "\n";
+        copy(result_vector.begin(), result_vector.end(), std::ostream_iterator<std::string>(std::cout, "|"));
+        std::cout << "\n";
 
         tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_base_flow();
@@ -1033,7 +1032,7 @@ TEST_F(Tshirt_C_Realization_Test, TestTotalDischargeOutputCalc1a) {
             nash_storage);
 
     std::vector<std::string> result_vector;
-    string line;
+    std::string line;
 
     while (getline(standalone_data_ingest_stream, line)) {
         Tokenizer tokenizer(line);
@@ -1056,8 +1055,8 @@ TEST_F(Tshirt_C_Realization_Test, TestTotalDischargeOutputCalc1a) {
         expected /= 1000;
 
         // Output the line essentially
-        copy(result_vector.begin(), result_vector.end(), ostream_iterator<string>(cout, "|"));
-        cout << "\n";
+        copy(result_vector.begin(), result_vector.end(), std::ostream_iterator<std::string>(std::cout, "|"));
+        std::cout << "\n";
 
         tshirt_c_real.run_formulation_for_timestep(input_storage, 3600);
         double actual = tshirt_c_real.get_latest_flux_total_discharge();


### PR DESCRIPTION
Fixes namepsace issues that lead to boost::geometry throwing cryptic compiler errors using gcc-12.