### PR TITLE
Fix macOS runners - add `netcdf-cxx` and `netcdf-fortran` package to brew install

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -75,7 +75,7 @@ runs:
               sudo apt-get install -y --fix-missing libnetcdf-dev libnetcdff-dev libnetcdf-c++4-1 libnetcdf-c++4-dev
             elif [ ${{ runner.os }} == 'macOS' ]
             then
-              brew install netcdf
+              brew install netcdf netcdf-cxx
               echo "LIBRARY_PATH=/usr/local/lib/:$LIBRARY_PATH" >> $GITHUB_ENV
               echo "LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH" >> $GITHUB_ENV
               echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -75,7 +75,7 @@ runs:
               sudo apt-get install -y --fix-missing libnetcdf-dev libnetcdff-dev libnetcdf-c++4-1 libnetcdf-c++4-dev
             elif [ ${{ runner.os }} == 'macOS' ]
             then
-              brew install netcdf netcdf-cxx
+              brew install netcdf netcdf-cxx netcdf-fortran
               echo "LIBRARY_PATH=/usr/local/lib/:$LIBRARY_PATH" >> $GITHUB_ENV
               echo "LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH" >> $GITHUB_ENV
               echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,4 +6,4 @@ ENV LD_LIBRARY_PATH=/home/linuxbrew/.linuxbrew/lib
 ENV CC=/home/linuxbrew/.linuxbrew/bin/gcc-11
 ENV CXX=/home/linuxbrew/.linuxbrew/bin/g++-11
 
-RUN brew install boost udunits numpy netcdf
+RUN brew install boost udunits numpy netcdf netcdf-cxx netcdf-fortran 


### PR DESCRIPTION
Add netcdf-cxx and netcdf-fortran package to brew install... looks like these were broken out into their own formulae about 15 days ago.

## Additions

- `netcdf-cxx` and `netcdf-fortran` brew install command for macOS build action
- updates to similar brew install command in `.gitpod.Dockerfile`

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
- [X] macOS
