### PR TITLE
Broadcast scalar input variable values to expected array structure

### DIFF
--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1130,11 +1130,11 @@ namespace realization {
                     //more than a single value needed for var_name
                     auto values = provider->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
-                    //need to marshal data types to the reciever as well
+                    //need to marshal data types to the receiver as well
                     //this could be done a little more elegantly if the provider interface were
                     //"type aware", but for now, this will do (but requires yet another copy)
                     if(values.size() == 1){
-                        //FIXME this isn't generic broacasting, but works for scalar implementations
+                        //FIXME this isn't generic broadcasting, but works for scalar implementations
                         std::cerr << "WARN: broadcasting variable '" << var_name << "' from scalar to expected array\n";
                         values.resize(numItems, values[0]);
                     } else if (values.size() != numItems) {

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1116,6 +1116,7 @@ namespace realization {
                 // TODO: probably need to actually allow this by default and warn, but have config option to activate
                 //  this type of behavior
                 // TODO: account for arrays later
+                int nbytes = get_bmi_model()->GetVarNbytes(var_name);
                 int varItemSize = get_bmi_model()->GetVarItemsize(var_name);
                 std::shared_ptr<void> value_ptr;
                 // Finally, use the value obtained to set the model input
@@ -1128,6 +1129,10 @@ namespace realization {
                     //need to marshal data types to the reciever as well
                     //this could be done a little more elegantly if the provider interface were
                     //"type aware", but for now, this will do (but requires yet another copy)
+                    if(values.size() == 1){
+                        //FIXME this isn't generic broacasting, but works for scalar implementations
+                        values.resize(nbytes/varItemSize, values[0]);
+                    }
                     value_ptr = get_values_as_type( type, values.begin(), values.end() );
 
                 } else {

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1135,7 +1135,12 @@ namespace realization {
                     //"type aware", but for now, this will do (but requires yet another copy)
                     if(values.size() == 1){
                         //FIXME this isn't generic broacasting, but works for scalar implementations
-                        values.resize(nbytes/varItemSize, values[0]);
+                        std::cerr << "WARN: broadcasting variable '" << var_name << "' from scalar to expected array\n";
+                        values.resize(numItems, values[0]);
+                    } else if (values.size() != numItems) {
+                        throw std::runtime_error("Mismatch in item count for variable '" + var_name + "': model expects " +
+                                                 std::to_string(numItems) + ", provider returned " + std::to_string(values.size()) +
+                                                 " items\n");
                     }
                     value_ptr = get_values_as_type( type, values.begin(), values.end() );
 

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1135,7 +1135,9 @@ namespace realization {
                     //"type aware", but for now, this will do (but requires yet another copy)
                     if(values.size() == 1){
                         //FIXME this isn't generic broadcasting, but works for scalar implementations
+                        #ifndef NGEN_QUIET
                         std::cerr << "WARN: broadcasting variable '" << var_name << "' from scalar to expected array\n";
+                        #endif
                         values.resize(numItems, values[0]);
                     } else if (values.size() != numItems) {
                         throw std::runtime_error("Mismatch in item count for variable '" + var_name + "': model expects " +

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -1113,16 +1113,20 @@ namespace realization {
                 else {
                     provider = forcing.get();
                 }
+
                 // TODO: probably need to actually allow this by default and warn, but have config option to activate
                 //  this type of behavior
                 // TODO: account for arrays later
                 int nbytes = get_bmi_model()->GetVarNbytes(var_name);
                 int varItemSize = get_bmi_model()->GetVarItemsize(var_name);
+                int numItems = nbytes / varItemSize;
+                assert(nbytes % varItemSize == 0);
+
                 std::shared_ptr<void> value_ptr;
                 // Finally, use the value obtained to set the model input
                 std::string type = get_bmi_model()->get_analogous_cxx_type(get_bmi_model()->GetVarType(var_name),
                                                                            varItemSize);
-                if (varItemSize != get_bmi_model()->GetVarNbytes(var_name)) {
+                if (numItems != 1) {
                     //more than a single value needed for var_name
                     auto values = provider->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));


### PR DESCRIPTION
Extracted from #534 to more directly clear the way for #536

Fixes #541, #549

Fixes a number of invalid memory access resulting from the receiving model trying to read more data that the framework is providing.

When built and configured with `export CXXFLAGS="-g -fsanitize=address" CFLAGS="-g -fsanitize=address" FFLAGS="-g"`, `ctest` reports as follows

* Before:
```
98% tests passed, 14 tests failed out of 821

[...]

The following tests FAILED:
	233 - Bmi_Fortran_Formulation_Test.GetOutputLineForTimestep_0_a (Subprocess aborted)
	291 - Bmi_Py_Formulation_Test.get_response_0_a (Subprocess aborted)
	292 - Bmi_Py_Formulation_Test.get_response_0_b (Subprocess aborted)
	294 - Bmi_Py_Formulation_Test.GetOutputLineForTimestep_0_a (Subprocess aborted)
	295 - Bmi_Py_Formulation_Test.GetOutputLineForTimestep_0_b (Subprocess aborted)
	315 - Bmi_Multi_Formulation_Test.GetOutputLineForTimestep_1_a (Subprocess aborted)
	316 - Bmi_Multi_Formulation_Test.GetOutputLineForTimestep_1_b (Subprocess aborted)
	460 - Bmi_Fortran_Formulation_Test.GetOutputLineForTimestep_0_a (Subprocess aborted)
	518 - Bmi_Py_Formulation_Test.get_response_0_a (Subprocess aborted)
	519 - Bmi_Py_Formulation_Test.get_response_0_b (Subprocess aborted)
	521 - Bmi_Py_Formulation_Test.GetOutputLineForTimestep_0_a (Subprocess aborted)
	522 - Bmi_Py_Formulation_Test.GetOutputLineForTimestep_0_b (Subprocess aborted)
	542 - Bmi_Multi_Formulation_Test.GetOutputLineForTimestep_1_a (Subprocess aborted)
	543 - Bmi_Multi_Formulation_Test.GetOutputLineForTimestep_1_b (Subprocess aborted)
```

* After:
```
100% tests passed, 0 tests failed out of 821
```

## Changes

- A variable provided as a scalar value from a source will be broadcast to an array of the recipient model's expected size.

## Notes

- This will entail broader discussion around #551 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
