### PR TITLE
Add support for a user-specified root output directory

### DIFF
--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -31,7 +31,7 @@ The `global` key-value object must contain the following two object keys:
 * `forcing`
   * key-value object with keys for `file_pattern` and `path` that define the default CSV file pattern and path for the input forcings relative to the executable directory
 
-The `global` key-value object *may* contain an `outputs` object key for user-defined output patterns for nexus and catchment outputs, where the `{{id}}` syntax reflects the nexus or catchment string identifiers (i.e. `cat-27`, `nex-68`).
+The `global` key-value object *may* contain an `output_root` key for a user-defined root output directory for nexus and catchment outputs.
 
 ```
 "global": {
@@ -49,10 +49,7 @@ The `global` key-value object *may* contain an `outputs` object key for user-def
       "file_pattern": ".*{{id}}.*.csv",
       "path": "./data/forcing/"
   },
-  "outputs": {
-      "nexus": "/path/to/nexus/{{id}}-output.csv",
-      "catchment": "/path/to/catchment/{{id}}-output.csv"
-  }
+  "output_root": "/path/to/outputs/"
 },  
 ```
 

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -15,11 +15,14 @@ The Configuration is a key-value object and must contain these three first level
 * `catchments` 
   *  is a key-value object that must include a list of individual catchments
 
+The configuration may *optionally* contain an `output_root` key with a user-defined root output directory as the key, for nexus and catchment outputs.
+
 ```
 {
    "global": {},
    "time": {},
-   "catchments": {}
+   "catchments": {},
+   "output_root": "/path/to/output/"
 } 
 ```
 
@@ -30,8 +33,6 @@ The `global` key-value object must contain the following two object keys:
   * `params` must be a list that holds key-value pairs
 * `forcing`
   * key-value object with keys for `file_pattern` and `path` that define the default CSV file pattern and path for the input forcings relative to the executable directory
-
-The `global` key-value object *may* contain an `output_root` key for a user-defined root output directory for nexus and catchment outputs.
 
 ```
 "global": {
@@ -48,8 +49,7 @@ The `global` key-value object *may* contain an `output_root` key for a user-defi
   "forcing": {
       "file_pattern": ".*{{id}}.*.csv",
       "path": "./data/forcing/"
-  },
-  "output_root": "/path/to/outputs/"
+  }
 },  
 ```
 

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -31,6 +31,8 @@ The `global` key-value object must contain the following two object keys:
 * `forcing`
   * key-value object with keys for `file_pattern` and `path` that define the default CSV file pattern and path for the input forcings relative to the executable directory
 
