### PR TITLE
Fix typo that would prevent file with units=`hours` from functioning …

### DIFF
--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -193,7 +193,7 @@ namespace data_access
                 }
 
                 // set time unit and scale factor
-                if ( time_unit_str == "h" || time_unit_str == "hours ")
+                if ( time_unit_str == "h" || time_unit_str == "hours")
                 {
                     time_unit = TIME_HOURS;
                     time_scale_factor = 3600;


### PR DESCRIPTION
…properly.

there's an unwanted space there.

## Additions

-

## Removals

- magic whitespace

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
