### PR TITLE
Passing catchment id to CatchmentAggrDataSelector

### DIFF
--- a/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
+++ b/src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
@@ -121,13 +121,7 @@ double Simple_Lumped_Model_Realization::get_response(time_step_t t_index, time_s
     }
 
     double precip;
-    const std::string forcing_name = CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE;
-    try {
-        precip = this->forcing->get_value(CatchmentAggrDataSelector(this->id, CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
-    }
-    catch (const std::exception& e){
-        precip = this->forcing->get_value(CatchmentAggrDataSelector(this->id, CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
-    }
+    precip = this->forcing->get_value(CatchmentAggrDataSelector(this->id, CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
     add_time(t_index+1, params.n);
     //FIXME should this run "daily" or hourly (t) which should really be dt
     //Do we keep an "internal dt" i.e. this->dt and reconcile with t?

--- a/src/realizations/catchment/Tshirt_C_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_C_Realization.cpp
@@ -446,9 +446,10 @@ double Tshirt_C_Realization::get_response(time_step_t t_index, time_step_t t_del
     if (t_current > stop_time) {
         throw std::invalid_argument("Getting response beyond time with available forcing.");
     }
+
     double precip;
     const std::string forcing_name = CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE;
-    precip = this->forcing->get_value(CatchmentAggrDataSelector("",CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
+    precip = this->forcing->get_value(CatchmentAggrDataSelector(this->catchment_id, CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
     int response_result = run_formulation_for_timestep(precip, t_delta_s);
     // TODO: check t_index is the next expected time step to be calculated
 

--- a/src/realizations/catchment/Tshirt_Realization.cpp
+++ b/src/realizations/catchment/Tshirt_Realization.cpp
@@ -107,9 +107,10 @@ double Tshirt_Realization::get_response(time_step_t t_index, time_step_t t_delta
     if (t_current > stop_time) {
         throw std::invalid_argument("Getting response beyond time with available forcing.");
     }
+
     double precip;
     const std::string forcing_name = CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE;
-    precip = this->forcing->get_value(CatchmentAggrDataSelector("",CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
+    precip = this->forcing->get_value(CatchmentAggrDataSelector(this->catchment_id, CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, t_current, t_delta_s, ""), data_access::SUM);
     //FIXME should this run "daily" or hourly (t) which should really be dt
     //Do we keep an "internal dt" i.e. this->dt and reconcile with t?
     int error = model->run(t_index, precip * t_delta_s / 1000, get_et_params_ptr());


### PR DESCRIPTION
Passing catchment id in place of an empty string in get_value function.

## Additions

-

## Removals

-

## Changes

src/realizations/catchment/Simple_Lumped_Model_Realization.cpp
src/realizations/catchment/Tshirt_C_Realization.cpp
src/realizations/catchment/Tshirt_Realization.cpp

## Testing

1. Various Unit tests
2. Run ngen

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
