### PR TITLE
explicitly import iostream for print message in routing adapter

### DIFF
--- a/src/routing/Routing_Py_Adapter.cpp
+++ b/src/routing/Routing_Py_Adapter.cpp
@@ -2,7 +2,7 @@
 
 #include <exception>
 #include <utility>
-
+#include <iostream>
 #include "Routing_Py_Adapter.hpp"
 
 using namespace routing_py_adapter;


### PR DESCRIPTION
A quick fix to ensure that `std::cout` is available in this compilation unit by explicitly `#include <iostream>`.  