### PR TITLE
Remove heuristics for finding Python and NumPy in favor of baseline find_package

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -153,6 +153,7 @@ runs:
           id: cmake_init
           run: |
             export BOOST_ROOT="$(pwd)/boost_1_72_0"
+            . .venv/bin/activate
             [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} -DBMI_C_LIB_ACTIVE:BOOL=${{ inputs.bmi_c }} -DNGEN_ACTIVATE_PYTHON:BOOL=${{ inputs.use_python }} -DUDUNITS_ACTIVE:BOOL=${{ inputs.use_udunits }} -DBMI_FORTRAN_ACTIVE:BOOL=${{ inputs.bmi_fortran }} -DNGEN_ACTIVATE_ROUTING:BOOL=${{ inputs.use_troute }} -DNETCDF_ACTIVE:BOOL=${{ inputs.use_netcdf }} -DMPI_ACTIVE:BOOL=${{ inputs.use_mpi }} -S .
             echo "build-dir=$(echo ${{ inputs.build-dir }})" >> $GITHUB_OUTPUT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,65 +214,6 @@ endif()
 # If Python set to be active, run steps to make sure it is included properly, and set compiler definition to true
 if (${NGEN_ACTIVATE_PYTHON})
     add_compile_definitions(ACTIVATE_PYTHON=true)
