### PR TITLE
fix t-route module build to install numpy

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -145,7 +145,7 @@ jobs:
           pip install -U pip
           pip install -U setuptools
           pip install -r requirements.txt
-          pip install deprecated pyarrow tables geopandas
+          pip install deprecated pyarrow tables geopandas numpy
           if [ ${{ runner.os }} == 'macOS' ] 
           then
             export LIBRARY_PATH=/usr/local/lib/gcc/11/


### PR DESCRIPTION
t-route integration test fails to build t-route missing numpy dependency.  This should ensure it is installed in the venv before attempting to build.