### PR TITLE
Replace "move()" with "std::move()" in ngen code

### DIFF
--- a/include/forcing/OptionalWrappedDataProvider.hpp
+++ b/include/forcing/OptionalWrappedDataProvider.hpp
@@ -56,7 +56,7 @@ namespace data_access {
          * @param defaultVals Mapping of some or all provided output defaults, keyed by output name.
          */
         OptionalWrappedDataProvider(vector<string> providedOuts, map<string, double> defaultVals)
-                : DeferredWrappedProvider(move(providedOuts)), defaultValues(move(defaultVals))
+                : DeferredWrappedProvider(std::move(providedOuts)), defaultValues(std::move(defaultVals))
         {
             // Validate the provided map of default values to ensure there aren't any unrecognized keys, as this
             //    constraint is later relied upon (i.e., keys of defaultValues being in the providedOutputs collection)
@@ -89,7 +89,7 @@ namespace data_access {
          */
         OptionalWrappedDataProvider(vector<string> providedOuts, map<string, double> defaultVals,
                                 map<string, int> defaultWaits)
-                : OptionalWrappedDataProvider(move(providedOuts), move(defaultVals))
+                : OptionalWrappedDataProvider(std::move(providedOuts), std::move(defaultVals))
         {
             // Validate that all keys/names in the defaultWaits map have corresponding key in defaultValues
             // (Note that this also depends on the delegated-to constructor to validate the keys in defaultValues)
@@ -111,7 +111,7 @@ namespace data_access {
                     }
                 }
                 // Assuming the mapping is valid, set it for the instance
-                defaultUsageWaits = move(defaultWaits);
+                defaultUsageWaits = std::move(defaultWaits);
             }
         }
 
@@ -121,7 +121,7 @@ namespace data_access {
          * @param providedOutputs The collection of the names of outputs this instance will need to provide.
          */
         explicit OptionalWrappedDataProvider(vector<string> providedOutputs)
-            : OptionalWrappedDataProvider(move(providedOutputs), map<string, double>()) { }
+            : OptionalWrappedDataProvider(std::move(providedOutputs), map<string, double>()) { }
 
         /**
          * Convenience constructor for when there is only one provided output name, which does not have a default.
@@ -171,8 +171,8 @@ namespace data_access {
         OptionalWrappedDataProvider(OptionalWrappedDataProvider &&provider_to_move) noexcept
                 : OptionalWrappedDataProvider(provider_to_move.providedOutputs)
         {
-            defaultValues = move(provider_to_move.defaultValues);
-            defaultUsageWaits = move(provider_to_move.defaultUsageWaits);
+            defaultValues = std::move(provider_to_move.defaultValues);
+            defaultUsageWaits = std::move(provider_to_move.defaultUsageWaits);
             wrapped_provider = provider_to_move.wrapped_provider;
             provider_to_move.wrapped_provider = nullptr;
         }

--- a/include/realizations/catchment/Bmi_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Adapter.hpp
@@ -23,13 +23,13 @@ namespace models {
 
             Bmi_Adapter(string model_name, string bmi_init_config, string forcing_file_path, bool allow_exceed_end,
                         bool has_fixed_time_step, utils::StreamHandler output)
-                : model_name(move(model_name)),
-                  bmi_init_config(move(bmi_init_config)),
+                : model_name(std::move(model_name)),
+                  bmi_init_config(std::move(bmi_init_config)),
                   bmi_model_uses_forcing_file(!forcing_file_path.empty()),
-                  forcing_file_path(move(forcing_file_path)),
+                  forcing_file_path(std::move(forcing_file_path)),
                   bmi_model_has_fixed_time_step(has_fixed_time_step),
                   allow_model_exceed_end_time(allow_exceed_end),
-                  output(move(output)),
+                  output(std::move(output)),
                   bmi_model_time_convert_factor(1.0)
             {
                 // This replicates a lot of Initialize, but it's necessary to be able to do it separately to support

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -40,7 +40,7 @@ namespace realization {
          * @param output_stream
          */
         Bmi_Multi_Formulation(string id, std::shared_ptr<data_access::GenericDataProvider> forcing_provider, utils::StreamHandler output_stream)
-                : Bmi_Formulation(move(id), forcing_provider, output_stream) { };
+                : Bmi_Formulation(std::move(id), forcing_provider, output_stream) { };
 
         virtual ~Bmi_Multi_Formulation() {};
 

--- a/src/realizations/catchment/Bmi_Py_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_Py_Adapter.cpp
@@ -11,14 +11,14 @@ using namespace pybind11::literals; // to bring in the `_a` literal for pybind11
 
 Bmi_Py_Adapter::Bmi_Py_Adapter(const string &type_name, string bmi_init_config, const string &bmi_python_type,
                                bool allow_exceed_end, bool has_fixed_time_step, utils::StreamHandler output)
-        : Bmi_Py_Adapter(type_name, move(bmi_init_config), bmi_python_type, "", allow_exceed_end, has_fixed_time_step,
-                         move(output)) {}
+        : Bmi_Py_Adapter(type_name, std::move(bmi_init_config), bmi_python_type, "", allow_exceed_end, has_fixed_time_step,
+                         std::move(output)) {}
 
 Bmi_Py_Adapter::Bmi_Py_Adapter(const string &type_name, string bmi_init_config, const string &bmi_python_type,
                                string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                                utils::StreamHandler output)
-        : Bmi_Adapter<py::object>(type_name + " (BMI Py)", move(bmi_init_config),
-                                  move(forcing_file_path), allow_exceed_end, has_fixed_time_step,
+        : Bmi_Adapter<py::object>(type_name + " (BMI Py)", std::move(bmi_init_config),
+                                  std::move(forcing_file_path), allow_exceed_end, has_fixed_time_step,
                                   output),
           bmi_type_py_full_name(bmi_python_type),
           np(utils::ngenPy::InterpreterUtil::getPyModule("numpy")) /* like 'import numpy as np' */


### PR DESCRIPTION
Changes to code to comply to intel compiler.

## Additions

-

## Removals

-

## Changes

include/forcing/OptionalWrappedDataProvider.hpp
include/realizations/catchment/Bmi_Adapter.hpp
include/realizations/catchment/Bmi_Multi_Formulation.hpp
src/realizations/catchment/Bmi_Py_Adapter.cpp

## Testing

Unit tests
Run ngen tests

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
