### PR TITLE
Handle non-existent module filename extension reliably

### DIFF
--- a/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
+++ b/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
@@ -91,6 +91,9 @@ namespace models {
                 if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {
                     //Try alternative extension...
                     size_t idx = bmi_lib_file.rfind(".");
+                    if(idx == string::npos){
+                        idx = bmi_lib_file.length()-1;
+                    }
                     std::string alt_bmi_lib_file;  
                     if(bmi_lib_file.length() == 0){
                         this->init_exception_msg =


### PR DESCRIPTION
Ensures that the substr call does not get a parameter that is larger than the string length if there is no extension in the `bmi_lib_file` string.

Using the "extensionless" filename for a shared library in a realization config is supposed to work, with ngen attaching whatever extension is typical for the OS. However, the code for doing that does not handle the case correctly. The docs say that std::string's `rfind` method returns `string::npos` when the string is not found, and that `string::npos` is -1 ... but the type is unsigned... so it is the max size_t value. This apparently causes the calls to `.substr` below to blow up. But... this was working previously, so must be a victim of undefined behavior--despite the fact that the docs for `substr` say that this should cause `out_of_range` to be thrown. 

Puzzling. See also ca76cc6 and f64ffd3 ... so this has worked in the past as it was.

## Additions

-

## Removals

-

## Changes

- Added check for `string::npos` in return of `rfind`

## Testing

1.

## Screenshots

![image](https://github.com/NOAA-OWP/ngen/assets/87771120/c24add6c-a17d-421c-a0c7-c068fb607f7a)

## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
