### PR TITLE
Fixing test_routing_pybind workflow failures

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -145,7 +145,7 @@ jobs:
           pip install 'pip>=23.0,<23.1'
           pip install -U setuptools
           pip install -r requirements.txt
-          pip install deprecated pyarrow tables geopandas numpy
+          pip install deprecated 'pyarrow!=12.0.0' tables geopandas numpy
           if [ ${{ runner.os }} == 'macOS' ] 
           then
             export LIBRARY_PATH=/usr/local/lib/gcc/11/

--- a/test/data/routing/ngen_routing_config_unit_test.yaml
+++ b/test/data/routing/ngen_routing_config_unit_test.yaml
@@ -9,7 +9,7 @@ network_topology_parameters:
     supernetwork_parameters:
         #----------
         geo_file_type: HYFeaturesNetwork 
-        geo_file_path: ../../test/data/routing/gauge_01073000.gpkg
+        geo_file_path: ./test/data/routing/gauge_01073000.gpkg
         mask_file_path: # domain/unit_test_noRS/coastal_subset.txt
         synthetic_wb_segments:
             #- 4800002
@@ -21,8 +21,8 @@ network_topology_parameters:
         break_network_at_waterbodies: False 
         level_pool:
             #----------
-            level_pool_waterbody_parameter_file_path: ../../test/data/routing/gauge_01073000.gpkg
-            reservoir_parameter_file                : ../../test/data/routing/gauge_01073000.gpkg
+            level_pool_waterbody_parameter_file_path: ./test/data/routing/gauge_01073000.gpkg
+            reservoir_parameter_file                : ./test/data/routing/gauge_01073000.gpkg
         #rfc:
             #----------
             #reservoir_parameter_file                : domain/reservoir_index_AnA.nc
@@ -58,11 +58,11 @@ compute_parameters:
         #----------
         qts_subdivisions            : 12
         dt                          : 300 # [sec]
-        qlat_input_folder           : ../../test/data/routing/
+        qlat_input_folder           : ./test/data/routing/
         qlat_file_pattern_filter    : "nex-*"
-        nexus_input_folder          : ../../test/data/routing/
+        nexus_input_folder          : ./test/data/routing/
         nexus_file_pattern_filter   : "nex-*" #OR "*NEXOUT.parquet" OR "nex-*"
-        binary_nexus_file_folder    : ../../test/data/routing/ # this is required if nexus_file_pattern_filter="nex-*"
+        binary_nexus_file_folder    : ./test/data/routing/ # this is required if nexus_file_pattern_filter="nex-*"
         #coastal_boundary_input_file : channel_forcing/schout_1.nc  
         nts                         : 8640 #288 for 1day
         max_loop_size               : 720 # [hr]  
@@ -98,6 +98,6 @@ output_parameters:
         #wrf_hydro_channel_output_source_folder: ./
     chanobs_output:
         #----------
-        chanobs_output_directory: ../../test/data/routing/
+        chanobs_output_directory: ./test/data/routing/
         chanobs_filepath        : Chanobs.nc
-    lakeout_output: ../../test/data/routing/
+    lakeout_output: ./test/data/routing/


### PR DESCRIPTION
See [comment in #519](https://github.com/NOAA-OWP/ngen/pull/519#issuecomment-1551370076) and discussion in #524 , rolls back some changes in 7550dfc to fix failing tests, and excludes pyarrow 12.0.0 because of apache/arrow#15054 (v11.0.0 doesn't have the behavior and hopefully 13.0.0 will fix it).

## Additions

-

## Removals

-

## Changes

- rolled back pathing changes in 7550dfc in `ngen_routing_config_unit_test.yaml`
- updated workflow YAML to exclude pyarrow version 12.0.0 specifically

## Testing

1.

## Screenshots


## Notes

-

## Todos

- Make sure when pyarrow 13.0.0 is released that the segfault bug goes away.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
- [X] macOS
