### PR TITLE
Interim Fix Issue #451

### DIFF
--- a/include/forcing/AorcForcing.hpp
+++ b/include/forcing/AorcForcing.hpp
@@ -40,8 +40,8 @@ struct forcing_params
   std::string end_time;
   std::string date_format =  "%Y-%m-%d %H:%M:%S";
   std::string provider;
-  time_t start_t;
-  time_t end_t;
+  time_t simulation_start_t;
+  time_t simulation_end_t;
   /*
     Constructor for forcing_params
   */
@@ -54,10 +54,10 @@ struct forcing_params
       strptime(this->start_time.c_str(), this->date_format.c_str() , &tm);
       //mktime returns time in local time based on system timezone
       //FIXME use timegm (not standard)? or implement timegm (see above link)
-      this->start_t = timegm( &tm );
+      this->simulation_start_t = timegm( &tm );
 
       strptime(this->end_time.c_str(), this->date_format.c_str() , &tm);
-      this->end_t = timegm( &tm );
+      this->simulation_end_t = timegm( &tm );
     }
 };
 

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -31,9 +31,9 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
     typedef struct tm time_type;
 
 
-    CsvPerFeatureForcingProvider(forcing_params forcing_config):start_date_time_epoch(forcing_config.start_t),
-                                           end_date_time_epoch(forcing_config.end_t),
-                                           current_date_time_epoch(forcing_config.start_t),
+    CsvPerFeatureForcingProvider(forcing_params forcing_config):start_date_time_epoch(forcing_config.simulation_start_t),
+                                           end_date_time_epoch(forcing_config.simulation_end_t),
+                                           current_date_time_epoch(forcing_config.simulation_start_t),
                                            forcing_vector_index(-1)
     {
         read_csv(forcing_config.path);
@@ -47,6 +47,8 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
      * @return The inclusive beginning of the period of time over which this instance can provide this data.
      */
     long get_data_start_time() override {
+        //FIXME: Trace this back and you will find that it is the simulation start time, not having anything to do with the forcing at all.
+        // Apparently this "worked", but at a minimum the description above is false.
         return start_date_time_epoch;
     }
 

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -255,7 +255,10 @@ namespace data_access
             std::tm tm{};
             std::stringstream s(epoch_start_str);
             s >> std::get_time(&tm, "%D %T");
-            std::time_t epoch_start_time = mktime(&tm);
+            //std::time_t epoch_start_time = mktime(&tm);
+            // See also comments in Simulation_Time.h .. timegm is not available on Windows at least (elsewhere?)
+            //TODO: Probably make the default string above explicit to UTC and interpret TZ from the string in all cases?
+            std::time_t epoch_start_time = timegm(&tm);
 
             // scale the time to account for time units and epoch_start
             // TODO make sure this happens with a FMA instruction

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -50,19 +50,23 @@ namespace data_access
          * @param log_s An output log stream for messages from the underlying library. If a provider object for
          * the given path already exists, this argument will be ignored.
          */
-        static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, utils::StreamHandler log_s){
+        static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s)
+        {
             const std::lock_guard<std::mutex> lock(shared_providers_mutex);
             std::shared_ptr<NetCDFPerFeatureDataProvider> p;
             if(shared_providers.count(input_path) > 0){
                 p = shared_providers[input_path];
             } else {
-                p = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(input_path, log_s);
+                p = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(input_path, sim_start, sim_end, log_s);
                 shared_providers[input_path] = p;
             }
             return p;
         }
 
-        NetCDFPerFeatureDataProvider(std::string input_path, utils::StreamHandler log_s) : log_stream(log_s), value_cache(20)
+        NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
+            sim_start_date_time_epoch(sim_start),
+            sim_end_date_time_epoch(sim_end)
+
         {
             //size_t sizep = 1073741824, nelemsp = 202481;
             //float preemptionp = 0.75;
@@ -289,14 +293,16 @@ namespace data_access
             start_time = time_vals[0];
             stop_time = time_vals.back() + time_stride;
 
-
+            sim_to_data_time_offset = sim_start_date_time_epoch - start_time;
         }
 
+        /*
         NetCDFPerFeatureDataProvider(const char* input_path, utils::StreamHandler stream_h) : 
             NetCDFPerFeatureDataProvider(std::string(input_path), stream_h)
         {
 
         }
+        */
 
         /** Return the variables that are accessable by this data provider */
 
@@ -315,14 +321,18 @@ namespace data_access
 
         long get_data_start_time() override
         {
-            return start_time;
+            //return start_time;
+            //FIXME: Matching behavior from CsvPerFeatureForcingProvider, but both are probably wrong!
+            return sim_start_date_time_epoch; // return start_time + sim_to_data_time_offset;
         }
 
         /** Return the last valid time for which data from the requested variable can be requested */
 
         long get_data_stop_time() override
         {
-            return stop_time;
+            //return stop_time;
+            //FIXME: Matching behavior from CsvPerFeatureForcingProvider, but both are probably wrong!
+            return sim_end_date_time_epoch; // return end_time + sim_to_data_time_offset;
         }
 
         long record_duration() override
@@ -489,6 +499,10 @@ namespace data_access
 
 
         private:
+
+        time_t sim_start_date_time_epoch;
+        time_t sim_end_date_time_epoch;
+        time_t sim_to_data_time_offset; // Deliberately signed--sim should never start before data, yes?
 
         static std::mutex shared_providers_mutex;
         static std::map<std::string, std::shared_ptr<NetCDFPerFeatureDataProvider>> shared_providers;

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -75,7 +75,7 @@ namespace realization {
         }
 #ifdef NETCDF_ACTIVE
         else if (forcing_config.provider == "NetCDF"){
-            fp = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, output_stream);
+            fp = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, output_stream);
         }
 #endif
         else { // Some unknown string in the provider field?

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -58,7 +58,10 @@ void NetCDFPerFeatureDataProviderTest::setupForcing()
         };
     std::string forcing_file_name = utils::FileChecker::find_first_readable(forcing_file_names);
 
-    nc_provider = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(forcing_file_name, utils::getStdErr() );
+    // Using this to compute epoch times... this is what's done in Formulation_Constructors.hpp, FWIW...
+    forcing_params forcing_p(forcing_file_name, "NetCDF", "2015-12-01 00:00:00", "2015-12-30 23:00:00");
+
+    nc_provider = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(forcing_file_name, forcing_p.simulation_start_t, forcing_p.simulation_end_t, utils::getStdErr() );
     start_date_time = std::make_shared<time_type>();
     end_date_time = std::make_shared<time_type>();
 }


### PR DESCRIPTION
Makes `NetCDFPerFeatureDataProvider` match behavior of `CsvPerFeatureForcingProvider` but both are probably wrong. Needs discussion but may need merging as an interim fix.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
