### PR TITLE
Shift UDUNITS to solely external installation

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -86,6 +86,18 @@ runs:
             fi
           shell: bash
 
+        - name: Install UDUNITS
+          run: |
+            if [ ${{ runner.os }} == 'Linux' ]
+            then
+              sudo apt-get update
+              sudo apt-get install -y --fix-missing libudunits2-dev
+            elif [ ${{ runner.os }} == 'macOS' ]
+            then
+              brew install udunits
+            fi
+          shell: bash
+
         - name: Init Submodules
           run: git submodule update --init --recursive
           shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,10 +21,6 @@
 	path = extern/noah-owp-modular/noah-owp-modular
 	url = https://github.com/NOAA-OWP/noah-owp-modular
 	branch = main
-[submodule "extern/UDUNITS-2"]
-	path = extern/UDUNITS-2
-	url = https://github.com/Unidata/UDUNITS-2.git
-	ignore = dirty
 [submodule "extern/bmi-cxx"]
 	path = extern/bmi-cxx
 	url = https://github.com/csdms/bmi-cxx.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,40 +126,12 @@ if (NOT (DEFINED UDUNITS_ACTIVE))
 endif()
 
 if(UDUNITS_ACTIVE)
-    find_package(UDUNITS2)
+    find_package(UDUNITS2 REQUIRED)
     if(UDUNITS2_LIBRARY)
         #add_library(libudunits2 SHARED IMPORTED)
         target_include_directories(libudunits2 INTERFACE ${UDUNITS2_INCLUDE})
         #include_directories(${UDUNITS2_INCLUDE})
         message("INFO Using UDUNITS2 at ${UDUNITS2_LIBRARY} and ${UDUNITS2_INCLUDE}")
