### PR TITLE
Compare Python & NumPy versions from configure/build time to runtime

### DIFF
--- a/cmake/dynamic_sourced_library.cmake
+++ b/cmake/dynamic_sourced_library.cmake
@@ -1,6 +1,6 @@
 ## Name : dynamic_sourced_library
 ## Params: LIB_NAME, WORK_DIR
-## Add/create a new library with the given name, passing a source files all the '*.cpp' files found in the given working directory for the library
+## Add/create a new library with the given name, passing as source files all the '*.cpp' files found in the given working directory for the library
 function(dynamic_sourced_cxx_library LIB_NAME WORK_DIR)
     execute_process(COMMAND ls
             COMMAND grep .cpp

--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -93,6 +93,27 @@ namespace utils {
                     addToPath(std::string(py::str(opt.attr("parent"))));
                     addToPath(std::string(py::str(opt)));
                 }
+
+                py::object python_version_info = importedTopLevelModules["sys"].attr("version_info");
+                py::str runtime_python_version = importedTopLevelModules["sys"].attr("version");
+                int major = py::int_(python_version_info.attr("major"));
+                int minor = py::int_(python_version_info.attr("minor"));
+                int patch = py::int_(python_version_info.attr("micro"));
+                if (major != python_major
+                    || minor != python_minor
+                    || patch != python_patch) {
+                    throw std::runtime_error("Python version mismatch between configure/build ("
+                                             + std::string(python_version)
+                                             + ") and runtime (" + std::string(runtime_python_version) + ")");
+                }
+
+                importTopLevelModule("numpy");
+                py::str runtime_numpy_version = importedTopLevelModules["numpy"].attr("version").attr("version");
+                if(std::string(runtime_numpy_version) != numpy_version) {
+                    throw std::runtime_error("NumPy version mismatch between configure/build ("
+                                             + std::string(numpy_version)
+                                             + ") and runtime (" + std::string(runtime_numpy_version) + ")");
+                }
             }
 
             ~InterpreterUtil() = default;

--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -332,6 +332,14 @@ namespace utils {
 
             py::object Path;
 
+            static const int python_major;
+            static const int python_minor;
+            static const int python_patch;
+            static const char* python_version;
+
+            // NumPy version is not broken down by CMake
+            static const char* numpy_version;
+
             /**
              * Import a specified top level module.
              *

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -45,6 +45,8 @@ if (${NGEN_ACTIVATE_PYTHON})
             ${PROJECT_SOURCE_DIR}/include/utilities
             ${PROJECT_SOURCE_DIR}/extern/pybind11/include
             )
+    configure_file(${PROJECT_SOURCE_DIR}/src/core/NGen_Python_Build_Versions.in NGen_Python_Build_Versions.cpp)
+    target_sources(core PRIVATE NGen_Python_Build_Versions.cpp)
     target_link_libraries(core PUBLIC
             Boost::boost                # Headers-only Boost
             pybind11::embed

--- a/src/core/NGen_Python_Build_Versions.in
+++ b/src/core/NGen_Python_Build_Versions.in
@@ -1,0 +1,17 @@
+#ifdef ACTIVATE_PYTHON
+
+#include "python/InterpreterUtil.hpp"
+
+namespace utils {
+    namespace ngenPy {
+
+        const int InterpreterUtil::python_major = ${Python_VERSION_MAJOR};
+        const int InterpreterUtil::python_minor = ${Python_VERSION_MINOR};
+        const int InterpreterUtil::python_patch = ${Python_VERSION_PATCH};
+        const char* InterpreterUtil::python_version = "${Python_VERSION}";
+
+        const char* InterpreterUtil::numpy_version = "${Python_NumPy_VERSION}";
+    }
+}
+
+#endif

--- a/src/realizations/catchment/CMakeLists.txt
+++ b/src/realizations/catchment/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(realizations_catchment PUBLIC
         )
 
 if(NGEN_ACTIVATE_PYTHON)
-   target_include_directories(realizations_catchment PUBLIC ${PROJECT_SOURCE_DIR}/extern/pybind11/include)
    target_link_libraries(realizations_catchment PUBLIC pybind11::embed)
 endif()
 


### PR DESCRIPTION
Fixes #545

## Additions

- Add `src/core/NGen_Python_Build_Versions.in]` to have CMake generate a corresponding `.cpp` file with the Python/NumPy versions

## Changes

- Get versions of Python and NumPy seen at runtime
- Check runtime versions against configure/build-time versions

## Testing

1. Tests fail if I `pip install numpy==1.24.0` in my virtual environment after building with 1.25.0 installed

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
