### PR TITLE
Build info and python runtime info

### DIFF
--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -254,6 +254,7 @@ namespace utils {
                 return py::list();
             }
 
+        public:
             /**
              * Get the current Python interpreter system path, returning in both a Python and C++ format.
              *
@@ -269,7 +270,33 @@ namespace utils {
                 }
                 return std::make_tuple(sys_path, sys_path_vector);
             }
+            /**
+             * Find any virtual environment site packages directory, starting from options under the current directory.
+             *
+             * @return The absolute path of the site packages directory, as a string.
+             */
+            std::string getDiscoveredVenvPath() {
+                // Look for a local virtual environment directory also, if there is one
+                const char* env_var_venv = std::getenv("VIRTUAL_ENV");
+                if(env_var_venv != nullptr){
+                    //std::string r(env_var_venv);
+                    return std::string(env_var_venv);
+                }
+                py::object venv_dir;
+                venv_dir = searchForVenvDir();
+                if(venv_dir.is_none()){
+                    return std::string("None");
+                }
+                if(py::bool_(venv_dir.attr("is_dir")())) {
+                    // Probably better to not resolve symlinks so you can see where it was found...
+                    //venv_dir = venv_dir.attr("resolve")();
+                    return py::str(venv_dir);
+                }
+                assert("Unexpected value of venv_dir in InterpreterUtil::getDiscoveredVenvPath()!");
+                return ""; // silence warning
+            }
 
+        protected:
             /**
              * Get whether a Python module is imported.
              *

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -92,15 +92,61 @@ int main(int argc, char *argv[]) {
     std::vector<string> catchment_subset_ids;
     std::vector<string> nexus_subset_ids;
 
-    if( argc < 6) {
+    if( argc < 2) {
+        // Usage
+        std::cout << "Usage: " << std::endl;
+        std::cout << argv[0] << " <catchment_data_path> <catchment subset ids> <nexus_data_path> <nexus subset ids>"
+                  << " <realization_config_path>" << std::endl
+                  << "Arguments for <catchment subset ids> and <nexus subset ids> must be given." << std::endl
+                  << "Use \"all\" as explicit argument when no subset is needed." << std::endl;
+
+        // Build and environment information
+        cout<<std::endl<<"Build Info:"<<std::endl;
+        cout<<"  NGen version: " // This is here mainly so that there will be *some* output if somehow no other options are enabled.
+          << ngen_VERSION_MAJOR << "."
+          << ngen_VERSION_MINOR << "."
+          << ngen_VERSION_PATCH << std::endl;
+        #ifdef NGEN_MPI_ACTIVE
+        cout<<"  Parallel build"<<std::endl;
+        #endif
+        #ifdef NETCDF_ACTIVE
+        cout<<"  NetCDF lumped forcing enabled"<<std::endl;
+        #endif
+        #ifdef NGEN_BMI_FORTRAN_ACTIVE
+        cout<<"  Fortran BMI enabled"<<std::endl;
+        #endif
+        #ifdef NGEN_C_LIB_ACTIVE
+        cout<<"  C BMI enabled"<<std::endl;
+        #endif
+        #ifdef ACTIVATE_PYTHON
+        cout<<"  Python active"<<std::endl;
+        cout<<"    Embedded interpreter version: "<<PY_MAJOR_VERSION<<"."<<PY_MINOR_VERSION<<"."<<PY_MICRO_VERSION<<std::endl;
+        #endif
+        #ifdef NGEN_ROUTING_ACTIVE
+        cout<<"  Routing active"<<std::endl;
+        #endif
+        #ifdef ACTIVATE_PYTHON
+        cout<<std::endl<<"Python Environment Info:"<<std::endl;
+        cout<<"  VIRTUAL_ENV environment variable: "<<(std::getenv("VIRTUAL_ENV") == nullptr ? "(not set)" : std::getenv("VIRTUAL_ENV"))<<std::endl;
+        cout<<"  Discovered venv: "<<_interp->getDiscoveredVenvPath()<<std::endl;
+        auto paths = _interp->getSystemPath();
+        cout<<"  System paths:"<<std::endl;
+        for(std::string& path: std::get<1>(paths)){
+          cout<<"    "<<path<<std::endl;
+        }
+        #endif
+        cout<<std::endl;
+        exit(0); // Unsure if this path should have a non-zero exit code?
+    } else if( argc < 6) {
         std::cout << "Missing required args:" << std::endl;
         std::cout << argv[0] << " <catchment_data_path> <catchment subset ids> <nexus_data_path> <nexus subset ids>"
                   << " <realization_config_path>" << std::endl;
         if(argc > 3) {
             std::cout << std::endl << "Note:" << std::endl
                       << "Arguments for <catchment subset ids> and <nexus subset ids> must be given." << std::endl
-                      << "Use empty string (\"\") as explicit argument when no subset is needed." << std::endl;
+                      << "Use \"all\" as explicit argument when no subset is needed." << std::endl;
         }
+
         exit(-1);
     }
     else {


### PR DESCRIPTION
Adds some basic build switch information and python runtime information, as well as usage info, to the output if the number of arguments is zero or 1... so we could call this our `--help` implementation, until we get a more sophisticated arguments parser. The Python info should be very useful in troubleshooting e.g. #441 .

## Additions

- Added information to usage output
- Added `InterpreterUtil::getDiscoveredVenvPath()` method

## Removals

-

## Changes

- Made `InterpreterUtil::getSystemPath()` public instead of protected

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