-    # If there is a virtual environment directory then look for several things there
-    if(EXISTS ${PROJECT_SOURCE_DIR}/.venv OR EXISTS ${PROJECT_SOURCE_DIR}/venv)
-        if (EXISTS ${PROJECT_SOURCE_DIR}/.venv)
-            set(PY_VENV_DIR ${PROJECT_SOURCE_DIR}/.venv)
-        else()
-            set(PY_VENV_DIR ${PROJECT_SOURCE_DIR}/venv)
-        endif()
-        # Start with looking for NumPy
-        file(GLOB_RECURSE NP_COMMON_HEADER ${PY_VENV_DIR}/*npy_common.h)
-        get_filename_component(NP_HEADER_DIR ${NP_COMMON_HEADER} DIRECTORY)
-        get_filename_component(NP_INCLUDE_DIR ${NP_HEADER_DIR} DIRECTORY)
-        set(Python_NumPy_INCLUDE_DIR ${NP_INCLUDE_DIR})
-        message(INFO " Found numpy include path  ${Python_NumPy_INCLUDE_DIR}")
-        # Also try to get the real python root
-        message(INFO " Before Python exec  ${PYTHON_EXECUTABLE}")
-        get_filename_component(PYTHON_EXECUTABLE ${PY_VENV_DIR}/bin/python REALPATH)
-        message(INFO " After Python exec  ${PYTHON_EXECUTABLE}")
-        get_filename_component(PYTHON_BIN ${PYTHON_EXECUTABLE} DIRECTORY)
-        get_filename_component(PY_ROOT_DIR ${PYTHON_BIN} DIRECTORY)
-        set(Python_ROOT_DIR "${PY_ROOT_DIR}")
-        message(INFO " Python root dir to search is  ${Python_ROOT_DIR}")
-        set(Python_FIND_VIRTUALENV ONLY)
-
-        # use, i.e. don't skip the full RPATH for the build tree
-        #set(CMAKE_SKIP_BUILD_RPATH FALSE)
-        #set(CMAKE_SKIP_BUILD_RPATH TRUE)
-        #set(CMAKE_INSTALL_RPATH "/Library/Developer/CommandLineTools/Library/Frameworks")
-        #message(INFO " ORIGIN is ${ORIGIN}")
-        #SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-        # add the automatically determined parts of the RPATH
-        # which point to directories outside the build tree to the install RPATH
-        #set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-        #set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
-
-        # the RPATH to be used when installing, but only if it's not a system directory
-        #list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-        #if("${isSystemDir}" STREQUAL "-1")
-        #    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-        #endif("${isSystemDir}" STREQUAL "-1")
-
-        # Alternatively, if there is something in the ENV for the user, try that
-    elseif(DEFINED ENV{Python_NumPy_INCLUDE_DIR})
-        set(Python_NumPy_INCLUDE_DIR $ENV{Python_NumPy_INCLUDE_DIR})
-    endif()
-
-#    if(DEFINED ENV{PYTHON_INCLUDE_DIR})
-#        set(PYTHON_INCLUDE_DIR $ENV{PYTHON_INCLUDE_DIR})
-#        message(INFO " Found 'PYTHON_INCLUDE_DIR' from ENV ($ENV{PYTHON_INCLUDE_DIR})")
-#    else()
-#        message(INFO " Did not find 'PYTHON_INCLUDE_DIR' in ENV")
-#    endif()
-#    if(DEFINED ENV{PYTHON_LIBRARIES})
-#        set(PYTHON_LIBRARIES $ENV{PYTHON_LIBRARIES})
-#        message(INFO " Found 'PYTHON_LIBRARIES' from ENV ($ENV{PYTHON_LIBRARIES})")
-#    else()
-#        message(INFO " Did not find 'PYTHON_LIBRARIES' in ENV")
-#    endif()
-#    include_directories(${PYTHON_INCLUDE_DIR})
 
     find_package(Python 3.6.8 REQUIRED COMPONENTS Interpreter Development NumPy)
     #message(INFO " the final Py lib is ${Python_LIBRARY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,11 +202,11 @@ endif()
 # First, define NGEN_ACTIVATE_PYTHON, if not already defined
 #   Use NGEN_ACTIVATE_PYTHON environment variable if available, or default to true
 if (NOT (DEFINED NGEN_ACTIVATE_PYTHON))
-    message(INFO " NGEN_ACTIVATE_PYTHON not defined")
     if (DEFINED ENV{NGEN_ACTIVATE_PYTHON})
-        message(INFO " set as $ENV{NGEN_ACTIVATE_PYTHON}")
+        message(INFO " NGEN_ACTIVATE_PYTHON set to '$ENV{NGEN_ACTIVATE_PYTHON}' from the environment")
         set(NGEN_ACTIVATE_PYTHON $ENV{NGEN_ACTIVATE_PYTHON})
     else()
+        message(INFO " NGEN_ACTIVATE_PYTHON set to 'true' by default")
         set(NGEN_ACTIVATE_PYTHON true)
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
 if(MPI_ACTIVE)
    set (CMAKE_CXX_COMPILER "mpicxx")

--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -279,7 +279,7 @@ An example implementation for an appropriate BMI model as a **C++** shared libra
 
 ### Enabling Python Integration
 
-Python integration is controlled with the CMake build flag `NGEN_ACTIVATE_PYTHON`, however this currently defaults to "On"--you would need to turn this off if Python is not available in your environment. See [the Dependencies documentation](DEPENDENCIES.md#python-3-libraries) for specifics on Python requirements, but in summary you will need a working Python environment with NumPy installed. You can set up a Python environment anywhere with the usual environment variables, but note that ngen will look for a Python environment in the build directory named `.venv` or `venv` by default. The appropriate Python environment should be active in the shell when ngen is run.
+Python integration is controlled with the CMake build flag `NGEN_ACTIVATE_PYTHON`, however this currently defaults to "On"--you would need to turn this off if Python is not available in your environment. See [the Dependencies documentation](DEPENDENCIES.md#python-3-libraries) for specifics on Python requirements, but in summary you will need a working Python environment with NumPy installed. You can set up a Python environment anywhere with the usual environment variables. The appropriate Python environment should be active in the shell when ngen is run.
 
 For Python BMI models specifically, you will also need to install the [bmipy](https://github.com/csdms/bmi-python) package, which provides a base class for Python BMI models.
 

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -10,7 +10,7 @@
 | [Boost (Headers Only)](#boost-headers-only) | external | `1.72.0` | headers only library |
 | [Udunits libraries](https://www.unidata.ucar.edu/software/udunits) | hybrid (external or submodule) | >= 2.0 | Can be installed via package manager; if not installed, will be automatically downloaded as submodule, and build will be attempted. |
 | [MPI](https://www.mpi-forum.org) | external | No current implementation or version requirements | Required for [multi-process distributed execution](DISTRIBUTED_PROCESSING.md) |
-| [Python 3 Libraries](#python-3-libraries) | external | \> `3.6.8` | Can be [excluded](#overriding-python-dependency). Requires ``numpy`` package |
+| [Python 3 Libraries](#python-3-libraries) | external | \> `3.6.8` | Can be [excluded](#overriding-python-dependency). |
 | [pybind11](#pybind11) | submodule | `v2.6.0` | Can be [excluded](#overriding-pybind11-dependency). |
 | [dmod.subsetservice](#the-dmodsubsetservice-package) | external | `>= 0.3.0` | Only required to perform integrated [hydrofabric file subdividing](DISTRIBUTED_PROCESSING.md#subdivided-hydrofabric) for distributed processing . |
 | [t-route](#t-route) | submodule | see below | Module required to enable channel-routing.  Requires pybind11 to enable |
@@ -155,7 +155,7 @@ Any version greater >= 2.0 (i.e., _udunits2_ or _libudunits2_).
 
 In order to interact with external models written in Python, the Python libraries must be made available.  
 
-Further, the Python environment must have `numpy` installed.  Several Python BMI function calls utilize `numpy` arrays, making `numpy` a necessity for using external Python models implementing BMI
+Further, the Python environment must have NumPy and a few other libraries installed.  Several Python BMI function calls utilize `numpy` arrays, making `numpy` a necessity for using external Python models implementing BMI.
 
 #### Overriding Python Dependency
 
@@ -165,22 +165,17 @@ To do this, set either the `NGEN_ACTIVATE_PYTHON` environment variable to `false
 
 ### Setup
 
-The first step is to make sure Python is installed (with step 1a being installing NumPy.  CMake will then use its [FindPython](https://cmake.org/cmake/help/v3.19/module/FindPython.html#module:FindPython) functionality to obtain the Python libraries. On some systems, CMake may be able to find everything automatically, though that will not always be the case.
+The first step is to make sure Python is installed. NGen's CMake will use its [FindPython](https://cmake.org/cmake/help/v3.19/module/FindPython.html#module:FindPython) functionality to locate the Python installation.
 
-If CMake cannot find the needed Python artifacts on its own, the following user environmental variables can be set in the user's shell to control where CMake looks:
+We recommend creating a Python 'virtual environment', and having it activated when configuring, building, testing, and running `ngen`. Necessary libraries can be installed in that environment without affecting the surrounding system.
 
-* `PYTHON_INCLUDE_DIR`
-    * This should be the directory containing the Python header files in the local installation
-* `PYTHON_LIBRARIES`
-    * This should be set to the directory containing the appropriate local lib file(s) (e.g., `libpython*.dylib` on a Mac)
+Otherwise, CMake can be guided to use a particular Python installation according to [its documentation](https://cmake.org/cmake/help/latest/module/FindPython.html).
 
-#### NumPy
+The Python installation found by CMake needs to have the relevant libraries installed. These libraries can be installed with
 
-Additionally, the NumPy package must be installed and its headers available, in particular to work with Python BMI functions (with the general details of installing Python packages left to the user).  The simplest method is installing in the root/global environment, though this is not always an option.
+    pip install numpy pandas pyyaml bmipy
 
-One supported option is to create a `virtualenv` environment at `.venv` in the project root, then install `numpy` within it.   Such `.venv` directory is ignored by Git and searched by CMake for the NumPy headers.
-
-The variable `Python_NumPy_INCLUDE_DIR` (either as a CMake variable or a user environment variable) can also be used to set the NumPy include directory path searched by CMake.  However, this will be ignored if there is a `.venv` directory found, as described above.
+or an equivalent command if using a different Python package manager.
     
 ### Version Requirements
 

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -6,7 +6,7 @@
 | ------------- |:------------- | :-----:| :-------: |
 | [Google Test](#google-test) | submodule  | `release-1.10.0` | |
 | [C/C++ Compiler](#c-and-c-compiler) | external | see below |  |
-| [CMake](#cmake) | external | \>= `3.12` | |
+| [CMake](#cmake) | external | \>= `3.14` | |
 | [Boost (Headers Only)](#boost-headers-only) | external | `1.72.0` | headers only library |
 | [Udunits libraries](https://www.unidata.ucar.edu/software/udunits) | hybrid (external or submodule) | >= 2.0 | Can be installed via package manager; if not installed, will be automatically downloaded as submodule, and build will be attempted. |
 | [MPI](https://www.mpi-forum.org) | external | No current implementation or version requirements | Required for [multi-process distributed execution](DISTRIBUTED_PROCESSING.md) |
@@ -75,7 +75,7 @@ However, a [CMake build system](BUILDS_AND_CMAKE.md#generating-a-build-system) m
 
 ### Version Requirements
 
-Currently, a version of CMake >= `3.12.0` is required.
+Currently, a version of CMake >= `3.14.0` is required.
 
 ## Boost (Headers Only)
 

--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -32,16 +32,16 @@ namespace utils {
         public:
             static std::shared_ptr<InterpreterUtil> getInstance() {
                 /**
-                 * @brief Singleton instance of embdedded python interpreter.
+                 * @brief Singleton instance of embedded python interpreter.
                  * 
-                 * Note that if no client holds a currernt reference to this singleton, it will get destroyed
+                 * Note that if no client holds a current reference to this singleton, it will get destroyed
                  * and the next call to getInstance will create and initialize a new scoped interpreter
                  * 
                  * This is required for the simple reason that a traditional static singleton instance has no guarantee
-                 * about the destrutction order of resources across multiple compliation units,
+                 * about the destruction order of resources across multiple compilation units,
                  * and this will cause seg faults if the python interpreter is torn down before the destruction of bound modules
                  * (such as this class' Path module).  If the interpreter is not available when those destructors are called,
-                 * a seg fault will occur.  With this implementaiton, the interpreter is guarnateed to exist as long as anything 
+                 * a seg fault will occur.  With this implementation, the interpreter is guaranteed to exist as long as anything
                  * referencing it needs it, and then can cleanly clean up internal references before the `py::scoped_interpreter`
                  * guard is destroyed, removing the python interpreter.
                  * 


### PR DESCRIPTION
The basic CMake FindPython functionality works well in modern enough versions. The heuristics may have predated the ability to specify `find_package(Python ... COMPONENTS ... NumPy)`.

FindPython docs for reference: https://cmake.org/cmake/help/latest/module/FindPython.html

## Additions

N/A

## Removals

N/A

## Changes

- Rely on CMake to pick up the active python installation (system or virtual environment) found by `find_package(Python ...)`
- Update the minimum version of CMake to ensure that will work

## Testing

1. Manual testing on my system with a mix of conformations of virtual environments and packages installed in the system environment

## Screenshots

N/A

## Notes

- Developers on other teams may need to be informed that they'll need to `activate` their virtual environment before configuring with `cmake`, rather than just having `ngen/venv` present

## Todos


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Update documentation accordingly
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS
