### PR TITLE
Allow passing feature properties to BMI models through `model_params`

### DIFF
--- a/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
+++ b/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
@@ -139,18 +139,24 @@ class TestBmiCpp : public bmi::Bmi {
         bool use_input_array, use_output_array;
    
         std::vector<std::string> input_var_names = { "INPUT_VAR_1", "INPUT_VAR_2" };
-        std::vector<std::string> output_var_names = { "OUTPUT_VAR_1", "OUTPUT_VAR_2" };
+        std::vector<std::string> output_var_names = { "OUTPUT_VAR_1", "OUTPUT_VAR_2", "OUTPUT_VAR_4", "OUTPUT_VAR_5" };
+        std::vector<std::string> model_var_names = { "MODEL_VAR_1", "MODEL_VAR_2" };
         std::vector<std::string> input_var_types = { "double", "double" };
-        std::vector<std::string> output_var_types = { "double", "double" };
+        std::vector<std::string> output_var_types = { "double", "double", "double", "double" };
+        std::vector<std::string> model_var_types = { "double", "double" };
         std::vector<std::string> input_var_units = { "m", "m" };
-        std::vector<std::string> output_var_units = { "m", "m/s" };
+        std::vector<std::string> output_var_units = { "m", "m/s", "m", "m" };
+        std::vector<std::string> model_var_units = { "m", "m" };
         std::vector<std::string> input_var_locations = { "node", "node" };
-        std::vector<std::string> output_var_locations = { "node", "node" };
+        std::vector<std::string> output_var_locations = { "node", "node", "node", "node" };
+        std::vector<std::string> model_var_locations = { "node", "node" };
 
         std::vector<int> input_var_item_count = { 1, 1 };
-        std::vector<int> output_var_item_count = { 1, 1 };
+        std::vector<int> output_var_item_count = { 1, 1, 1, 1 };
+        std::vector<int> model_var_item_count = { 1, 1 };
         std::vector<int> input_var_grids = { 1, 1 };
-        std::vector<int> output_var_grids = { 1, 1 };
+        std::vector<int> output_var_grids = { 1, 1, 1, 1 };
+        std::vector<int> model_var_grids = { 1, 1 };
         
         std::map<std::string,int> type_sizes = {
             {BMI_TYPE_NAME_DOUBLE, sizeof(double)},
@@ -178,6 +184,10 @@ class TestBmiCpp : public bmi::Bmi {
         std::unique_ptr<double> input_var_2 = nullptr;
         std::unique_ptr<double> output_var_1 = nullptr;
         std::unique_ptr<double> output_var_2 = nullptr;
+        std::unique_ptr<double> output_var_4 = nullptr;
+        std::unique_ptr<double> output_var_5 = nullptr;
+        std::unique_ptr<double> model_var_1 = nullptr;
+        std::unique_ptr<double> model_var_2 = nullptr;
 
         //Variables for testing array in/out
         std::unique_ptr<double[]> input_var_3 = nullptr;

--- a/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
+++ b/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
@@ -35,10 +35,10 @@ class TestBmiCpp : public bmi::Bmi {
         *
         * @return Pointer to the newly created @ref test_bmi_c_model struct instance in memory.
         */
-        TestBmiCpp(bool input_array = false, bool output_array = false):
-            use_input_array(input_array), use_output_array(output_array)
+        TestBmiCpp(bool input_array = false, bool output_array = false, bool model_params = false):
+            use_input_array(input_array), use_output_array(output_array), use_model_params(model_params)
         {
-            set_usage(input_array, output_array);
+            set_usage(input_array, output_array, model_params);
         };
 
         virtual void Initialize(std::string config_file);
@@ -102,9 +102,10 @@ class TestBmiCpp : public bmi::Bmi {
 
     private:
 
-        inline void set_usage(bool input_array = false, bool output_array = false){
+        inline void set_usage(bool input_array = false, bool output_array = false, bool model_params = false){
             use_input_array = input_array;
             use_output_array = output_array;
+            use_model_params = model_params;
             //NOTE use the correct array constructor here or things get weird
             //make_unique<double>(3) will give a unique pointer to a single double initialized to 3
             //make_unique<double[]>(3) will give a unique pointer to an array of 3 doubles, default initialized
@@ -134,29 +135,56 @@ class TestBmiCpp : public bmi::Bmi {
                 output_var_item_count.push_back(3); //an array of 3 values
                 output_var_grids.push_back(1);
             }
+            if( use_model_params ){
+                this->output_var_4 = std::make_unique<double>(0);
+                this->output_var_5 = std::make_unique<double>(1);
+                this->model_var_1  = std::make_unique<double>(1);
+                this->model_var_2 = std::make_unique<double>(2);
+                std::cout<<"USING MODEL PARAMS\n";
+                output_var_names.push_back("OUTPUT_VAR_4");
+                output_var_types.push_back("double");
+                output_var_units.push_back("m");
+                output_var_locations.push_back("node");
+                output_var_item_count.push_back(1);
+                output_var_grids.push_back(1);
+
+                output_var_names.push_back("OUTPUT_VAR_5");
+                output_var_types.push_back("double");
+                output_var_units.push_back("m");
+                output_var_locations.push_back("node");
+                output_var_item_count.push_back(1);
+                output_var_grids.push_back(1);
+
+                this->model_var_names = { "MODEL_VAR_1", "MODEL_VAR_2" };
+                this->model_var_types = { "double", "double" };
+                this->model_var_units = { "m", "m" };
+                this->model_var_locations = { "node", "node" };
+                this->model_var_item_count = { 1, 1 };
+                this->model_var_grids = { 1, 1 };
+            }
         }
         //flags for conditional use of input/output var 3
-        bool use_input_array, use_output_array;
+        bool use_input_array, use_output_array, use_model_params;
    
         std::vector<std::string> input_var_names = { "INPUT_VAR_1", "INPUT_VAR_2" };
-        std::vector<std::string> output_var_names = { "OUTPUT_VAR_1", "OUTPUT_VAR_2", "OUTPUT_VAR_4", "OUTPUT_VAR_5" };
-        std::vector<std::string> model_var_names = { "MODEL_VAR_1", "MODEL_VAR_2" };
+        std::vector<std::string> output_var_names = { "OUTPUT_VAR_1", "OUTPUT_VAR_2"};
+        std::vector<std::string> model_var_names = {};
         std::vector<std::string> input_var_types = { "double", "double" };
-        std::vector<std::string> output_var_types = { "double", "double", "double", "double" };
-        std::vector<std::string> model_var_types = { "double", "double" };
+        std::vector<std::string> output_var_types = { "double", "double" };
+        std::vector<std::string> model_var_types = {};
         std::vector<std::string> input_var_units = { "m", "m" };
         std::vector<std::string> output_var_units = { "m", "m/s", "m", "m" };
-        std::vector<std::string> model_var_units = { "m", "m" };
+        std::vector<std::string> model_var_units = {};
         std::vector<std::string> input_var_locations = { "node", "node" };
-        std::vector<std::string> output_var_locations = { "node", "node", "node", "node" };
-        std::vector<std::string> model_var_locations = { "node", "node" };
+        std::vector<std::string> output_var_locations = { "node", "node" };
+        std::vector<std::string> model_var_locations = {};
 
         std::vector<int> input_var_item_count = { 1, 1 };
-        std::vector<int> output_var_item_count = { 1, 1, 1, 1 };
-        std::vector<int> model_var_item_count = { 1, 1 };
+        std::vector<int> output_var_item_count = { 1, 1 };
+        std::vector<int> model_var_item_count = {};
         std::vector<int> input_var_grids = { 1, 1 };
-        std::vector<int> output_var_grids = { 1, 1, 1, 1 };
-        std::vector<int> model_var_grids = { 1, 1 };
+        std::vector<int> output_var_grids = { 1, 1 };
+        std::vector<int> model_var_grids = {};
         
         std::map<std::string,int> type_sizes = {
             {BMI_TYPE_NAME_DOUBLE, sizeof(double)},
@@ -184,14 +212,16 @@ class TestBmiCpp : public bmi::Bmi {
         std::unique_ptr<double> input_var_2 = nullptr;
         std::unique_ptr<double> output_var_1 = nullptr;
         std::unique_ptr<double> output_var_2 = nullptr;
-        std::unique_ptr<double> output_var_4 = nullptr;
-        std::unique_ptr<double> output_var_5 = nullptr;
-        std::unique_ptr<double> model_var_1 = nullptr;
-        std::unique_ptr<double> model_var_2 = nullptr;
 
         //Variables for testing array in/out
         std::unique_ptr<double[]> input_var_3 = nullptr;
         std::unique_ptr<double[]> output_var_3 = nullptr;
+
+        // Variables for testing model params
+        std::unique_ptr<double> output_var_4 = nullptr;
+        std::unique_ptr<double> output_var_5 = nullptr;
+        std::unique_ptr<double> model_var_1 = nullptr;
+        std::unique_ptr<double> model_var_2 = nullptr;
 
         /**
         * Read the BMI initialization config file and use its contents to set the state of the model.

--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
@@ -496,10 +496,7 @@ void TestBmiCpp::read_file_line_counts(std::string file_name, int* line_count, i
 
 
 void TestBmiCpp::run(long dt)
-{
-    *this->output_var_4 = *this->model_var_1;
-    *this->output_var_5 = *this->model_var_2 * 1.0;
-  
+{  
     if (dt == this->time_step_size) {
         *this->output_var_1 = *this->input_var_1;
         *this->output_var_2 = 2.0 * *this->input_var_2;
@@ -512,6 +509,10 @@ void TestBmiCpp::run(long dt)
       this->output_var_3.get()[0] += 1;
       this->output_var_3.get()[1] += 2;
       this->output_var_3.get()[2] += 3;
+    }
+    if (this->use_model_params) {
+        *this->output_var_4 = *this->model_var_1;
+        *this->output_var_5 = *this->model_var_2 * 1.0;
     }
     this->current_model_time += (double)dt;
 }

--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
@@ -149,6 +149,19 @@ void* TestBmiCpp::GetValuePtr(std::string name){
   if (use_output_array && name == "OUTPUT_VAR_3") {
     return this->output_var_3.get();
   }
+  if (name == "OUTPUT_VAR_4") {
+    return this->output_var_4.get();
+  }
+  if (name == "OUTPUT_VAR_5") {
+    return this->output_var_5.get();
+  }
+
+  if (name == "MODEL_VAR_1") {
+    return this->model_var_1.get();
+  }
+  if (name == "MODEL_VAR_2") {
+    return this->model_var_2.get();
+  }
 
   throw std::runtime_error("GetValuePtr called for unknown variable: "+name);
 }
@@ -171,6 +184,10 @@ std::string TestBmiCpp::GetVarLocation(std::string name){
   if(iter != this->input_var_names.end()){
     return this->input_var_locations[iter - this->input_var_names.begin()];
   }
+  iter = std::find(this->model_var_names.begin(), this->model_var_names.end(), name);
+  if(iter != this->model_var_names.end()){
+    return this->model_var_locations[iter - this->model_var_names.begin()];
+  }
   throw std::runtime_error("GetVarLocation called for non-existent variable: "+name+"" SOURCE_LOC);
 }
 
@@ -189,6 +206,10 @@ int TestBmiCpp::GetVarNbytes(std::string name){
   if(iter != this->input_var_names.end()){
     item_count = this->input_var_item_count[iter - this->input_var_names.begin()];
   }
+  iter = std::find(this->model_var_names.begin(), this->model_var_names.end(), name);
+  if(iter != this->model_var_names.end()){
+    item_count = this->model_var_item_count[iter - this->model_var_names.begin()];
+  }
   if(item_count == -1){
     // This is probably impossible to reach--the same conditions above failing will cause a throw
     // in GetVarItemSize --> GetVarType (called earlier) instead.
@@ -206,6 +227,10 @@ std::string TestBmiCpp::GetVarType(std::string name){
   if(iter != this->input_var_names.end()){
     return this->input_var_types[iter - this->input_var_names.begin()];
   }
+  iter = std::find(this->model_var_names.begin(), this->model_var_names.end(), name);
+  if(iter != this->model_var_names.end()){
+    return this->model_var_types[iter - this->model_var_names.begin()];
+  }
   throw std::runtime_error("GetVarType called for non-existent variable: "+name+"" SOURCE_LOC );
 }
 
@@ -217,6 +242,10 @@ std::string TestBmiCpp::GetVarUnits(std::string name){
   iter = std::find(this->input_var_names.begin(), this->input_var_names.end(), name);
   if(iter != this->input_var_names.end()){
     return this->input_var_units[iter - this->input_var_names.begin()];
+  }
+  iter = std::find(this->model_var_names.begin(), this->model_var_names.end(), name);
+  if(iter != this->model_var_names.end()){
+    return this->model_var_types[iter - this->model_var_names.begin()];
   }
   throw std::runtime_error("GetVarUnits called for non-existent variable: "+name+"" SOURCE_LOC);
 }
@@ -249,6 +278,10 @@ void TestBmiCpp::Initialize(std::string file){
   this->input_var_2 = std::make_unique<double>(0);
   this->output_var_1 = std::make_unique<double>(0);
   this->output_var_2 = std::make_unique<double>(0);
+  this->output_var_4 = std::make_unique<double>(0);
+  this->output_var_5 = std::make_unique<double>(1);
+  this->model_var_1 = std::make_unique<double>(1);
+  this->model_var_2 = std::make_unique<double>(2);
 
 }
 
@@ -463,6 +496,9 @@ void TestBmiCpp::read_file_line_counts(std::string file_name, int* line_count, i
 
 void TestBmiCpp::run(long dt)
 {
+    *this->output_var_4 = *this->model_var_1;
+    *this->output_var_5 = *this->model_var_2 * 1.0;
+  
     if (dt == this->time_step_size) {
         *this->output_var_1 = *this->input_var_1;
         *this->output_var_2 = 2.0 * *this->input_var_2;

--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
@@ -149,18 +149,20 @@ void* TestBmiCpp::GetValuePtr(std::string name){
   if (use_output_array && name == "OUTPUT_VAR_3") {
     return this->output_var_3.get();
   }
-  if (name == "OUTPUT_VAR_4") {
-    return this->output_var_4.get();
-  }
-  if (name == "OUTPUT_VAR_5") {
-    return this->output_var_5.get();
-  }
 
-  if (name == "MODEL_VAR_1") {
-    return this->model_var_1.get();
-  }
-  if (name == "MODEL_VAR_2") {
-    return this->model_var_2.get();
+  if (use_model_params) {
+    if (name == "OUTPUT_VAR_4") {
+      return this->output_var_4.get();
+    }
+    if (name == "OUTPUT_VAR_5") {
+      return this->output_var_5.get();
+    }
+    if (name == "MODEL_VAR_1") {
+      return this->model_var_1.get();
+    }
+    if (name == "MODEL_VAR_2") {
+      return this->model_var_2.get();
+    }
   }
 
   throw std::runtime_error("GetValuePtr called for unknown variable: "+name);
@@ -278,10 +280,6 @@ void TestBmiCpp::Initialize(std::string file){
   this->input_var_2 = std::make_unique<double>(0);
   this->output_var_1 = std::make_unique<double>(0);
   this->output_var_2 = std::make_unique<double>(0);
-  this->output_var_4 = std::make_unique<double>(0);
-  this->output_var_5 = std::make_unique<double>(1);
-  this->model_var_1 = std::make_unique<double>(1);
-  this->model_var_2 = std::make_unique<double>(2);
 
 }
 
@@ -432,6 +430,9 @@ void TestBmiCpp::read_init_config(std::string config_file)
     if( strcmp(param_key, "use_output_array") == 0) {
       this->use_output_array = true;
     }
+    if( strcmp(param_key, "use_model_params") == 0) {
+      this->use_model_params = true;
+    }
   }
 
   if (is_epoch_start_time_set == FALSE) {
@@ -443,8 +444,8 @@ void TestBmiCpp::read_init_config(std::string config_file)
 #endif
 
   //dynamic creation/usage of optional var 3
-  if(use_input_array || use_output_array ){
-    set_usage(use_input_array, use_output_array);
+  if(use_input_array || use_output_array || use_model_params){
+    set_usage(use_input_array, use_output_array, use_model_params);
   }
 }
 

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -617,7 +617,8 @@ namespace realization {
             void parse_external_model_params(geojson::PropertyMap& model_params, const geojson::Feature catchment_feature) {
                 geojson::PropertyMap attr {};
                 for (decltype(auto) param : model_params) {
-                    if (!param.second.has_key("source")) {
+                    // Check for type to short-circuit. If param.second is not an object, `.has_key()` will throw
+                    if (param.second.get_type() != geojson::PropertyType::Object || !param.second.has_key("source")) {
                         attr.emplace(param.first, param.second);
                         continue;
                     }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -523,24 +523,24 @@ namespace realization {
                         throw std::logic_error("ERROR: 'model_params' source `" + param_source_name + "` not currently supported. Only `hydrofabric` is supported.");
                     }
 
-                    decltype(auto) param_name = param.second.get_child_optional("from")
-                        ? param.second.get_child("from").get_value<std::string>()
-                        : param.first;
+                    decltype(auto) param_name = param.second.find("from") == param.second.not_found()
+                        ? param.first
+                        : param.second.get_child("from").get_value<std::string>();
 
                     if (catchment_feature->has_property(param_name)) {
                         auto catchment_attribute = catchment_feature->get_property(param_name);
                         switch (catchment_attribute.get_type()) {
                             case geojson::PropertyType::Natural:
-                                attr.put(param_name, catchment_attribute.as_natural_number());
+                                attr.put(param.first, catchment_attribute.as_natural_number());
                                 break;
                             case geojson::PropertyType::Boolean:
-                                attr.put(param_name, catchment_attribute.as_boolean());
+                                attr.put(param.first, catchment_attribute.as_boolean());
                                 break;
                             case geojson::PropertyType::Real:
-                                attr.put(param_name, catchment_attribute.as_real_number());
+                                attr.put(param.first, catchment_attribute.as_real_number());
                                 break;
                             case geojson::PropertyType::String:
-                                attr.put(param_name, catchment_attribute.as_string());
+                                attr.put(param.first, catchment_attribute.as_string());
                                 break;
 
                             case geojson::PropertyType::List:

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -170,19 +170,21 @@ namespace realization {
                           continue;
                       }
 
-                      auto catchment_feature = fabric->get_feature(catchment_index);
-                      auto formulations = catchment_config.second.get_child_optional("formulations");
+                      decltype(auto) formulations = catchment_config.second.get_child_optional("formulations");
                       if( !formulations ) {
                         throw std::runtime_error("ERROR: No formulations defined for "+catchment_config.first+".");
                       }
 
                       // Parse catchment-specific model_params
-                      auto model_params = formulations->get_child_optional("params.model_params");
-                      if (model_params) {
-                        parse_external_model_params(*model_params, catchment_feature);
-                      }
+                      auto catchment_feature = fabric->get_feature(catchment_index);
 
-                      for (const auto &formulation: *formulations) {
+                      for (auto &formulation: *formulations) {
+                          decltype(auto) model_params = formulation.second.get_child_optional("params.model_params");
+                          if (model_params) {
+                              std::cerr << "Checking for external model_params\n";
+                              parse_external_model_params(*model_params, catchment_feature);
+                          }
+                        
                           this->add_formulation(
                               this->construct_formulation_from_tree(
                                   simulation_time_config,
@@ -507,49 +509,51 @@ namespace realization {
              * @param catchment_feature Associated catchment feature
              */
             void parse_external_model_params(boost::property_tree::ptree& model_params, const geojson::Feature catchment_feature) {
-                 for (auto& param : model_params) {
-                    auto param_source = param.second.get_child_optional("source");
-                    if (!param_source) {
+                 boost::property_tree::ptree attr {};
+                 for (decltype(auto) param : model_params) {
+                    if (param.second.count("source") == 0) {
+                        attr.put_child(param.first, param.second);
                         continue;
                     }
-
-                    auto param_source_name = param_source->get_value<std::string>();
+                
+                    decltype(auto) param_source = param.second.get_child("source");
+                    decltype(auto) param_source_name = param_source.get_value<std::string>();
                     if (param_source_name != "hydrofabric") {
                         // temporary until the logic for alternative sources is designed
                         throw std::logic_error("ERROR: 'model_params' source `" + param_source_name + "` not currently supported. Only `hydrofabric` is supported.");
                     }
 
-                    auto param_name = param.second.get_child_optional("from")
+                    decltype(auto) param_name = param.second.get_child_optional("from")
                         ? param.second.get_child("from").get_value<std::string>()
                         : param.first;
-
-                    model_params.erase(param.first);
 
                     if (catchment_feature->has_property(param_name)) {
                         auto catchment_attribute = catchment_feature->get_property(param_name);
                         switch (catchment_attribute.get_type()) {
                             case geojson::PropertyType::Natural:
-                                model_params.put(param_name, catchment_attribute.as_natural_number());
+                                attr.put(param_name, catchment_attribute.as_natural_number());
                                 break;
                             case geojson::PropertyType::Boolean:
-                                model_params.put(param_name, catchment_attribute.as_boolean());
+                                attr.put(param_name, catchment_attribute.as_boolean());
                                 break;
                             case geojson::PropertyType::Real:
-                                model_params.put(param_name, catchment_attribute.as_real_number());
+                                attr.put(param_name, catchment_attribute.as_real_number());
                                 break;
                             case geojson::PropertyType::String:
-                                model_params.put(param_name, catchment_attribute.as_string());
+                                attr.put(param_name, catchment_attribute.as_string());
                                 break;
 
                             case geojson::PropertyType::List:
                             case geojson::PropertyType::Object:
                             default:
                                 std::cerr << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
-                                          << "Must be one of: Natural (int), Real (double), Boolean, or String" << std::endl;
+                                          << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
                                 break;
                         }
                     }
                 }
+
+                model_params.swap(attr);
             }
 
             boost::property_tree::ptree tree;

--- a/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt
+++ b/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt
@@ -1,0 +1,2 @@
+epoch_start_time=1448949600
+num_time_steps=720

--- a/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt
+++ b/test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt
@@ -1,2 +1,3 @@
 epoch_start_time=1448949600
 num_time_steps=720
+use_model_params

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -527,7 +527,13 @@ const std::string test_bmi_cpp_cfg = utils::FileChecker::find_first_readable({
   "./test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt"
 });
 
-const std::string EXAMPLE_5 =
+/**
+ * Configuration for model_params parsing at levels:
+ * - global single-bmi
+ * - catchment-specific single-bmi
+ * - catchment-specific multi-bmi
+ */
+const std::string EXAMPLE_5_a =
 "{"
 "    \"global\": {"
 "        \"formulations\": ["
@@ -642,6 +648,65 @@ const std::string EXAMPLE_5 =
 "                \"path\": \"./data/forcing/cat-27115-nwm-aorc-variant-derived-format.csv\""
 "            }"
 "        }"
+"    }"
+"}";
+
+/**
+ * Configuration for model_params parsing at level:
+ * - global multi-bmi
+ */
+const std::string EXAMPLE_5_b =
+"{"
+"    \"global\": {"
+"         \"formulations\": ["
+"             {"
+"                 \"name\": \"bmi_multi\","
+"                 \"params\": {"
+"                     \"model_type_name\": \"bmi_multi_c++\","
+"                     \"forcing_file\": \"\","
+"                     \"init_config\": \"\","
+"                     \"allow_exceed_end_time\": true,"
+"                     \"main_output_variable\": \"OUTPUT_VAR_4\","
+"                     \"uses_forcing_file\": false,"
+"                     \"modules\": ["
+"                         {"
+"                             \"name\": \"bmi_c++\","
+"                             \"params\": {"
+"                                 \"model_type_name\": \"test_bmi_c++\","
+"                                 \"library_file\": \"" + test_bmi_cpp_lib + "\","
+"                                 \"init_config\": \"" + test_bmi_cpp_cfg + "\","
+"                                 \"allow_exceed_end_time\": true,"
+"                                 \"main_output_variable\": \"OUTPUT_VAR_4\","
+"                                 \"uses_forcing_file\": false,"
+"                                 \"model_params\": {"
+"                                     \"MODEL_VAR_1\": {"
+"                                         \"source\": \"hydrofabric\","
+"                                         \"from\": \"val\""
+"                                     },"
+"                                     \"MODEL_VAR_2\": {"
+"                                         \"source\": \"hydrofabric\""
+"                                     }"
+"                                 },"
+"                                 \"" BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "\": {"
+"                                     \"INPUT_VAR_1\": \"APCP_surface\","
+"                                     \"INPUT_VAR_2\": \"APCP_surface\""
+"                                 }"
+"                             }"
+"                         }"
+"                     ]"
+"                 }"
+"             }"
+"         ],"
+"        \"forcing\": { "
+"            \"file_pattern\": \".*{{id}}.*.csv\","
+"            \"path\": \"./data/forcing/\","
+"            \"provider\": \"CsvPerFeature\""
+"        }"
+"    },"
+"    \"time\": {"
+"        \"start_time\": \"2015-12-01 00:00:00\","
+"        \"end_time\": \"2015-12-30 23:00:00\","
+"        \"output_interval\": 3600"
 "    }"
 "}";
 
@@ -840,13 +905,26 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
     if (test_bmi_cpp_lib == "")
       GTEST_SKIP() << "Skipping external attributes test, can't find libtestbmicppmodel.so";
 
-    std::stringstream stream;
-    stream << fix_paths(EXAMPLE_5);
+    std::stringstream stream_a;
+    stream_a << fix_paths(EXAMPLE_5_a);
+
+    std::stringstream stream_b;
+    stream_b << fix_paths(EXAMPLE_5_b);
 
     std::ostream* ptr = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(ptr, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
+    time_step_t ts = 2;
+    std::array<double, 5> values;
+    std::vector<std::string> str_values;
+
+    /**
+     * Lambda to add a feature to the fabric, and then assert that its properties exists.
+     *
+     * Assertions:
+     * - Asserts that the feature with `id` correctly has all properties in `properties`.
+     */
     auto add_and_check_feature = [&, this](const std::string& id, geojson::PropertyMap properties) {
       this->add_feature(id, properties);
       auto feature = this->fabric->get_feature(id);
@@ -854,36 +932,21 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
         ASSERT_TRUE(feature->has_property(pair.first));
     };
 
-    auto manager = realization::Formulation_Manager(stream);
-  
-    add_and_check_feature("cat-67", geojson::PropertyMap{
-      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 10 } },
-      { "n",           geojson::JSONProperty{"n",           1.70352 } },
-    });
-
-    add_and_check_feature("cat-52", geojson::PropertyMap{
-      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 15 } },
-      { "pi",           geojson::JSONProperty{"pi",         3.14159 } },
-    });
-
-    add_and_check_feature("cat-27115", geojson::PropertyMap{
-      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 20 } },
-      { "e",           geojson::JSONProperty{"e",           2.71828 } },
-    });
-
-    manager.read(this->fabric, catchment_output);
-
-    ASSERT_EQ(manager.get_size(), 3);
-    ASSERT_TRUE(manager.contains("cat-67"));
-    ASSERT_TRUE(manager.contains("cat-52"));
-    ASSERT_TRUE(manager.contains("cat-27115"));
-
-    time_step_t ts = 2;
-    std::array<double, 5> values;
-    std::vector<std::string> str_values;
-
-    auto check_formulation_values = [&](const std::string& id, std::initializer_list<double> expected) {
-        auto formulation = manager.get_formulation(id);
+    /**
+     * Lambda to check that formulation values are present in output.
+     * 
+     * Assertions:
+     * - Asserts that the formulation manager contains the given catchment ID.
+     * - Asserts that the expected values are contained within the output line at
+     *   timestep `ts`.
+     *
+     * @note The output line is checked by splitting it along its delimiter,
+     *       and parsing the resulting strings to doubles. Then, `std::find`
+     *       is used to check for the existence of the expected doubles.
+     */
+    auto check_formulation_values = [&](auto fm, const std::string& id, std::initializer_list<double> expected) {
+        ASSERT_TRUE(fm.contains(id));
+        auto formulation = fm.get_formulation(id);
         formulation->get_response(ts, 3600);
         boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(ts), [](auto c) -> bool { return c == ','; });
         auto values_it = values.begin();
@@ -898,7 +961,42 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
         }
     };
 
-    check_formulation_values("cat-67",    { 1.70352, 10.0 });
-    check_formulation_values("cat-52",    { 3.14159, 15.0 });
-    check_formulation_values("cat-27115", { 2.71828, 20.0 });
+    auto manager = realization::Formulation_Manager(stream_a);
+  
+    add_and_check_feature("cat-67", geojson::PropertyMap{
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 10 } },
+      { "n",           geojson::JSONProperty{"n",           1.70352 } }
+    });
+
+    add_and_check_feature("cat-52", geojson::PropertyMap{
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 15 } },
+      { "pi",           geojson::JSONProperty{"pi",         3.14159 } }
+    });
+
+    add_and_check_feature("cat-27115", geojson::PropertyMap{
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 20 } },
+      { "e",           geojson::JSONProperty{"e",           2.71828 } }
+    });
+
+    manager.read(this->fabric, catchment_output);
+
+    ASSERT_EQ(manager.get_size(), 3);
+    check_formulation_values(manager, "cat-67",    { 1.70352, 10.0 });
+    check_formulation_values(manager, "cat-52",    { 3.14159, 15.0 });
+    check_formulation_values(manager, "cat-27115", { 2.71828, 20.0 });
+
+    this->fabric->remove_feature_by_id("cat-67");
+    this->fabric->remove_feature_by_id("cat-52");
+    this->fabric->remove_feature_by_id("cat-27115");
+
+    manager = realization::Formulation_Manager(stream_b);
+    
+    add_and_check_feature("cat-67", geojson::PropertyMap{
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 9231 } },
+      { "val",           geojson::JSONProperty{"val",       7.41722 } }
+    });
+
+    manager.read(this->fabric, catchment_output);
+
+    check_formulation_values(manager, "cat-67", { 7.41722, 9231 });
 }

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <AorcForcing.hpp>
 #include <Bmi_Formulation.hpp>
