### PR TITLE
Fix potential char overflow bug

### DIFF
--- a/extern/test_bmi_c/src/bmi_test_bmi_c.c
+++ b/extern/test_bmi_c/src/bmi_test_bmi_c.c
@@ -729,7 +729,11 @@ int read_file_line_counts(const char* file_name, int* line_count, int* max_line_
         return -1;
     }
     int seen_non_whitespace = 0;
-    char c;
+    int c; //EOF is a negative constant...and char may be either signed OR unsigned
+    //depending on the compiler, system, achitectured, ect.  So there are cases
+    //where this loop could go infinite comparing EOF to unsigned char
+    //the return of fgetc is int, and should be stored as such!
+    //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
         // keep track if this line has seen any char other than space or tab
         if (c != ' ' && c != '\t' && c != '\n')

--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
@@ -426,7 +426,11 @@ void TestBmiCpp::read_file_line_counts(std::string file_name, int* line_count, i
     throw std::runtime_error("Configuration file does not exist." SOURCE_LOC);
   }
   int seen_non_whitespace = 0;
-  char c;
+  int c; //EOF is a negative constant...and char may be either signed OR unsigned
+  //depending on the compiler, system, achitectured, ect.  So there are cases
+  //where this loop could go infinite comparing EOF to unsigned char
+  //the return of fgetc is int, and should be stored as such!
+  //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
   for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
     // keep track if this line has seen any char other than space or tab
     if (c != ' ' && c != '\t' && c != '\n')


### PR DESCRIPTION
A potential overflow flow bug exists in the `read_file_line_counts` function.  Depending on system, compiler, and hardware, this can lead to a infinite loop.

This bug has also been patched in these repositories as discovered. 

- [x] noaa-owp/cfe#85
- [x] noaa-owp/alt-modular#50
- [x] noaa-owp/aorc_bmi#6
- [x] noaa-owp/SoilFreezeThaw#6
- [x] noaa-owp/evapotranspiration#22

It may pop again in the future in different modules if the original bug was copy/pasted more.  If you think you are stuck initializing a module that shouldn't take forever...grep for `fgetc` and check if it is reading into a `char`, if so, it should be an `int`.

## Changes

- Change the i/o buffer type for character reading to `int` from `char` to avoid overflowing a possible unsigned char type.

## Testing

1. Tested through ngen unit tests

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux (x86 and arm)
- [x] MacOS (x86 and arm)

