### PR TITLE
Fix ASan-reported errors in Fortran BMI testing

### DIFF
--- a/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
@@ -368,7 +368,7 @@ namespace models {
                 if (src.size() != total_bytes / item_size) {
                     throw std::runtime_error(
                             "Cannot set " + name + " variable of " + model_name + " from vector of size " +
-                            std::to_string(src.size) + " (expected size " + std::to_string(total_bytes / item_size) +
+                            std::to_string(src.size()) + " (expected size " + std::to_string(total_bytes / item_size) +
                             ")");
                 }
                 SetValue(std::move(name), static_cast<void *>(src.data()));

--- a/test/realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
@@ -1557,7 +1557,7 @@ TEST_F(Bmi_Fortran_Adapter_Test, Profile)
     adapter->SetValue("grid_1_shape", shape.data());
     //set some initial value for grid var 1
     std::vector<double> data = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-    adapter->SetValue("GRID_VAR_1", data.data());
+    adapter->SetValue("GRID_VAR_1", data);
     shape = {2,2,3};
     adapter->SetValue("grid_2_shape", shape.data());
     // Do the first few time steps

--- a/test/realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
@@ -1556,8 +1556,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, Profile)
     std::vector<int> shape = {2,3};
     adapter->SetValue("grid_1_shape", shape.data());
     //set some initial value for grid var 1
-    double data = 0.0;
-    adapter->SetValue("GRID_VAR_1", &data);
+    std::vector<double> data = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    adapter->SetValue("GRID_VAR_1", data.data());
     shape = {2,2,3};
     adapter->SetValue("grid_2_shape", shape.data());
     // Do the first few time steps


### PR DESCRIPTION
In response to error report in #536, correct the Fortran BMI adapter unit test to allocate a `vector` of data rather than a scalar, for a variable that was going to read more than a single value.

Then, switch to calling the `vector` overload of `SetValue` rather than the pointer overload, and found that it didn't compile and didn't have test coverage to expose that.

Fixes #538

## Testing

Configure as follows:
> `cmake -S . -B build-asan-4 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=-fsanitize=address -DCMAKE_C_FLAGS=-fsanitize=address -DNGEN_ACTIVATE_PYTHON=ON -DBOOST_ROOT=/opt/homebrew/opt/boost\@1.76/ -DBMI_C_LIB_ACTIVE=ON -DBMI_FORTRAN_ACTIVE=ON`

`test/test_bmi_fortran --gtest_filter=Bmi_Fortran_Adapter_Test.Profile` previously failed, now passes

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