@@ -794,6 +795,37 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
 
 
     ASSERT_NEAR(result, 1.70352, 1e-5);
-    ASSERT_EQ(formulation->get_output_header_line(","), "Cgw,Klf,Kn,n,static_var");
-    ASSERT_EQ(formulation->get_output_line_for_timestep(0), "0.010000,1.703520,0.030000,2.000000,0.000000");
+    
+    std::vector<std::string> columns;
+    columns.reserve(5);
+    boost::algorithm::split(columns, formulation->get_output_header_line(","), [](auto c) -> bool { return c == ','; });
+    
+    std::vector<std::string> str_values;
+    str_values.reserve(5);
+    boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(0), [](auto c) -> bool { return c == ','; });
+    
+    std::array<double, 5> values;
+    auto values_it = values.begin();
+    for (auto& str : str_values) {
+      auto end = &str[0] + str.size();
+      *values_it = strtod(str.c_str(), &end);
+      values_it++;
+    }
+
+#define ASSERT_CONTAINS(container, value) \
+  ASSERT_NE(std::find(container.begin(), container.end(), value), container.end())
+
+    ASSERT_CONTAINS(columns, "Cgw");
+    ASSERT_CONTAINS(columns, "Klf");
+    ASSERT_CONTAINS(columns, "Kn");
+    ASSERT_CONTAINS(columns, "n");
+    ASSERT_CONTAINS(columns, "static_var");
+
+    ASSERT_CONTAINS(values, 0.01);
+    ASSERT_CONTAINS(values, 1.70352);
+    ASSERT_CONTAINS(values, 0.03);
+    ASSERT_CONTAINS(values, 2.0);
+    ASSERT_CONTAINS(values, 0.0);
+  
+#undef ASSERT_CONTAINS
 }

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -512,8 +512,56 @@ const std::string EXAMPLE_4 = "{ "
     "} "
 "}";
 