-    else()
-        set(UDUNITS_DIR ${PROJECT_SOURCE_DIR}/extern/UDUNITS-2)
-        set(UDUNITS_BUILD_BASE ${CMAKE_CURRENT_BINARY_DIR}/UDUNITS-2)
-        set(UDUNITS_BUILD_DIR ${UDUNITS_BUILD_BASE}/build)
-        set(UDUNITS_INSTALL_DIR ${UDUNITS_BUILD_BASE}/build)
-        git_update_submodule(${UDUNITS_DIR})
-        ExternalProject_Add(libudunits2_build
-            PREFIX ${UDUNITS_BUILD_BASE}
-            SOURCE_DIR ${UDUNITS_DIR}
-            BINARY_DIR ${UDUNITS_BUILD_DIR}
-            INSTALL_DIR ${UDUNITS_INSTALL_DIR}
-            PATCH_COMMAND find ${PROJECT_SOURCE_DIR}/extern/UDUNITS-2  \( -type d -name .git -prune \) -o -type f -name "CMakeLists.txt" -exec sed -i -e "s/CMAKE_MINIMUM_REQUIRED(VERSION 3\.19)/CMAKE_MINIMUM_REQUIRED(VERSION 3.17)/" {} +
-            #CMAKE_ARGS -DBOOST_ROOT=${BOOST_ROOT} CMAKE_INSTALL_RPATH_USE_LINK_PATH="ON" -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${UDUNITS_INSTALL_DIR}
-        )
-        add_library(libudunits2 SHARED IMPORTED)
-        add_dependencies(libudunits2 libudunits2_build)
-
-        #set_property(TARGET libudunits2 PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
-        #set(CMAKE_MACOSX_RPATH 1)
-        message("INFO - Linking libudunits2 to path \"${UDUNITS_INSTALL_DIR}/lib/libudunits2.${SHARED_LIB_EXTENSION}\"")
-        set_property(TARGET libudunits2 PROPERTY IMPORTED_LOCATION "${UDUNITS_INSTALL_DIR}/lib/libudunits2.${SHARED_LIB_EXTENSION}")
-        list( APPEND CMAKE_INSTALL_RPATH ${UDUNITS_INSTALL_DIR}/lib ${UDUNITS_INSTALL_DIR}/include )
-        list( APPEND CMAKE_BUILD_RPATH ${UDUNITS_BUILD_DIR}/lib )
-        
-        #set_property(TARGET libudunits2 PROPERTY GENERATED TRUE)
-        target_include_directories(libudunits2 INTERFACE "${UDUNITS_DIR}/lib") # This seems like it should have worked...??
-        include_directories("${UDUNITS_DIR}/lib")
     endif()
     #add_compile_definitions("NGEN_UDUNITS2_XML_PATH=\"${UDUNITS_INSTALL_DIR}/share/udunits/udunits2.xml\"")
 endif()

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -8,7 +8,7 @@
 | [C/C++ Compiler](#c-and-c-compiler) | external | see below |  |
 | [CMake](#cmake) | external | \>= `3.14` | |
 | [Boost (Headers Only)](#boost-headers-only) | external | `1.72.0` | headers only library |
-| [Udunits libraries](https://www.unidata.ucar.edu/software/udunits) | hybrid (external or submodule) | >= 2.0 | Can be installed via package manager; if not installed, will be automatically downloaded as submodule, and build will be attempted. |
+| [Udunits libraries](https://www.unidata.ucar.edu/software/udunits) | external | >= 2.0 | Can be installed via package manager or from source |
 | [MPI](https://www.mpi-forum.org) | external | No current implementation or version requirements | Required for [multi-process distributed execution](DISTRIBUTED_PROCESSING.md) |
 | [Python 3 Libraries](#python-3-libraries) | external | \> `3.6.8` | Can be [excluded](#overriding-python-dependency). |
 | [pybind11](#pybind11) | submodule | `v2.6.0` | Can be [excluded](#overriding-pybind11-dependency). |
@@ -105,15 +105,9 @@ At present, a version >= `1.72.0` is required.
 
 ## Udunits
 
-[Udunits](https://www.unidata.ucar.edu/software/udunits) is a C library and associated command line tool for converting between compatible units.  Only the C library is a required dependency, though these frequently get bundled together.
+[Udunits](https://www.unidata.ucar.edu/software/udunits) is a C library and associated command line tool for converting between compatible units.  Only the C library is a required dependency, though these frequently get bundled together. The library and needed development files can be installed via typical package managing tools.
 
-### Setup
-
-The description of the setup is more complicated than most other current dependencies.  However, the required steps should be very easy to perform.
-
-Basically, the library and needed development files can be installed via typical package managing tools.  But, the ngen project build is also be able to automatically obtain and build it, but only when the transitive dependencies are already available.
-
-#### Option 1: Package Manager Install
+#### Package Manager Install
 
 The Udunits library and development files can be installed via standard OS package management tools.  The ngen project will automatically detect and use these.  Note that both the library itself and development files must be installed, which are typically two separate, similarly named packages.
 
@@ -134,18 +128,6 @@ Packages for both the _library_ and _development files_ are needed.  Package man
 `yum install udunits2-devel`
 
 As mentioned before, you may need to [enable the EPEL repo first](https://docs.fedoraproject.org/en-US/epel/) first, if yum can't find the package.
-
-#### Option 2: Automatic Submodule Build
-
-The CMake build will attempt to find an installed copy of the Udunits library.  If it can't though, it will automatically initialize and download Udunits as a Git submodule (under _extern/UDUNITS-2/_), and then build an internal copy of the library.
-
-When this works, it will work totally automatically when building an existing build targets (e.g., `ngen` or `test_bmi_c`).  However, it won't always work.  The reason for this is that the ngen build cannot currently automatically manage the dependencies of Udunits, in the same way it can manage its own dependency on Udunits.
-
-What this means is that, if all the transitive dependencies are already available locally, builds will "just work".  But, if any aren't, they would have to be "manually" obtained.  "Manually" here will frequently mean installing via a package manager, but at that point it's usually easier to just install Udunits itself that way.
-
-##### Caveat: Regenerate When Switching Options
-
-If you try to go from one option to another, is best to make sure to [fully regenerate your CMake build](BUILDS_AND_CMAKE.md#build-system-regeneration) to avoid any unexpected issues.  The most common case for doing that is if an automatic build (option 2) is tried but doesn't work successfully, so the Udunits packages are installed instead.
 
 ### Version Requirements
 


### PR DESCRIPTION
UDUNITS is available in every package repository we care about. If users want a specific version, they can still build it themselves and point CMake at it. Otherwise, there's no good reason for us to treat it specially by bundling code to download and build it.

## Changes

- Document that udunits should be installed from a package repository
- Remove code to download and install it ourselves
- Update the CI scripts to install it before configuring and building ngen

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
