### PR TITLE
Use `span` to avoid copying WKB geometry data

### DIFF
--- a/include/geopackage/WKB.hpp
+++ b/include/geopackage/WKB.hpp
@@ -60,37 +60,37 @@ struct wkb {
      * Read a WKB point into a cartesian model.
      * @return point_t 
      */
-    static point_t read_point(const byte_vector&, int&, uint8_t);
+    static point_t read_point(const boost::span<const uint8_t>, int&, uint8_t);
 
     /**
      * Read a WKB linestring into a cartesian model.
      * @return linestring_t 
      */
-    static linestring_t read_linestring(const byte_vector&, int&, uint8_t);
+    static linestring_t read_linestring(const boost::span<const uint8_t>, int&, uint8_t);
 
     /**
      * Read a WKB polygon into a cartesian model.
      * @return polygon_t 
      */
-    static polygon_t read_polygon(const byte_vector&, int&, uint8_t);
+    static polygon_t read_polygon(const boost::span<const uint8_t>, int&, uint8_t);
 
     /**
      * Read a WKB multipoint into a cartesian model.
      * @return multipoint_t 
      */
-    static multipoint_t read_multipoint(const byte_vector&, int&, uint8_t);
+    static multipoint_t read_multipoint(const boost::span<const uint8_t>, int&, uint8_t);
 
     /**
      * Read a WKB multilinestring into a cartesian model.
      * @return multilinestring_t 
      */
-    static multilinestring_t read_multilinestring(const byte_vector&, int&, uint8_t);
+    static multilinestring_t read_multilinestring(const boost::span<const uint8_t>, int&, uint8_t);
 
     /**
      * Read a WKB multipolygon into a cartesian model.
      * @return multipolygon_t 
      */
-    static multipolygon_t read_multipolygon(const byte_vector&, int&, uint8_t);
+    static multipolygon_t read_multipolygon(const boost::span<const uint8_t>, int&, uint8_t);
 };
 
 /**

--- a/include/geopackage/WKB.hpp
+++ b/include/geopackage/WKB.hpp
@@ -51,7 +51,7 @@ struct wkb {
      * @param[in] buffer byte vector buffer
      * @return geometry wkb::geometry struct containing the geometry data from the buffer
      */
-    static geometry read(const byte_vector& buffer);
+    static geometry read(const boost::span<const uint8_t> buffer);
 
     static bg::srs::dpar::parameters<> get_prj(uint32_t srid);
 

--- a/include/utilities/EndianCopy.hpp
+++ b/include/utilities/EndianCopy.hpp
@@ -1,9 +1,8 @@
 #ifndef NGEN_ENDIANCOPY_H
 #define NGEN_ENDIANCOPY_H
 
-#include <vector>
-
 #include <boost/endian.hpp>
