### PR TITLE
#539 GIUH: Adjust CDF search indexing to start from 1 to avoid underflowing input array

### DIFF
--- a/src/core/catchment/giuh/GIUH.cpp
+++ b/src/core/catchment/giuh/GIUH.cpp
@@ -123,7 +123,7 @@ void giuh_kernel_impl::interpolate_regularized_cdf()
 
         // Find index 'i' of largest CDF time less than the time for the current ordinate
         // Start by getting the index of the first time greater than time_for_ordinate
-        int cdf_times_index_for_iteration = 0;
+        int cdf_times_index_for_iteration = 1;
         while (this->cdf_times[cdf_times_index_for_iteration] < regularized_times_s.back()) {
             cdf_times_index_for_iteration++;
         }


### PR DESCRIPTION
When the found bounding entry is `0`, the subsequent decrement means that we subscript the vector at `-1`, resulting in an out-of-bounds access. Detected with AddressSanitizer, confirmed by testing the code with `.at()` in place of `[]`.

Fixes #539 

## Testing

1. `ctest` re-run after fix, all pass

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