+const std::string test_bmi_cpp_lib = utils::FileChecker::find_first_readable({
+  "../../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+  "../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+  "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+  "../../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+  "../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+  "./extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+});
+
+const std::string test_bmi_cpp_cfg = utils::FileChecker::find_first_readable({
+  "../../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
+  "../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
+  "./test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt"
+});
+
 const std::string EXAMPLE_5 =
 "{"
+"    \"global\": {"
+"        \"formulations\": ["
+"            {"
+"                \"name\": \"bmi_c++\","
+"                \"params\": {"
+"                    \"model_type_name\": \"test_bmi_c++\","
+"                    \"library_file\": \"" + test_bmi_cpp_lib + "\","
+"                    \"init_config\": \"" + test_bmi_cpp_cfg + "\","
+"                    \"allow_exceed_end_time\": true,"
+"                    \"main_output_variable\": \"OUTPUT_VAR_4\","
+"                    \"uses_forcing_file\": false,"
+"                    \"model_params\": {"
+"                        \"MODEL_VAR_1\": {"
+"                            \"source\": \"hydrofabric\","
+"                            \"from\": \"pi\""
+"                        },"
+"                        \"MODEL_VAR_2\": {"
+"                            \"source\": \"hydrofabric\""
+"                        }"
+"                    },"
+"                    \"" BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "\": {"
+"                        \"INPUT_VAR_1\": \"APCP_surface\","
+"                        \"INPUT_VAR_2\": \"APCP_surface\""
+"                    }"
+"                }"
+"            }"
+"        ],"
+"        \"forcing\": { "
+"            \"file_pattern\": \".*{{id}}.*.csv\","
+"            \"path\": \"./data/forcing/\","
+"            \"provider\": \"CsvPerFeature\""
+"        }"
+"    },"
 "    \"time\": {"
 "        \"start_time\": \"2015-12-01 00:00:00\","
 "        \"end_time\": \"2015-12-30 23:00:00\","
