### PR TITLE
Correct typo in function name avaliable -> available

### DIFF
--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -222,7 +222,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         return is_param_sum_over_time_step(name);
     }
 
-    const std::vector<std::string> &get_avaliable_variable_names() override {
+    const std::vector<std::string> &get_available_variable_names() override {
         return available_forcings;
     }
 

--- a/include/forcing/DataProvider.hpp
+++ b/include/forcing/DataProvider.hpp
@@ -32,7 +32,7 @@ namespace data_access
 
         /** Return the variables that are accessable by this data provider */
 
-        virtual const std::vector<std::string>& get_avaliable_variable_names() = 0;
+        virtual const std::vector<std::string>& get_available_variable_names() = 0;
 
         /** Return the first valid time for which data from the request variable  can be requested */
 

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -72,7 +72,7 @@ namespace data_access {
          * @return The names of the outputs for which this instance is (or will be) able to provide values.
          */
 
-        const std::vector<std::string> &get_avaliable_variable_names() {
+        const std::vector<std::string> &get_available_variable_names() {
             return providedOutputs;
         }
 
@@ -139,7 +139,7 @@ namespace data_access {
             }
 
             // Confirm this will provide everything needed
-            const vector<string> &available = provider->get_avaliable_variable_names();
+            const vector<string> &available = provider->get_available_variable_names();
             for (const string &requiredName : providedOutputs) {
                 if (std::find(available.begin(), available.end(), requiredName) == available.end()) {
                     setMessage = "Given provider does not provide the required " + requiredName;

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -316,7 +316,7 @@ namespace data_access
 
         /** Return the variables that are accessable by this data provider */
 
-        const std::vector<std::string>& get_avaliable_variable_names() override
+        const std::vector<std::string>& get_available_variable_names() override
         {
             return variable_names;
         }

--- a/include/forcing/OptionalWrappedDataProvider.hpp
+++ b/include/forcing/OptionalWrappedDataProvider.hpp
@@ -399,7 +399,7 @@ namespace data_access {
         map<string, int> defaultUsageWaits;
 
         static bool isSuppliedByProvider(const string &outputName, GenericDataProvider *provider) {
-            const vector<string> &available = provider->get_avaliable_variable_names();
+            const vector<string> &available = provider->get_available_variable_names();
             return find(available.begin(), available.end(), outputName) != available.end();
         }
 

--- a/include/forcing/WrappedDataProvider.hpp
+++ b/include/forcing/WrappedDataProvider.hpp
@@ -46,13 +46,13 @@ namespace data_access {
         }
 
         /**
-         * @brief Get the avaliable variable names object
+         * @brief Get the available variable names object
          * 
-         * @return const std::vector<std::string>& the names of avaliable data variables
+         * @return const std::vector<std::string>& the names of available data variables
          */
 
-        const std::vector<std::string> &get_avaliable_variable_names() override {
-            return wrapped_provider->get_avaliable_variable_names();
+        const std::vector<std::string> &get_available_variable_names() override {
+            return wrapped_provider->get_available_variable_names();
         }
 
         /**

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -244,7 +244,7 @@ namespace realization {
          * @see ForcingProvider
          */
         //const vector<std::string> &get_available_forcing_outputs() {
-        const vector<std::string> &get_avaliable_variable_names() override {
+        const vector<std::string> &get_available_variable_names() override {
             if (is_model_initialized() && available_forcings.empty()) {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);
@@ -257,7 +257,7 @@ namespace realization {
             return available_forcings;
         }
 
-        //inline const vector<std::string> &get_avaliable_variable_names() override {
+        //inline const vector<std::string> &get_available_variable_names() override {
         //    return get_available_forcing_outputs();
         //}
 
@@ -395,7 +395,7 @@ namespace realization {
 
             // First make sure this is an available output
             //const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
-            const std::vector<std::string> forcing_outputs = get_avaliable_variable_names();
+            const std::vector<std::string> forcing_outputs = get_available_variable_names();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
                 throw runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
             }
@@ -464,7 +464,7 @@ namespace realization {
 
             // First make sure this is an available output
             //const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
-            const std::vector<std::string> forcing_outputs = get_avaliable_variable_names();
+            const std::vector<std::string> forcing_outputs = get_available_variable_names();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
                 throw runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
             }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -137,7 +137,7 @@ namespace realization {
             }
             // Otherwise, check the modules directly for the standard ET output variable names.
             for (size_t i = 0; i < modules.size(); ++i) {
-                std::vector<std::string> values = modules[i]->get_avaliable_variable_names();
+                std::vector<std::string> values = modules[i]->get_available_variable_names();
                 if (std::find(values.begin(), values.end(), NGEN_STD_NAME_POTENTIAL_ET_FOR_TIME_STEP) != values.end()) {
                     return i;
                 }
@@ -180,8 +180,8 @@ namespace realization {
          * @see ForcingProvider
          */
         //const vector<std::string> &get_available_forcing_outputs();
-        //const vector<std::string> &get_avaliable_variable_names() override { return get_available_forcing_outputs(); }
-        const vector<std::string> &get_avaliable_variable_names() override;
+        //const vector<std::string> &get_available_variable_names() override { return get_available_forcing_outputs(); }
+        const vector<std::string> &get_available_variable_names() override;
 
         /**
         * Get the input variables of 
@@ -691,10 +691,10 @@ namespace realization {
                                       "provider to satisfy set of deferred provisions for nested module at index "
                                       + std::to_string(deferredProviderModuleIndices[d]) + ": {";
                     // There must always be at least 1; get manually to help with formatting
-                    msg += deferredProvider->get_avaliable_variable_names()[0];
+                    msg += deferredProvider->get_available_variable_names()[0];
                     // And here make sure to start at 1 instead of 0
-                    for (int i = 1; i < deferredProvider->get_avaliable_variable_names().size(); ++i)
-                        msg += ", " + deferredProvider->get_avaliable_variable_names()[i];
+                    for (int i = 1; i < deferredProvider->get_available_variable_names().size(); ++i)
+                        msg += ", " + deferredProvider->get_available_variable_names()[i];
                     msg += "}";
                     throw realization::ConfigurationException(msg);
                 }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -16,7 +16,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     set_model_type_name(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE).as_string());
 
     std::shared_ptr<data_access::WrappedDataProvider> forcing_provider = std::make_shared<data_access::WrappedDataProvider>(forcing.get());
-    for (const std::string &forcing_name_or_alias : forcing->get_avaliable_variable_names()) {
+    for (const std::string &forcing_name_or_alias : forcing->get_available_variable_names()) {
         availableData[forcing_name_or_alias] = forcing_provider;
     }
 
@@ -177,7 +177,7 @@ const bool &Bmi_Multi_Formulation::get_allow_model_exceed_end_time() const {
  * @see ForcingProvider
  */
 //const vector<std::string> &Bmi_Multi_Formulation::get_available_forcing_outputs() {
-const vector<std::string> &Bmi_Multi_Formulation::get_avaliable_variable_names() {
+const vector<std::string> &Bmi_Multi_Formulation::get_available_variable_names() {
     if (is_model_initialized() && available_forcings.empty()) {
         for (const nested_module_ptr &module: modules) {
             for (const std::string &out_var_name: module->get_bmi_output_variables()) {

--- a/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
+++ b/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
@@ -169,7 +169,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataUnitConversion)
 ///Test AORC Forcing Object
 TEST_F(CsvPerFeatureForcingProviderTest, TestGetAvailableForcingOutputs)
 {
-    const std::vector<std::string>& afos = Forcing_Object->get_avaliable_variable_names();
+    const std::vector<std::string>& afos = Forcing_Object->get_available_variable_names();
     EXPECT_EQ(afos.size(), 18);
     EXPECT_TRUE(std::find(afos.begin(), afos.end(), "DLWRF_surface") != afos.end());
     EXPECT_TRUE(std::find(afos.begin(), afos.end(), CSDMS_STD_NAME_SOLAR_LONGWAVE) != afos.end());
@@ -180,7 +180,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestGetAvailableForcingOutputs)
 TEST_F(CsvPerFeatureForcingProviderTest, TestForcingUnitHeaderParsing)
 {
     const time_t t = Forcing_Object_3->get_data_start_time() + (8 * 3600);
-    const auto& varnames = this->Forcing_Object_3->get_avaliable_variable_names();
+    const auto& varnames = this->Forcing_Object_3->get_available_variable_names();
     const std::vector<std::tuple<std::string, std::string, std::string>>& expected = {
         {"RAINRATE", "mm s^-1", "cm min^-1"},
         {"T2D", "K", "degC"},

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -70,7 +70,7 @@ void NetCDFPerFeatureDataProviderTest::setupForcing()
 TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
 {
     // check to see that the variable "T2D" exists
-    auto var_names = nc_provider->get_avaliable_variable_names();
+    auto var_names = nc_provider->get_available_variable_names();
     auto pos = std::find(var_names.begin(), var_names.end(), CSDMS_STD_NAME_SURFACE_TEMP);
     if ( pos != var_names.end() )
     {

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -24,7 +24,7 @@ namespace data_access {
                 outputs.push_back(OUTPUT_NAME_1);
             }
                                   
-            const std::vector<std::string>& get_avaliable_variable_names() override {
+            const std::vector<std::string>& get_available_variable_names() override {
                 return outputs;
             }
 


### PR DESCRIPTION
Functions should not have spelling mistakes in their names

## Changes

- Rename all declarations, definitions, and call sites

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
