### PR TITLE
Fix a smattering of errors and warnings with newer compilers

### DIFF
--- a/include/forcing/DataProviderSelectors.hpp
+++ b/include/forcing/DataProviderSelectors.hpp
@@ -134,7 +134,9 @@ class CSVDataSelector : public CatchmentAggrDataSelector
         CatchmentAggrDataSelector(std::string(), var, start, dur, units)
     {}
 
+    #if GCC_VERSION < 8 && !defined(__llvm__)
     operator const CatchmentAggrDataSelector&() const { return *this; }
+    #endif
 
     private:
 };
@@ -147,7 +149,9 @@ class BMIDataSelector : public CatchmentAggrDataSelector
         CatchmentAggrDataSelector(std::string(), var, start, dur, units)
     {}
 
+    #if GCC_VERSION < 8 && !defined(__llvm__)
     operator const CatchmentAggrDataSelector&() const { return *this; }
+    #endif
 
     private:
 };
@@ -170,8 +174,9 @@ class NetCDFDataSelector : public CatchmentAggrDataSelector
         
     }
 
+    #if GCC_VERSION < 8 && !defined(__llvm__)
     operator const CatchmentAggrDataSelector&() const { return *this; }
-
+    #endif
 
     private: 
 };

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -297,7 +297,7 @@ namespace data_access
 
         /** Return the variables that are accessable by this data provider */
 
-        const std::vector<std::string>& get_avaliable_variable_names()
+        const std::vector<std::string>& get_avaliable_variable_names() override
         {
             return variable_names;
         }
@@ -310,19 +310,19 @@ namespace data_access
 
         /** Return the first valid time for which data from the request variable  can be requested */
 
-        long get_data_start_time()
+        long get_data_start_time() override
         {
             return start_time;
         }
 
         /** Return the last valid time for which data from the requested variable can be requested */
 
-        long get_data_stop_time()
+        long get_data_stop_time() override
         {
             return stop_time;
         }
 
-        long record_duration()
+        long record_duration() override
         {
             return time_stride;
         }
@@ -336,7 +336,7 @@ namespace data_access
          * @return The index of the forcing time step that contains the given point in time.
          * @throws std::out_of_range If the given point is not in any time step.
          */
-        size_t get_ts_index_for_time(const time_t &epoch_time)
+        size_t get_ts_index_for_time(const time_t &epoch_time) override
         {
             if (start_time <= epoch_time && epoch_time < stop_time)
             {

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -244,7 +244,7 @@ namespace realization {
          * @see ForcingProvider
          */
         //const vector<std::string> &get_available_forcing_outputs() {
-        const vector<std::string> &get_avaliable_variable_names() {
+        const vector<std::string> &get_avaliable_variable_names() override {
             if (is_model_initialized() && available_forcings.empty()) {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -181,7 +181,7 @@ namespace realization {
          */
         //const vector<std::string> &get_available_forcing_outputs();
         //const vector<std::string> &get_avaliable_variable_names() override { return get_available_forcing_outputs(); }
-        const vector<std::string> &get_avaliable_variable_names();
+        const vector<std::string> &get_avaliable_variable_names() override;
 
         /**
         * Get the input variables of 

--- a/test/core/nexus/NexusTests.cpp
+++ b/test/core/nexus/NexusTests.cpp
@@ -47,7 +47,7 @@ TEST_F(Nexus_Test, TestInit0)
     //HY_HydroLocationType type(HY_HydroLocationType::undefined);    //!< Test data type
     //HY_IndirectPosition pos;
     //std::shared_ptr<HY_HydroLocation>location = std::make_shared<HY_HydroLocation>(point, type, pos);
-    std::vector<string> contrib = {"cat-1"};
+    std::vector<std::string> contrib = {"cat-1"};
     //HY_PointHydroNexus("nex-0", location, std::vector<string>(), contrib);
     HY_PointHydroNexus("nex-0", contrib);
     ASSERT_TRUE( true );


### PR DESCRIPTION
Fixes one actual build error in `NexusTests.cpp` and a bunch of warnings to clean up output.

After this only the `GetValue` -> `GetValues` deprecation warning remains 🎉 

## Additions

- Added `std::` to string vector in `NexusTests.cpp`
- Put `#if` around Selector constructors that are only needed for older compilers
- Added several missing `override` statements that were being warned on

## Removals

-

## Changes

- Bumped googletest to 1.12.1

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
