### PR TITLE
Test cleanup

### DIFF
--- a/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
+++ b/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
@@ -91,7 +91,12 @@ namespace models {
                 if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {
                     //Try alternative extension...
                     size_t idx = bmi_lib_file.rfind(".");
-                    std::string alt_bmi_lib_file;                    
+                    std::string alt_bmi_lib_file;  
+                    if(bmi_lib_file.length() == 0){
+                        this->init_exception_msg =
+                                "Can't init " + this->model_name + "; library file path is empty";
+                        throw std::runtime_error(this->init_exception_msg);
+                    }                
                     if(bmi_lib_file.substr(idx) == ".so"){
                         alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".dylib";
                     } else if(bmi_lib_file.substr(idx) == ".dylib"){

--- a/include/realizations/catchment/Bmi_Py_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Py_Adapter.hpp
@@ -674,6 +674,10 @@ namespace models {
                     if (init_exception_msg.empty()) {
                         init_exception_msg = "Unknown Python model initialization exception.";
                     }
+                    //This message is lost and often contains valuable info.  Either need to break up and catch 
+                    //other possible exceptions, wrap all these in a custom exception, or at the very least, print
+                    //the original messge before it gets lost in this re-throw.
+                    std::cerr<<init_exception_msg<<std::endl;
                     throw e;
                 }
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -285,6 +285,7 @@ if(NGEN_ACTIVATE_ROUTING)
             test_routing_pybind
             1
             routing/Routing_Py_Bind_Test.cpp
+            NGen::core # for filechecker utility
             NGen::routing
             pybind11::embed
     )

--- a/test/core/nexus/NexusRemoteTests.cpp
+++ b/test/core/nexus/NexusRemoteTests.cpp
@@ -68,6 +68,10 @@ void Nexus_Remote_Test::TearDown()
 //to a downstream remote nexus.
 TEST_F(Nexus_Remote_Test, TestInit0)
 {
+    if ( mpi_num_procs < 2 ) {
+	    GTEST_SKIP();
+    }
+
     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
 
     std::shared_ptr<HY_PointHydroNexusRemote> nexus;
@@ -409,6 +413,10 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
 
 TEST_F(Nexus_Remote_Test, TestDeadlock1)
 {
+    if ( mpi_num_procs < 2 ) {
+	    GTEST_SKIP();
+    }
+
     HY_PointHydroNexusRemote::catcment_location_map_t loc_map;
 
     std::shared_ptr<HY_PointHydroNexusRemote> nexus1;

--- a/test/data/routing/ngen_routing_config_unit_test.yaml
+++ b/test/data/routing/ngen_routing_config_unit_test.yaml
@@ -9,7 +9,7 @@ network_topology_parameters:
     supernetwork_parameters:
         #----------
         geo_file_type: HYFeaturesNetwork 
-        geo_file_path: ./test/data/routing/gauge_01073000.gpkg 
+        geo_file_path: ../../test/data/routing/gauge_01073000.gpkg
         mask_file_path: # domain/unit_test_noRS/coastal_subset.txt
         synthetic_wb_segments:
             #- 4800002
@@ -21,8 +21,8 @@ network_topology_parameters:
         break_network_at_waterbodies: False 
         level_pool:
             #----------
-            level_pool_waterbody_parameter_file_path: ./test/data/routing/gauge_01073000.gpkg 
-            reservoir_parameter_file                : ./test/data/routing/gauge_01073000.gpkg
+            level_pool_waterbody_parameter_file_path: ../../test/data/routing/gauge_01073000.gpkg
+            reservoir_parameter_file                : ../../test/data/routing/gauge_01073000.gpkg
         #rfc:
             #----------
             #reservoir_parameter_file                : domain/reservoir_index_AnA.nc
@@ -58,11 +58,11 @@ compute_parameters:
         #----------
         qts_subdivisions            : 12
         dt                          : 300 # [sec]
-        qlat_input_folder           : ./test/data/routing/ 
+        qlat_input_folder           : ../../test/data/routing/
         qlat_file_pattern_filter    : "nex-*"
-        nexus_input_folder          : ./test/data/routing/ 
+        nexus_input_folder          : ../../test/data/routing/
         nexus_file_pattern_filter   : "nex-*" #OR "*NEXOUT.parquet" OR "nex-*"
-        binary_nexus_file_folder    : ./test/data/routing/ # this is required if nexus_file_pattern_filter="nex-*"
+        binary_nexus_file_folder    : ../../test/data/routing/ # this is required if nexus_file_pattern_filter="nex-*"
         #coastal_boundary_input_file : channel_forcing/schout_1.nc  
         nts                         : 8640 #288 for 1day
         max_loop_size               : 720 # [hr]  
@@ -98,6 +98,6 @@ output_parameters:
         #wrf_hydro_channel_output_source_folder: ./
     chanobs_output:
         #----------
-        chanobs_output_directory: ./test/data/routing/ 
+        chanobs_output_directory: ../../test/data/routing/
         chanobs_filepath        : Chanobs.nc
-    lakeout_output: ./test/data/routing/
+    lakeout_output: ../../test/data/routing/

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -69,11 +69,12 @@ class Formulation_Manager_Test : public ::testing::Test {
 
     std::vector<std::string> path_options = {
             "",
+            "../",
+            "../../",
             "./test/",
             "../test/",
-            "../../test/",
-            "../",
-            "../../"
+            "../../test/"
+
     };
 
     std::string fix_paths(std::string json)
@@ -84,6 +85,17 @@ class Formulation_Manager_Test : public ::testing::Test {
                 "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv",
                 "./data/forcing/cat-27115-nwm-aorc-variant-derived-format.csv"
         };
+        std::vector<std::string> v = {};
+        for(unsigned int i = 0; i < path_options.size(); i++){
+                v.push_back( path_options[i] + "data/forcing" );
+        }
+        std::string dir = utils::FileChecker::find_first_readable(v);
+        if(dir != ""){
+                std::string remove = "\"./data/forcing/\"";
+                std::string replace = "\""+dir+"\"";
+                //std::cerr<<"TRYING TO REPLACE DIRECTORY... "<<remove<<" -> "<<replace<<std::endl;
+                boost::replace_all(json, remove , replace);
+        }
         for (unsigned int i = 0; i < forcing_paths.size(); i++) {
           if(json.find(forcing_paths[i]) == std::string::npos){
             continue;
@@ -95,7 +107,7 @@ class Formulation_Manager_Test : public ::testing::Test {
           std::string right_path = utils::FileChecker::find_first_readable(v);
           if(right_path != forcing_paths[i]){
             std::cerr<<"Replacing "<<forcing_paths[i]<<" with "<<right_path<<std::endl;
-            json = json.replace(json.find(forcing_paths[i]), forcing_paths[i].length(), right_path);
+            boost::replace_all(json, forcing_paths[i] , right_path);
           }
         }
         return json;

--- a/test/routing/Routing_Py_Bind_Test.cpp
+++ b/test/routing/Routing_Py_Bind_Test.cpp
@@ -1,6 +1,7 @@
 #ifdef ROUTING_PYBIND_TESTS_ACTIVE
 #include "gtest/gtest.h"
 #include "Routing_Py_Adapter.hpp"
+#include "FileChecker.h"
 #include <string>
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
@@ -33,8 +34,12 @@ TEST_F(RoutingPyBindTest, TestRoutingPyBind)
   //std::vector<double> nexus_values_vec{1.1, 2.2, 3.3, 4.4, 5.5};
 
   //SET THESE AS INPUTS
-  std::string t_route_config_file_with_path = "./test/data/routing/ngen_routing_config_unit_test.yaml";
-
+  std::vector<std::string> paths = {
+          "./test/data/routing/ngen_routing_config_unit_test.yaml",
+          "../test/data/routing/ngen_routing_config_unit_test.yaml",
+          "../../test/data/routing/ngen_routing_config_unit_test.yaml"
+  };
+  std::string t_route_config_file_with_path = utils::FileChecker::find_first_readable(paths);
   //Note: Currently, delta_time is set in the t-route yaml configuration file, and the
   //number_of_timesteps is determined from the total number of nexus outputs in t-rout
   //It is recommended to still pass these values to the routing_py_adapter object in


### PR DESCRIPTION
Some long overdue cleanup of some test classes and cases.  The changes here are mostly focused on implementing file path checking/substitution to allow the tests to discover required input data from different initial working directories.  Ultimately, this now allows `ctest` to run effectively and do both test discovery and execution.  So from the repo root directory, one can do the following:

Activate most all features for a build
```sh
make -B test_build -S . -DNETCDF_ACTIVE:BOOL=On -DBMI_C_LIB_ACTIVE:BOOL=On -DBMI_FORTRAN_ACTIVE:BOOL=On -DNGEN_ACTIVATE_PYTHON:BOOL=On -DNGEN_ACTIVATE_ROUTING:BOOL=On
```

Compile all targets (including activated tests for the various options)
```sh
cmake --build test_build --target all -j 8 
```

Discover and run all built tests
```sh
cmake --build test_build --target test
```

The builds and tests can also be done via `make`, e.g.
```sh
cd test_build
make test
```

What is important to note here, is that we have a couple standard test targets we test often, `test_unit` and `test_all`, which have 152 and 128 total possible tests, for a combined 280 tests.  (using the above build flags).

When you run the entirety of the discoverable tests using `ctest`, there are 822 tests discovered!  Even with the overlap in test_unit/test_all, there are clearly some test cases not be exercised frequently (some of where are fixed up in this PR).

This should have no regression on existing testing workflows, but should allow for more comprehensive ones, and we may even want to revisit the automated action runners and consider using the ctest interface to discover and run tests.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:


### Target Environment support

- [x] Linux
- [x] MacOS
