### PR TITLE
Guard interpreter util

### DIFF
--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -27,7 +27,9 @@ using namespace realization;
 
 class Bmi_Multi_Formulation_Test : public ::testing::Test {
 private:
+#ifdef ACTIVATE_PYTHON
     static std::shared_ptr<InterpreterUtil> interperter;
+#endif
 protected:
 
     static std::string find_file(std::vector<std::string> dir_opts, const std::string& basename) {
@@ -448,7 +450,9 @@ private:
 
 };
 //Make sure the interperter is instansiated and lives throught the test class
+#ifdef ACTIVATE_PYTHON
 std::shared_ptr<InterpreterUtil> Bmi_Multi_Formulation_Test::interperter = InterpreterUtil::getInstance();
+#endif
 
 void Bmi_Multi_Formulation_Test::SetUpTestSuite() {
     #ifdef ACTIVATE_PYTHON


### PR DESCRIPTION
Fix a bug when building ngen with python turned off

## Additions

-

## Removals

-

## Changes

test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp

## Testing

Building and running ngen

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
