### PR TITLE
Update github action set-output to use new environment file

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -153,7 +153,7 @@ runs:
             export BOOST_ROOT="$(pwd)/boost_1_72_0"
             [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} -DBMI_C_LIB_ACTIVE:BOOL=${{ inputs.bmi_c }} -DNGEN_ACTIVATE_PYTHON:BOOL=${{ inputs.use_python }} -DUDUNITS_ACTIVE:BOOL=${{ inputs.use_udunits }} -DBMI_FORTRAN_ACTIVE:BOOL=${{ inputs.bmi_fortran }} -DNGEN_ACTIVATE_ROUTING:BOOL=${{ inputs.use_troute }} -DNETCDF_ACTIVE:BOOL=${{ inputs.use_netcdf }} -DMPI_ACTIVE:BOOL=${{ inputs.use_mpi }} -S .
-            echo "::set-output name=build-dir::$(echo ${{ inputs.build-dir }})"
+            echo "build-dir=$(echo ${{ inputs.build-dir }})" >> $GITHUB_OUTPUT
           shell: bash
 
         - name: Build Targets

--- a/.github/actions/ngen-submod-build/action.yaml
+++ b/.github/actions/ngen-submod-build/action.yaml
@@ -40,7 +40,7 @@ runs:
           id: cmake_init
           run: |
             cmake -B ${{ inputs.mod-dir}}/${{ inputs.build-dir }} -S ${{ inputs.mod-dir }}
-            echo "::set-output name=build-dir::$(echo ${{ inputs.mod-dir}}/${{ inputs.build-dir }})"
+            echo "build-dir=$(echo ${{ inputs.mod-dir}}/${{ inputs.build-dir }})" >> $GITHUB_OUTPUT
           shell: bash
 
         - name: Build Targets


### PR DESCRIPTION
Make changes in github actions to use the new github environment file to prepare for anticipated deprecation of "set-output"

## Additions

-

## Removals

-

## Changes

.github/actions/ngen-build/action.yaml
.github/actions/ngen-submod-build/action.yaml

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