+The `global` key-value object *may* contain an `outputs` object key for user-defined output patterns for nexus and catchment outputs, where the `{{id}}` syntax reflects the nexus or catchment string identifiers (i.e. `cat-27`, `nex-68`).
+
 ```
 "global": {
   "formulations": [
@@ -46,6 +48,10 @@ The `global` key-value object must contain the following two object keys:
   "forcing": {
       "file_pattern": ".*{{id}}.*.csv",
       "path": "./data/forcing/"
+  },
+  "outputs": {
+      "nexus": "/path/to/nexus/{{id}}-output.csv",
+      "catchment": "/path/to/catchment/{{id}}-output.csv"
   }
 },  
 ```

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -266,7 +266,7 @@ namespace realization {
              * @return std::string of the output root directory
              */
             std::string get_output_root() const noexcept {
-                const auto output_root = this->tree.get_optional<std::string>("global.output_root");
+                const auto output_root = this->tree.get_optional<std::string>("output_root");
                 if (output_root != boost::none && *output_root != "") {
                     // Check if the path ends with a trailing slash,
                     // otherwise add it.

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -250,6 +250,80 @@ namespace realization {
                     return "";
             }
 
+            /**
+             * @brief Get the formatted nexus output path with the given @c id interpolated
+             *
+             * @code{.cpp}
+             * // Example config:
+             * // ...
+             * // "outputs": {
+             * //   ...
+             * //   "nexus": "/path/to/nexus-dir/{{id}}-output.csv",
+             * //   ...
+             * // }
+             * // ...
+             * const auto manager = Formulation_Manger(CONFIG);
+             * manager.get_nexus_output_path("nex-27");
+             * //> "/path/to/nexus-dir/nex-27-output.csv"
+             * @endcode
+             *
+             * @param id Nexus string ID
+             * @return std::string of the interpolated nexus output path if the realization config file
+                                   contains it, otherwise an output path in the form "./{{id}}_output.csv".
+             */
+            std::string get_nexus_output_path(const std::string& id) const noexcept {
+                const auto nexus_path_format = this->tree.get_optional<std::string>("global.outputs.nexus");
+                if (nexus_path_format != boost::none) {
+                    const auto pattern_idx = nexus_path_format->find("{{id}}");
+                    if (pattern_idx != std::string::npos) {
+                        std::string nexus_path = *nexus_path_format; // copy
+                        return nexus_path.replace(pattern_idx, sizeof("{{id}}") - 1, id);
+                    }
+                    // TODO: should we still return the path if it doesn't have an ID parameter?
+                    // this would imply that the user specified a path (and may know) that will
+                    // only ever output 1 file. Since, if there is more than 1 output, they will
+                    // overwrite one another.
+                }
+
+                // TODO: Should catchments and nexi have the same default output format?
+                return "./" + id + "_output.csv";
+            }
+
+            /**
+             * @brief Get the formatted catchment output path with the given @c id interpolated
+             *
+             * @code{.cpp}
+             * // Example config:
+             * // ...
+             * // "outputs": {
+             * //   ...
+             * //   "catchment": "/path/to/catchment-dir/{{id}}-output.csv",
+             * //   ...
+             * // }
+             * // ...
+             * const auto manager = Formulation_Manger(CONFIG);
+             * manager.get_catchment_output_path("cat-27");
+             * //> "/path/to/catchment-dir/cat-27-output.csv"
+             * @endcode
+             * 
+             * @param id Catchment string ID
+             * @return std::string of the interpolated catchment output path if the realization config file
+                                   contains it, otherwise an output path in the form "./{{id}}.csv".
+             */
+            std::string get_catchment_output_path(const std::string& id) const noexcept {
+                const auto catchment_path_format = this->tree.get_optional<std::string>("global.outputs.catchment");
+                if (catchment_path_format != boost::none) {
+                    const auto pattern_idx = catchment_path_format->find("{{id}}");
+                    if (pattern_idx != std::string::npos) {
+                        std::string catchment_path = *catchment_path_format; // copy
+                        return catchment_path.replace(pattern_idx, sizeof("{{id}}") - 1, id);
+                    }
+                    // TODO: same TODO as this::get_nexus_output_path
+                }
+
+                return "./" + id + ".csv";
+            }
+
 
         protected:
             std::shared_ptr<Catchment_Formulation> construct_formulation_from_tree(

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -251,77 +251,31 @@ namespace realization {
             }
 
             /**
-             * @brief Get the formatted nexus output path with the given @c id interpolated
+             * @brief Get the formatted output root
              *
              * @code{.cpp}
              * // Example config:
              * // ...
-             * // "outputs": {
-             * //   ...
-             * //   "nexus": "/path/to/nexus-dir/{{id}}-output.csv",
-             * //   ...
-             * // }
+             * // "output_root": "/path/to/dir/"
              * // ...
              * const auto manager = Formulation_Manger(CONFIG);
-             * manager.get_nexus_output_path("nex-27");
-             * //> "/path/to/nexus-dir/nex-27-output.csv"
-             * @endcode
-             *
-             * @param id Nexus string ID
-             * @return std::string of the interpolated nexus output path if the realization config file
-                                   contains it, otherwise an output path in the form "./{{id}}_output.csv".
-             */
-            std::string get_nexus_output_path(const std::string& id) const noexcept {
-                const auto nexus_path_format = this->tree.get_optional<std::string>("global.outputs.nexus");
-                if (nexus_path_format != boost::none) {
-                    const auto pattern_idx = nexus_path_format->find("{{id}}");
-                    if (pattern_idx != std::string::npos) {
-                        std::string nexus_path = *nexus_path_format; // copy
-                        return nexus_path.replace(pattern_idx, sizeof("{{id}}") - 1, id);
-                    }
-                    // TODO: should we still return the path if it doesn't have an ID parameter?
-                    // this would imply that the user specified a path (and may know) that will
-                    // only ever output 1 file. Since, if there is more than 1 output, they will
-                    // overwrite one another.
-                }
-
-                // TODO: Should catchments and nexi have the same default output format?
-                return "./" + id + "_output.csv";
-            }
-
-            /**
-             * @brief Get the formatted catchment output path with the given @c id interpolated
-             *
-             * @code{.cpp}
-             * // Example config:
-             * // ...
-             * // "outputs": {
-             * //   ...
-             * //   "catchment": "/path/to/catchment-dir/{{id}}-output.csv",
-             * //   ...
-             * // }
-             * // ...
-             * const auto manager = Formulation_Manger(CONFIG);
-             * manager.get_catchment_output_path("cat-27");
-             * //> "/path/to/catchment-dir/cat-27-output.csv"
+             * manager.get_output_root();
+             * //> "/path/to/dir/"
              * @endcode
              * 
-             * @param id Catchment string ID
-             * @return std::string of the interpolated catchment output path if the realization config file
-                                   contains it, otherwise an output path in the form "./{{id}}.csv".
+             * @return std::string of the output root directory
              */
-            std::string get_catchment_output_path(const std::string& id) const noexcept {
-                const auto catchment_path_format = this->tree.get_optional<std::string>("global.outputs.catchment");
-                if (catchment_path_format != boost::none) {
-                    const auto pattern_idx = catchment_path_format->find("{{id}}");
-                    if (pattern_idx != std::string::npos) {
-                        std::string catchment_path = *catchment_path_format; // copy
-                        return catchment_path.replace(pattern_idx, sizeof("{{id}}") - 1, id);
-                    }
-                    // TODO: same TODO as this::get_nexus_output_path
+            std::string get_output_root() const noexcept {
+                const auto output_root = this->tree.get_optional<std::string>("global.output_root");
+                if (output_root != boost::none && *output_root != "") {
+                    // Check if the path ends with a trailing slash,
+                    // otherwise add it.
+                    return output_root->back() == '/'
+                           ? *output_root
+                           : *output_root + "/";
                 }
 
-                return "./" + id + ".csv";
+                return "./";
             }
 
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -316,10 +316,10 @@ int main(int argc, char *argv[]) {
     for(const auto& id : features.nexuses()) {
         #ifdef NGEN_MPI_ACTIVE
         if (!features.is_remote_sender_nexus(id)) {
-          nexus_outfiles[id].open(manager->get_nexus_output_path(id), std::ios::trunc);
+          nexus_outfiles[id].open(manager->get_output_root() + id + "_output.csv", std::ios::trunc);
         }
         #else
-        nexus_outfiles[id].open(manager->get_nexus_output_path(id), std::ios::trunc);
+        nexus_outfiles[id].open(manager->get_output_root() + id + "_output.csv", std::ios::trunc);
         #endif
     }
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -316,10 +316,10 @@ int main(int argc, char *argv[]) {
     for(const auto& id : features.nexuses()) {
         #ifdef NGEN_MPI_ACTIVE
         if (!features.is_remote_sender_nexus(id)) {
-          nexus_outfiles[id].open("./"+id+"_output.csv", std::ios::trunc);
+          nexus_outfiles[id].open(manager->get_nexus_output_path(id), std::ios::trunc);
         }
         #else
-        nexus_outfiles[id].open("./"+id+"_output.csv", std::ios::trunc);
+        nexus_outfiles[id].open(manager->get_nexus_output_path(id), std::ios::trunc);
         #endif
     }
 
@@ -370,6 +370,7 @@ int main(int argc, char *argv[]) {
   #ifdef NGEN_MPI_ACTIVE
         if (!features.is_remote_sender_nexus(id)) { //Ensures only one side of the dual sided remote nexus actually doing this...
   #endif
+
           //Get the correct "requesting" id for downstream_flow
 	        const auto& nexus = features.nexus_at(id);
           const auto& cat_ids = nexus->get_receiving_catchments();

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -28,7 +28,7 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_catchment_output_path(feat_id));
+          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.
           formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -28,7 +28,7 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(feat_id+".csv");
+          formulation->set_output_stream(formulations->get_catchment_output_path(feat_id));
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.
           formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -38,7 +38,7 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(feat_id+".csv");
+          formulation->set_output_stream(formulations->get_catchment_output_path(feat_id));
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.
           formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -38,7 +38,7 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_catchment_output_path(feat_id));
+          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.
           formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -121,10 +121,7 @@ const double EPSILON = 0.0000001;
 
 const std::string EXAMPLE_1 = "{ "
     "\"global\": { "
-      "\"outputs\": {"
-        "\"nexus\": \"/tmp/nexus-dir/{{id}}-output.csv\","
-        "\"catchment\": \"/tmp/catchment-dir/{{id}}-output.csv\""
-      "},"
+      "\"output_root\": \"/tmp/output-dir/\","
       "\"formulations\": [ "
             "{"
               "\"name\": \"tshirt\", "
@@ -663,8 +660,7 @@ TEST_F(Formulation_Manager_Test, basic_reading_1) {
 
     ASSERT_TRUE(manager.contains("cat-52"));
     ASSERT_TRUE(manager.contains("cat-67"));
-    ASSERT_EQ(manager.get_nexus_output_path("nex-52"), "/tmp/nexus-dir/nex-52-output.csv");
-    ASSERT_EQ(manager.get_catchment_output_path("cat-52"), "/tmp/catchment-dir/cat-52-output.csv");
+    ASSERT_EQ(manager.get_output_root(), "/tmp/output-dir/");
 }
 
 TEST_F(Formulation_Manager_Test, basic_reading_2) {

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -120,8 +120,8 @@ class Formulation_Manager_Test : public ::testing::Test {
 const double EPSILON = 0.0000001;
 
 const std::string EXAMPLE_1 = "{ "
+    "\"output_root\": \"/tmp/output-dir/\","
     "\"global\": { "
-      "\"output_root\": \"/tmp/output-dir/\","
       "\"formulations\": [ "
             "{"
               "\"name\": \"tshirt\", "
@@ -683,6 +683,7 @@ TEST_F(Formulation_Manager_Test, basic_reading_2) {
 
     ASSERT_TRUE(manager.contains("cat-52"));
     ASSERT_TRUE(manager.contains("cat-67"));
+    ASSERT_EQ(manager.get_output_root(), "./");
 }
 
 TEST_F(Formulation_Manager_Test, basic_run_1) {

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -121,6 +121,10 @@ const double EPSILON = 0.0000001;
 
 const std::string EXAMPLE_1 = "{ "
     "\"global\": { "
+      "\"outputs\": {"
+        "\"nexus\": \"/tmp/nexus-dir/{{id}}-output.csv\","
+        "\"catchment\": \"/tmp/catchment-dir/{{id}}-output.csv\""
+      "},"
       "\"formulations\": [ "
             "{"
               "\"name\": \"tshirt\", "
@@ -659,6 +663,8 @@ TEST_F(Formulation_Manager_Test, basic_reading_1) {
 
     ASSERT_TRUE(manager.contains("cat-52"));
     ASSERT_TRUE(manager.contains("cat-67"));
+    ASSERT_EQ(manager.get_nexus_output_path("nex-52"), "/tmp/nexus-dir/nex-52-output.csv");
+    ASSERT_EQ(manager.get_catchment_output_path("cat-52"), "/tmp/catchment-dir/cat-52-output.csv");
 }
 
 TEST_F(Formulation_Manager_Test, basic_reading_2) {


### PR DESCRIPTION
This PR resolves #374. After discussion with @mattw-nws, this PR instead only adds support for a user-specified *root* directory. Within this directory, catchments and nexi will continue to be outputted as `{id}.csv` and `{id}_output.csv`, respectively. Any example of the new syntax is as follows:
```jsonc
{
  "global": {
    ...
    "output_root": "/path/to/output/",
    ...
  },
  ...
}
```

~Based on my comment on #374, I implemented the alternative syntax because I didn't see any benefit to the initial syntax. This is fairly easy to modify though, so if the initial syntax fits better, we can pivot to that.~

## Additions

- Adds public member functions to `realization::Formulation_Manager`:
  * `get_output_root`

## Changes

- Modifies `src/NGen.cpp` to use `manager->get_output_root` when writing nexus outputs.
- Modifies `src/core/HY_Features{_MPI}.cpp` to use `formulations->get_output_root` when setting the output stream.
- Adds a simple test case for reading/formatting the output path in `Formulation_Manager_Test:basic_reading_1`.

## Testing

- All unit tests passed locally with clang 15.0.7, GCC 13.1.1, and ICX 2023.

## Todos

- [x] Add documentation on the realization config page? (i.e. `doc/REALIZATION_CONFIGURATION.md`)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
