### PR TITLE
Basic fix to make sure NetCDF files get closed

### DIFF
--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -63,6 +63,16 @@ namespace data_access
             return p;
         }
 
+        /**
+         * @brief Cleanup the shared providers cache, ensuring that the files get closed.
+         */
+        static void cleanup_shared_providers()
+        {
+            const std::lock_guard<std::mutex> lock(shared_providers_mutex);
+            // First lets try just emptying the map... if all goes well, everything will destruct properly on its own...
+            shared_providers.clear();
+        }
+
         NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
             sim_start_date_time_epoch(sim_start),
             sim_end_date_time_epoch(sim_end)

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -44,7 +44,11 @@ namespace realization {
                 this->tree = loaded_tree;
             }
 
-            virtual ~Formulation_Manager(){};
+            virtual ~Formulation_Manager(){
+#ifdef NETCDF_ACTIVE
+                data_access::NetCDFPerFeatureDataProvider::cleanup_shared_providers();
+#endif
+            };
 
             virtual void read(geojson::GeoJSON fabric, utils::StreamHandler output_stream) {
                 //TODO seperate the parsing of configuration options like time


### PR DESCRIPTION
Fixes #481. Seems to do the job in serial and parallel builds.

## Additions

- static function `data_access::NetCDFPerFeatureDataProvider::cleanup_shared_providers()`

## Removals

-

## Changes

- Calls above static function in `Formulation_Manager` destructor.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. Passing all auto tests. Tested on data in `./data/forcing` with mixed realization with NetCDF and CSV forcing in different catchments, serial and parallel builds (2 partitions). Not seeing any H5Dclose errors.

### Target Environment support

- [X] Linux
