### PR TITLE
Pin pyarrow to avoid crash in 12.x

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -145,7 +145,7 @@ jobs:
           pip install 'pip>=23.0,<23.1'
           pip install -U setuptools
           pip install -r requirements.txt
-          pip install deprecated 'pyarrow!=12.*' tables geopandas numpy
+          pip install deprecated 'pyarrow==11.0.0' tables geopandas numpy
           if [ ${{ runner.os }} == 'macOS' ] 
           then
             export LIBRARY_PATH=/usr/local/lib/gcc/11/

--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -145,7 +145,7 @@ jobs:
           pip install 'pip>=23.0,<23.1'
           pip install -U setuptools
           pip install -r requirements.txt
-          pip install deprecated 'pyarrow!=12.0.0' tables geopandas numpy
+          pip install deprecated 'pyarrow!=12.*' tables geopandas numpy
           if [ ${{ runner.os }} == 'macOS' ] 
           then
             export LIBRARY_PATH=/usr/local/lib/gcc/11/


### PR DESCRIPTION
See PR #528 ... it was expected that the next release of pyarrow would make this problem go away. However, looking closer at https://github.com/apache/arrow/issues/15054 and https://github.com/apache/arrow/pull/33858 , it appears that the underlying issue supposedly _was fixed_ in the 12.0.0 release... so the fact that we're still seeing it is confusing. Either way, this problem should probably now be referred to t-route, created issue https://github.com/NOAA-OWP/t-route/issues/614 .

## Additions

- 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