@@ -526,23 +574,8 @@ const std::string EXAMPLE_5 =
 "                    \"name\": \"bmi_c++\","
 "                    \"params\": {"
 "                        \"model_type_name\": \"test_bmi_c++\","
-"                        \"library_file\": \"" +
-utils::FileChecker::find_first_readable({
-  "../../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
-  "../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
-  "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
-  "../../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
-  "../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
-  "./extern/test_bmi_cpp/build/libtestbmicppmodel.so",
-}) +
-"\","
-"                        \"init_config\": \"" +
-utils::FileChecker::find_first_readable({
-  "../../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
-  "../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
-  "./test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt"
-}) +
-"\","
+"                        \"library_file\": \"" + test_bmi_cpp_lib + "\","
+"                        \"init_config\": \"" + test_bmi_cpp_cfg + "\","
 "                        \"allow_exceed_end_time\": true,"
 "                        \"main_output_variable\": \"OUTPUT_VAR_4\","
 "                        \"uses_forcing_file\": false,"
@@ -761,6 +794,16 @@ TEST_F(Formulation_Manager_Test, forcing_provider_specification) {
 }
 
 TEST_F(Formulation_Manager_Test, read_external_attributes) {
+    if (utils::FileChecker::find_first_readable({
+      "../../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+      "../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+      "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+      "../../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+      "../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+      "./extern/test_bmi_cpp/build/libtestbmicppmodel.so"
+    }) == "") {
+      GTEST_SKIP() << "Skipping external attributes test, can't find libtestbmicppmodel.so";
+    }
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_5);
 