+#include "span.hpp"
 
 namespace utils {
 
@@ -21,7 +20,7 @@ namespace utils {
  * @param order endianness value (0x01 == Little; 0x00 == Big)
  */
 template<typename S>
-void copy_from(const std::vector<uint8_t>& src, int& index, S& dst, uint8_t order)
+void copy_from(const boost::span<const uint8_t> src, int& index, S& dst, uint8_t order)
 {
     std::memcpy(&dst, src.data() + index, sizeof(dst));
 
@@ -37,7 +36,7 @@ void copy_from(const std::vector<uint8_t>& src, int& index, S& dst, uint8_t orde
 // boost::endian doesn't support using primitive doubles
 // see: https://github.com/boostorg/endian/issues/36
 template<>
-inline void copy_from<double>(const std::vector<uint8_t>& src, int& index, double& dst, uint8_t order)
+inline void copy_from<double>(const boost::span<const uint8_t> src, int& index, double& dst, uint8_t order)
 {
     static_assert(sizeof(uint64_t) == sizeof(double), "sizeof(uint64_t) is not the same as sizeof(double)!");
 

--- a/src/geopackage/geometry.cpp
+++ b/src/geopackage/geometry.cpp
@@ -75,7 +75,8 @@ geojson::geometry geopackage::build_geometry(
     }
 
     if (!is_empty) {
-        const std::vector<uint8_t> geometry_data(geometry_blob.begin() + index, geometry_blob.end());
+        const boost::span<const uint8_t> geometry_data(geometry_blob.data() + index,
+                                                       geometry_blob.data() + geometry_blob.size());
         auto wkb_geometry = wkb::read(geometry_data);
         geojson::geometry geometry = boost::apply_visitor(pvisitor, wkb_geometry);
         return geometry;

--- a/src/geopackage/wkb.cpp
+++ b/src/geopackage/wkb.cpp
@@ -158,7 +158,7 @@ typename wkb::multipolygon_t wkb::read_multipolygon(const boost::span<const uint
 
 // ----------------------------------------------------------------------------
 
-typename wkb::geometry wkb::read(const byte_vector& buffer)
+typename wkb::geometry wkb::read(const boost::span<const uint8_t> buffer)
 {
     if (buffer.size() < 5) {
         throw std::runtime_error("buffer reached end before encountering WKB");

--- a/src/geopackage/wkb.cpp
+++ b/src/geopackage/wkb.cpp
@@ -29,7 +29,7 @@ void throw_if_not_type(uint32_t given, wkb_geom_t expected)
 // WKB Readers
 // ----------------------------------------------------------------------------
 
-typename wkb::point_t wkb::read_point(const byte_vector& buffer, int& index, uint8_t order)
+typename wkb::point_t wkb::read_point(const boost::span<const uint8_t> buffer, int& index, uint8_t order)
 {
     double x, y;
     utils::copy_from(buffer, index, x, order);
@@ -39,7 +39,7 @@ typename wkb::point_t wkb::read_point(const byte_vector& buffer, int& index, uin
 
 // ----------------------------------------------------------------------------
 
-typename wkb::linestring_t wkb::read_linestring(const byte_vector& buffer, int& index, uint8_t order)
+typename wkb::linestring_t wkb::read_linestring(const boost::span<const uint8_t> buffer, int& index, uint8_t order)
 {
     uint32_t count;
     utils::copy_from(buffer, index, count, order);
@@ -55,7 +55,7 @@ typename wkb::linestring_t wkb::read_linestring(const byte_vector& buffer, int& 
 
 // ----------------------------------------------------------------------------
 
-typename wkb::polygon_t wkb::read_polygon(const byte_vector& buffer, int& index, uint8_t order)
+typename wkb::polygon_t wkb::read_polygon(const boost::span<const uint8_t> buffer, int& index, uint8_t order)
 {
     uint32_t count;
     utils::copy_from(buffer, index, count, order);
@@ -88,7 +88,7 @@ typename wkb::polygon_t wkb::read_polygon(const byte_vector& buffer, int& index,
 
 // ----------------------------------------------------------------------------
 
-typename wkb::multipoint_t wkb::read_multipoint(const byte_vector& buffer, int& index, uint8_t order)
+typename wkb::multipoint_t wkb::read_multipoint(const boost::span<const uint8_t> buffer, int& index, uint8_t order)
 {
     uint32_t count;
     utils::copy_from(buffer, index, count, order);
@@ -112,7 +112,7 @@ typename wkb::multipoint_t wkb::read_multipoint(const byte_vector& buffer, int& 
 
 // ----------------------------------------------------------------------------
 
-typename wkb::multilinestring_t wkb::read_multilinestring(const byte_vector& buffer, int& index, uint8_t order)
+typename wkb::multilinestring_t wkb::read_multilinestring(const boost::span<const uint8_t> buffer, int& index, uint8_t order)
 {
     uint32_t count;
     utils::copy_from(buffer, index, count, order);
@@ -135,7 +135,7 @@ typename wkb::multilinestring_t wkb::read_multilinestring(const byte_vector& buf
 
 // ----------------------------------------------------------------------------
 
-typename wkb::multipolygon_t wkb::read_multipolygon(const byte_vector& buffer, int& index, uint8_t order)
+typename wkb::multipolygon_t wkb::read_multipolygon(const boost::span<const uint8_t> buffer, int& index, uint8_t order)
 {
     uint32_t count;
     utils::copy_from(buffer, index, count, order);


### PR DESCRIPTION
Fixes #582 

## Changes

- Convert internal GeoPackage interfaces from passing around `const std::vector<uint8_t>&` to passing `const boost::span<const uint8_t>`, so that callers won't need to have a `vector` in hand to pass as an argument
- Avoid constructing and copying into a temporary `vector` with almost the entire geometry blob, since we can now pass a `span` referring to the source of the copy

## Testing

1. `test_geopackage` runs equally successfully before and after (with fixes from #580)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
