### PR TITLE
#362: Remove repeated searches for Boost that were picking up mixed versions

### DIFF
--- a/src/core/catchment/CMakeLists.txt
+++ b/src/core/catchment/CMakeLists.txt
@@ -13,9 +13,6 @@ target_include_directories(core_catchment PUBLIC
         ${PROJECT_SOURCE_DIR}/include/core/catchment/giuh
         )
 
-# TODO: consider setting a minimum or required version
-find_package(Boost)
-
 add_subdirectory("giuh")
 
 target_link_libraries(core_catchment PUBLIC

--- a/src/core/catchment/giuh/CMakeLists.txt
+++ b/src/core/catchment/giuh/CMakeLists.txt
@@ -13,7 +13,6 @@ target_include_directories(core_catchment_giuh PUBLIC
         ${PROJECT_SOURCE_DIR}/include/core/catchment/giuh
         )
 
-find_package(Boost)
 target_link_libraries(core_catchment_giuh PUBLIC
         Boost::boost                # Headers-only Boost
         )

--- a/src/core/hydrolocation/CMakeLists.txt
+++ b/src/core/hydrolocation/CMakeLists.txt
@@ -13,9 +13,6 @@ target_include_directories(core_hydrolocation PUBLIC
         ${PROJECT_SOURCE_DIR}/include/utilities
         )
 
-# TODO: consider setting a minimum or required version
-find_package(Boost)
-
 target_link_libraries(core_hydrolocation PUBLIC
         Boost::boost                # Headers-only Boost
         )

--- a/src/core/nexus/CMakeLists.txt
+++ b/src/core/nexus/CMakeLists.txt
@@ -14,9 +14,6 @@ target_include_directories(core_nexus PUBLIC
         ${PROJECT_SOURCE_DIR}/include/utilities
         )
 
-# TODO: consider setting a minimum or required version
-find_package(Boost)
-
 target_link_libraries(core_nexus PUBLIC
         Boost::boost                # Headers-only Boost
         )

--- a/src/geojson/CMakeLists.txt
+++ b/src/geojson/CMakeLists.txt
@@ -8,8 +8,6 @@ add_library(NGen::geojson ALIAS geojson)
 target_include_directories(geojson PUBLIC
         ${PROJECT_SOURCE_DIR}/include/geojson
         )
-# TODO: consider setting a minimum or required version
-find_package(Boost)
 target_link_libraries(geojson PUBLIC
         Boost::boost                # Headers-only Boost
         )


### PR DESCRIPTION
Having multiple calls to `find_package(Boost)`, some specifying a required version and others not, led to CMake searching for the package multiple times, and flipping imports between found instances depending on which one was found last (or maybe within the calling scope). This could result in a quietly and inscrutably broken build, with ABI mismatches and ODR violations.

Address these concerns by removing all of the `find_package` calls other than the one with the specified version at the root of the package.

Fixes #362

## Additions

- N/A

## Removals

- N/A

## Changes

- Drop `find_package(Boost)` calls from subsidiary packages' `CMakeLists.txt`

## Testing

1.

## Screenshots

See #362 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