@@ -774,37 +817,45 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
       { "n",           geojson::JSONProperty{"n",           1.70352 } },
     });
 
+    this->add_feature("cat-52", geojson::PropertyMap{
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 15 } },
+      { "pi",           geojson::JSONProperty{"pi",         3.14159 } },
+    });
+
     auto feature = this->fabric->get_feature("cat-67");
     ASSERT_TRUE(feature->has_property("MODEL_VAR_2"));
     ASSERT_TRUE(feature->has_property("n"));
 
+    feature = this->fabric->get_feature("cat-52");
+    ASSERT_TRUE(feature->has_property("MODEL_VAR_2"));
+    ASSERT_TRUE(feature->has_property("pi"));
+
     manager.read(this->fabric, catchment_output);
 
-    ASSERT_EQ(manager.get_size(), 1);
+    ASSERT_EQ(manager.get_size(), 2);
     ASSERT_TRUE(manager.contains("cat-67"));
-  
-    auto formulation = manager.get_formulation("cat-67");
+    ASSERT_TRUE(manager.contains("cat-52"));
+
     time_step_t ts = 2;
-    formulation->get_response(ts, 3600);
-    
-    // std::cerr << formulation->get_output_header_line(",") << '\n';
-    
-    std::vector<std::string> str_values;
-    str_values.reserve(4);
-    boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(ts), [](auto c) -> bool { return c == ','; });
-    // std::cerr << formulation->get_output_line_for_timestep(ts) << '\n';
-
     std::array<double, 5> values;
-    auto values_it = values.begin();
-    for (auto& str : str_values) {
-      auto end = &str[0] + str.size();
-      *values_it = strtod(str.c_str(), &end);
-      values_it++;
-    }
+    std::array<std::string, 4> str_values;
 
