### PR TITLE
Add stdexcept include to UnitsHelper header

### DIFF
--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include "all.h"
 
 #ifndef NGEN_UNITSHELPER_H


### PR DESCRIPTION
This PR resolves #523 by including `<stdexcept>` in `UnitsHelper.hpp`. In `libstdc++` version 13.1.0, the `<mutex>` header removed an include to `<system_error>`, which also removed includes to `<stdexcept>` and `<string>`. This caused `std::string` and `std::runtime_error` to raise errors on compilation of target `core_mediator`.

## Additions

- Adds `<stdexcept>` to `include/core/mediator/UnitsHelper.hpp`.

## Testing

- `core_mediator` compiles successfully and all unit tests pass locally using `libstdc++` and `libc++` with GCC version 13.1.0, clang 15.0.7, and icx 2023.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