-#define ASSERT_CONTAINS(container, value) \
-  ASSERT_NE(std::find(container.begin(), container.end(), value), container.end())
-    ASSERT_CONTAINS(values, 1.70352);
-    ASSERT_CONTAINS(values, 10.0);
-#undef ASSERT_CONTAINS
+    auto check_formulation_values = [&](const std::string& id, std::initializer_list<double> expected) {
+        auto formulation = manager.get_formulation(id);
+        formulation->get_response(ts, 3600);
+        boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(ts), [](auto c) -> bool { return c == ','; });
+        auto values_it = values.begin();
+        for (auto& str : str_values) {
+          auto end = &str[0] + str.size();
+          *values_it = strtod(str.c_str(), &end);
+          values_it++;
+        }
+
+        for (auto& expect : expected) {
+            ASSERT_NE(std::find(values.begin(), values.end(), expect), values.end());
+        }
+    };
+
+    check_formulation_values("cat-67", { 1.70352, 10.0 });
+    check_formulation_values("cat-52", { 3.14159, 15.0 });
 }

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -110,6 +110,23 @@ class Formulation_Manager_Test : public ::testing::Test {
 
     };
 
+    void replace_paths(std::string& input, const std::string& pattern, const std::string& replacement)
+    {
+        std::vector<std::string> v{path_options.size()};
+        for(unsigned int i = 0; i < path_options.size(); i++)
+            v[i] = path_options[i] + replacement;
+        
+        const std::string dir = utils::FileChecker::find_first_readable(v);
+        if (dir == "") {
+            // std::cerr << "Can't find any of:\n";
+            // for (const auto& s : v)
+            //   std::cerr << "  - " << s << '\n';
+            return;
+        }
+
+        boost::replace_all(input, pattern, dir);
+    }
+
     std::string fix_paths(std::string json)
     {
         std::vector<std::string> forcing_paths = {
@@ -129,30 +146,14 @@ class Formulation_Manager_Test : public ::testing::Test {
                 //std::cerr<<"TRYING TO REPLACE DIRECTORY... "<<remove<<" -> "<<replace<<std::endl;
                 boost::replace_all(json, remove , replace);
         }
+      
         //BMI_C_INIT_DIR_PATH
-        v = {};
-        for(unsigned int i = 0; i < path_options.size(); i++){
-            v.push_back( path_options[i] + "data/bmi/test_bmi_c" );
-        }
-        dir = utils::FileChecker::find_first_readable(v);
-        if(dir != ""){
-                std::string remove = "{{BMI_C_INIT_DIR_PATH}}";
-                std::string replace = dir;
-                //std::cerr<<"TRYING TO REPLACE DIRECTORY... "<<remove<<" -> "<<replace<<std::endl;
-                boost::replace_all(json, remove , replace);
-        }
+        replace_paths(json, "{{BMI_C_INIT_DIR_PATH}}", "data/bmi/test_bmi_c");
+        //BMI_CPP_INIT_DIR_PATH
+        replace_paths(json, "{{BMI_CPP_INIT_DIR_PATH}}", "data/bmi/test_bmi_cpp");
         //EXTERN_DIR_PATH
-        v = {};
-        for(unsigned int i = 0; i < path_options.size(); i++){
-            v.push_back( path_options[i] + "extern" );
-        }
-        dir = utils::FileChecker::find_first_readable(v);
-        if(dir != ""){
-                std::string remove = "{{EXTERN_DIR_PATH}}";
-                std::string replace = dir;
-                //std::cerr<<"TRYING TO REPLACE DIRECTORY... "<<remove<<" -> "<<replace<<std::endl;
-                boost::replace_all(json, remove , replace);
-        }
+        replace_paths(json, "{{EXTERN_DIR_PATH}}", "extern");
+        
         for (unsigned int i = 0; i < forcing_paths.size(); i++) {
           if(json.find(forcing_paths[i]) == std::string::npos){
             continue;
@@ -512,21 +513,6 @@ const std::string EXAMPLE_4 = "{ "
     "} "
 "}";
 
-const std::string test_bmi_cpp_lib = utils::FileChecker::find_first_readable({
-  "../../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
-  "../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
-  "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
-  "../../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
-  "../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
-  "./extern/test_bmi_cpp/build/libtestbmicppmodel.so",
-});
-
-const std::string test_bmi_cpp_cfg = utils::FileChecker::find_first_readable({
-  "../../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
-  "../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
-  "./test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt"
-});
-
 /**
  * Configuration for model_params parsing at levels:
  * - global single-bmi
@@ -541,8 +527,8 @@ const std::string EXAMPLE_5_a =
 "                \"name\": \"bmi_c++\","
 "                \"params\": {"
 "                    \"model_type_name\": \"test_bmi_c++\","
-"                    \"library_file\": \"" + test_bmi_cpp_lib + "\","
-"                    \"init_config\": \"" + test_bmi_cpp_cfg + "\","
+"                    \"library_file\": \"{{EXTERN_DIR_PATH}}/test_bmi_cpp/cmake_build/libtestbmicppmodel.so\","
+"                    \"init_config\": \"{{BMI_CPP_INIT_DIR_PATH}}/test_bmi_cpp_config_2.txt\","
 "                    \"allow_exceed_end_time\": true,"
 "                    \"main_output_variable\": \"OUTPUT_VAR_4\","
 "                    \"uses_forcing_file\": false,"
@@ -580,8 +566,8 @@ const std::string EXAMPLE_5_a =
 "                    \"name\": \"bmi_c++\","
 "                    \"params\": {"
 "                        \"model_type_name\": \"test_bmi_c++\","
-"                        \"library_file\": \"" + test_bmi_cpp_lib + "\","
-"                        \"init_config\": \"" + test_bmi_cpp_cfg + "\","
+"                        \"library_file\": \"{{EXTERN_DIR_PATH}}/test_bmi_cpp/cmake_build/libtestbmicppmodel.so\","
+"                        \"init_config\": \"{{BMI_CPP_INIT_DIR_PATH}}/test_bmi_cpp_config_2.txt\","
 "                        \"allow_exceed_end_time\": true,"
 "                        \"main_output_variable\": \"OUTPUT_VAR_4\","
 "                        \"uses_forcing_file\": false,"
@@ -620,8 +606,8 @@ const std::string EXAMPLE_5_a =
 "                                \"name\": \"bmi_c++\","
 "                                \"params\": {"
 "                                    \"model_type_name\": \"test_bmi_c++\","
-"                                    \"library_file\": \"" + test_bmi_cpp_lib + "\","
-"                                    \"init_config\": \"" + test_bmi_cpp_cfg + "\","
+"                                    \"library_file\": \"{{EXTERN_DIR_PATH}}/test_bmi_cpp/cmake_build/libtestbmicppmodel.so\","
+"                                    \"init_config\": \"{{BMI_CPP_INIT_DIR_PATH}}/test_bmi_cpp_config_2.txt\","
 "                                    \"allow_exceed_end_time\": true,"
 "                                    \"main_output_variable\": \"OUTPUT_VAR_4\","
 "                                    \"uses_forcing_file\": false,"
@@ -673,8 +659,8 @@ const std::string EXAMPLE_5_b =
 "                             \"name\": \"bmi_c++\","
 "                             \"params\": {"
 "                                 \"model_type_name\": \"test_bmi_c++\","
-"                                 \"library_file\": \"" + test_bmi_cpp_lib + "\","
-"                                 \"init_config\": \"" + test_bmi_cpp_cfg + "\","
+"                                  \"library_file\": \"{{EXTERN_DIR_PATH}}/test_bmi_cpp/cmake_build/libtestbmicppmodel.so\","
+"                                  \"init_config\": \"{{BMI_CPP_INIT_DIR_PATH}}/test_bmi_cpp_config_2.txt\","
 "                                 \"allow_exceed_end_time\": true,"
 "                                 \"main_output_variable\": \"OUTPUT_VAR_4\","
 "                                 \"uses_forcing_file\": false,"

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -902,9 +902,6 @@ TEST_F(Formulation_Manager_Test, forcing_provider_specification) {
 }
 
 TEST_F(Formulation_Manager_Test, read_external_attributes) {
-    if (test_bmi_cpp_lib == "")
-      GTEST_SKIP() << "Skipping external attributes test, can't find libtestbmicppmodel.so";
-
     std::stringstream stream_a;
     stream_a << fix_paths(EXAMPLE_5_a);
 

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -1,3 +1,5 @@
+#include "FileChecker.h"
+#include "StreamHandler.hpp"
 #include "gtest/gtest.h"
 #include <Formulation_Manager.hpp>
 #include <Catchment_Formulation.hpp>
@@ -65,6 +67,30 @@ class Formulation_Manager_Test : public ::testing::Test {
         id,
         properties
         //bounding_box
+      ));
+
+      fabric->add_feature(feature);
+    }
+
+    void add_feature(const std::string& id, geojson::PropertyMap properties)
+    {
+      geojson::three_dimensional_coordinates three_dimensions {
+          {
+              {1.0, 2.0},
+              {3.0, 4.0},
+              {5.0, 6.0}
+          },
+          {
+              {7.0, 8.0},
+              {9.0, 10.0},
+              {11.0, 12.0}
+          }
+      };
+
+      geojson::Feature feature = std::make_shared<geojson::PolygonFeature>(geojson::PolygonFeature(
+        geojson::polygon(three_dimensions),
+        id,
+        properties
       ));
 
       fabric->add_feature(feature);
@@ -482,6 +508,60 @@ const std::string EXAMPLE_4 = "{ "
     "} "
 "}";
 
+const std::string EXAMPLE_5 =
+"{"
+"    \"time\": {"
+"        \"start_time\": \"2015-12-01 00:00:00\","
+"        \"end_time\": \"2015-12-30 23:00:00\","
+"        \"output_interval\": 3600"
+"    },"
+"    \"catchments\": {"
+"        \"cat-67\": {"
+"            \"formulations\": ["
+"                {"
+"                    \"name\": \"bmi_c++\","
+"                    \"params\": {"
+"                        \"model_type_name\": \"bmi_c++_sloth\","
+"                        \"library_file\": \"" +
+utils::FileChecker::find_first_readable({
+  "../../extern/sloth/cmake_build/libslothmodel.so",
+  "../extern/sloth/cmake_build/libslothmodel.so",
+  "./extern/sloth/cmake_build/libslothmodel.so",
+  "../../extern/sloth/build/libslothmodel.so",
+  "../extern/sloth/build/libslothmodel.so",
+  "./extern/sloth/build/libslothmodel.so",
+})+
+"\","
+"                        \"init_config\": \"/dev/null\","
+"                        \"allow_exceed_end_time\": true,"
+"                        \"main_output_variable\": \"Klf\","
+"                        \"uses_forcing_file\": false,"
+"                        \"model_params\": {"
+"                            \"Klf\": {"
+"                                \"source\": \"hydrofabric\""
+"                            },"
+"                            \"Kn\": {"
+"                                \"source\": \"hydrofabric\""
+"                            },"
+"                            \"nash_n\": {"
+"                                \"source\": \"hydrofabric\","
+"                                \"from\": \"n\""
+"                            },"
+"                            \"Cgw\": {"
+"                                \"source\": \"hydrofabric\""
+"                            },"
+"                            \"static_var\": 0.0"
+"                        }"
+"                    }"
+"                }"
+"            ],"
+"            \"forcing\": {"
+"                \"path\": \"./data/forcing/cat-67_2015-12-01 00_00_00_2015-12-30 23_00_00.csv\""
+"            }"
+"        }"
+"    }"
+"}";
+
 TEST_F(Formulation_Manager_Test, basic_reading_1) {
     std::stringstream stream;
 
@@ -673,3 +753,47 @@ TEST_F(Formulation_Manager_Test, forcing_provider_specification) {
     }
 }
 
+TEST_F(Formulation_Manager_Test, read_external_attributes) {
+    std::stringstream stream;
+    stream << fix_paths(EXAMPLE_5);
+
+    std::ostream* ptr = &std::cout;
+    std::shared_ptr<std::ostream> s_ptr(ptr, [](void*) {});
+    utils::StreamHandler catchment_output(s_ptr);
+
+    auto manager = realization::Formulation_Manager(stream);
+    this->add_feature("cat-67", geojson::PropertyMap{
+      { "Klf",    geojson::JSONProperty{"Klf",    1.70352 } },
+      { "Kn",     geojson::JSONProperty{"Kn",     0.03    } },
+      { "n",      geojson::JSONProperty{"n",      2       } }, // nash_n
+      { "Cgw",    geojson::JSONProperty{"Cgw",    0.01    } }
+    });
+
+    auto feature = this->fabric->get_feature("cat-67");
+    ASSERT_TRUE(feature->has_property("Klf"));
+    ASSERT_TRUE(feature->has_property("Kn"));
+    ASSERT_TRUE(feature->has_property("n"));
+    ASSERT_TRUE(feature->has_property("Cgw"));
+
+    manager.read(this->fabric, catchment_output);
+
+    ASSERT_EQ(manager.get_size(), 1);
+    ASSERT_TRUE(manager.contains("cat-67"));
+  
+    pdm03_struct pdm_et_data;
+    pdm_et_data.scaled_distribution_fn_shape_parameter = 1.3;
+    pdm_et_data.vegetation_adjustment = 0.99;
+    pdm_et_data.model_time_step = 0.0;
+    pdm_et_data.max_height_soil_moisture_storerage_tank = 400.0;
+    pdm_et_data.maximum_combined_contents = pdm_et_data.max_height_soil_moisture_storerage_tank / (1.0+pdm_et_data.scaled_distribution_fn_shape_parameter);
+    std::shared_ptr<pdm03_struct> et_params_ptr = std::make_shared<pdm03_struct>(pdm_et_data);
+
+    auto formulation = manager.get_formulation("cat-67");
+    formulation->set_et_params(et_params_ptr);
+    double result = formulation->get_response(0, 3600);
+
+
+    ASSERT_NEAR(result, 1.70352, 1e-5);
+    ASSERT_EQ(formulation->get_output_header_line(","), "Cgw,Klf,Kn,n,static_var");
+    ASSERT_EQ(formulation->get_output_line_for_timestep(0), "0.010000,1.703520,0.030000,2.000000,0.000000");
+}

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -1,3 +1,6 @@
+#include "Bmi_Cpp_Formulation.hpp"
+#include "DataProvider.hpp"
+#include "DataProviderSelectors.hpp"
 #include "FileChecker.h"
 #include "StreamHandler.hpp"
 #include "gtest/gtest.h"
@@ -522,36 +525,39 @@ const std::string EXAMPLE_5 =
 "                {"
 "                    \"name\": \"bmi_c++\","
 "                    \"params\": {"
-"                        \"model_type_name\": \"bmi_c++_sloth\","
+"                        \"model_type_name\": \"test_bmi_c++\","
 "                        \"library_file\": \"" +
 utils::FileChecker::find_first_readable({
-  "../../extern/sloth/cmake_build/libslothmodel.so",
-  "../extern/sloth/cmake_build/libslothmodel.so",
-  "./extern/sloth/cmake_build/libslothmodel.so",
-  "../../extern/sloth/build/libslothmodel.so",
-  "../extern/sloth/build/libslothmodel.so",
-  "./extern/sloth/build/libslothmodel.so",
-})+
+  "../../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+  "../extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+  "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+  "../../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+  "../extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+  "./extern/test_bmi_cpp/build/libtestbmicppmodel.so",
+}) +
 "\","
-"                        \"init_config\": \"/dev/null\","
+"                        \"init_config\": \"" +
+utils::FileChecker::find_first_readable({
+  "../../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
+  "../test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt",
+  "./test/data/bmi/test_bmi_cpp/test_bmi_cpp_config_2.txt"
+}) +
+"\","
 "                        \"allow_exceed_end_time\": true,"
-"                        \"main_output_variable\": \"Klf\","
+"                        \"main_output_variable\": \"OUTPUT_VAR_4\","
 "                        \"uses_forcing_file\": false,"
 "                        \"model_params\": {"
-"                            \"Klf\": {"
-"                                \"source\": \"hydrofabric\""
-"                            },"
-"                            \"Kn\": {"
-"                                \"source\": \"hydrofabric\""
-"                            },"
-"                            \"nash_n\": {"
+"                            \"MODEL_VAR_1\": {"
 "                                \"source\": \"hydrofabric\","
 "                                \"from\": \"n\""
 "                            },"
-"                            \"Cgw\": {"
+"                            \"MODEL_VAR_2\": {"
 "                                \"source\": \"hydrofabric\""
-"                            },"
-"                            \"static_var\": 0.0"
+"                            }"
+"                        },"
+"                        \"" BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "\": {"
+"                            \"INPUT_VAR_1\": \"APCP_surface\","
+"                            \"INPUT_VAR_2\": \"APCP_surface\""
 "                        }"
 "                    }"
 "                }"
@@ -764,46 +770,30 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
 
     auto manager = realization::Formulation_Manager(stream);
     this->add_feature("cat-67", geojson::PropertyMap{
-      { "Klf",    geojson::JSONProperty{"Klf",    1.70352 } },
-      { "Kn",     geojson::JSONProperty{"Kn",     0.03    } },
-      { "n",      geojson::JSONProperty{"n",      2       } }, // nash_n
-      { "Cgw",    geojson::JSONProperty{"Cgw",    0.01    } }
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 10 } },
+      { "n",           geojson::JSONProperty{"n",           1.70352 } },
     });
 
     auto feature = this->fabric->get_feature("cat-67");
-    ASSERT_TRUE(feature->has_property("Klf"));
-    ASSERT_TRUE(feature->has_property("Kn"));
+    ASSERT_TRUE(feature->has_property("MODEL_VAR_2"));
     ASSERT_TRUE(feature->has_property("n"));
-    ASSERT_TRUE(feature->has_property("Cgw"));
 
     manager.read(this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 1);
     ASSERT_TRUE(manager.contains("cat-67"));
   
-    pdm03_struct pdm_et_data;
-    pdm_et_data.scaled_distribution_fn_shape_parameter = 1.3;
-    pdm_et_data.vegetation_adjustment = 0.99;
-    pdm_et_data.model_time_step = 0.0;
-    pdm_et_data.max_height_soil_moisture_storerage_tank = 400.0;
-    pdm_et_data.maximum_combined_contents = pdm_et_data.max_height_soil_moisture_storerage_tank / (1.0+pdm_et_data.scaled_distribution_fn_shape_parameter);
-    std::shared_ptr<pdm03_struct> et_params_ptr = std::make_shared<pdm03_struct>(pdm_et_data);
-
     auto formulation = manager.get_formulation("cat-67");
-    formulation->set_et_params(et_params_ptr);
-    double result = formulation->get_response(0, 3600);
-
-
-    ASSERT_NEAR(result, 1.70352, 1e-5);
+    time_step_t ts = 2;
+    formulation->get_response(ts, 3600);
     
-    std::vector<std::string> columns;
-    columns.reserve(5);
-    boost::algorithm::split(columns, formulation->get_output_header_line(","), [](auto c) -> bool { return c == ','; });
+    // std::cerr << formulation->get_output_header_line(",") << '\n';
     
     std::vector<std::string> str_values;
-    str_values.reserve(5);
-    boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(0), [](auto c) -> bool { return c == ','; });
-    
+    str_values.reserve(4);
+    boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(ts), [](auto c) -> bool { return c == ','; });
+    // std::cerr << formulation->get_output_line_for_timestep(ts) << '\n';
+
     std::array<double, 5> values;
     auto values_it = values.begin();
     for (auto& str : str_values) {
@@ -814,18 +804,7 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
 
 #define ASSERT_CONTAINS(container, value) \
   ASSERT_NE(std::find(container.begin(), container.end(), value), container.end())
-
-    ASSERT_CONTAINS(columns, "Cgw");
-    ASSERT_CONTAINS(columns, "Klf");
-    ASSERT_CONTAINS(columns, "Kn");
-    ASSERT_CONTAINS(columns, "n");
-    ASSERT_CONTAINS(columns, "static_var");
-
-    ASSERT_CONTAINS(values, 0.01);
     ASSERT_CONTAINS(values, 1.70352);
-    ASSERT_CONTAINS(values, 0.03);
-    ASSERT_CONTAINS(values, 2.0);
-    ASSERT_CONTAINS(values, 0.0);
-  
+    ASSERT_CONTAINS(values, 10.0);
 #undef ASSERT_CONTAINS
 }


### PR DESCRIPTION
This PR resolves #554 by providing a new value specification for formulation model parameters (`model_params`).

An *external model parameter* is described as:
```
<parameter name>: { "source": <source> [, "from": <mapping>] }
```
Where the following represent:
- `<parameter name>`: the name the BMI model will use
- `<source>`: This PR only supports a source of `"hydrofabric"`, but this scaffolds out the possibly of supplying a path to a separate file that can be joined on demand.
- `<mapping>`: A mapping name that signifies what the property is named as within `<source>`

An example of what this could look like is as follows:
```json
{
  "model_params": {
    "area_sqkm": {
      "source": "hydrofabric",
      "from": "area"
    },
    "some_static_param": 3.0,
    "length_km": {
      "source": "hydrofabric"
    }
  }
}
```

In this example, `area` and `length_km` are defined within the hydrofabric feature, and are passed to the BMI model as `area_sqkm` and `length_km`, respectively.

> **Note**: notice that `length_km` does not specify a `"from"` key, so we assume it is named the same within the hydrofabric feature's properties. If it **does not** exist within the feature properties, it is ignored, and removed from `model_params`.

## Additions

- Adds a member function `parse_external_model_params` to `realization::Formulation_Manager` that performs the parsing/modification of `model_params`.
- Adds a small section of logic to `Formulation_Manager::read` that checks for a `model_params` key when iterating the catchment-specific formulations.
- Adds an additional set of unit tests to the formulation manager tests that verifies this PR's functionality.

## Testing

All unit tests pass locally in `Release` with GCC 13.1.1, Clang 15.0.7, and IntelLLVM 2023.

## Todos

- [X] Parse and modify `model_params` for global formulations.
- [X] Add tests for global formulation `model_params`.
- [X] Parse and modify `model_params` for catchment-specific multi-BMI formulations.
- [X] Add tests for catchment-specific multi-BMI `model_params`.
- [x] Parse and modify `model_params` for global multi-BMI formulations.
- [x] Add tests for global multi-BMI `model_params`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
