### PR TITLE
Remove hunting for Python venv in working directory and parents

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -183,8 +183,11 @@ runs:
         - name: Build Targets
           #cmake >= 3.15 can build multiple targets
           run: |
+            # Build Targets
             # Disable leak detection during test enumeration
             export ASAN_OPTIONS=detect_leaks=false
+            # Activate venv so that test discovery run during build works
+            . .venv/bin/activate
             cmake --build ${{ inputs.build-dir }} --target ${{ inputs.targets }} -- -j  ${{ inputs.build-cores }}
           shell: bash
 

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -289,6 +289,7 @@ jobs:
 
       - name: run_bmi_python_tests
         run: |
+          . .venv/bin/activate
           cd ./cmake_build/test/
           ./test_bmi_python
           cd ../../
@@ -353,7 +354,9 @@ jobs:
           additional_python_requirements: 'extern/test_bmi_py/requirements.txt'
 
       - name: Run Unit Tests
-        run: ./cmake_build/test/test_bmi_multi
+        run: |
+          . .venv/bin/activate
+          ./cmake_build/test/test_bmi_multi
         timeout-minutes: 15
 
       - name: Clean Up Unit Test Build

--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -226,35 +226,6 @@ namespace utils {
         protected:
 
             /**
-             * Search for and return a recognized virtual env directory.
-             *
-             * Both ``.venv`` and ``venv`` will be recognized.  Search locations are the current working directory, one
-             * level up (parent directory), and two levels up, with the first find being return.
-             *
-             * A Python ``None`` object is returned if no existing directory is found in the search locations.
-             *
-             * @return A Python Path object for a found venv dir, or a Python ``None`` object.
-             */
-            py::object searchForVenvDir() {
-                py::object current_dir = Path.attr("cwd")();
-                std::vector<py::object> parent_options = {
-                        current_dir,
-                        current_dir.attr("parent"),
-                        current_dir.attr("parent").attr("parent")
-                };
-                std::vector<std::string> dir_name_options = {".venv", "venv"};
-                for (py::object &parent_option : parent_options) {
-                    for (const std::string &dir_name_option : dir_name_options) {
-                        py::object venv_dir_candidate = parent_option.attr("joinpath")(dir_name_option);
-                        if (py::bool_(venv_dir_candidate.attr("is_dir")())) {
-                            return venv_dir_candidate;
-                        }
-                    }
-                }
-                return py::none();
-            }
-
-            /**
              * Find any virtual environment site packages directory, starting from options under the current directory.
              *
              * @return The absolute path of the site packages directory, as a string.
@@ -262,7 +233,7 @@ namespace utils {
             py::list getVenvPackagesDirOptions() {
                 // Look for a local virtual environment directory also, if there is one
                 const char* env_var_venv = std::getenv("VIRTUAL_ENV");
-                py::object venv_dir = env_var_venv != nullptr ? Path(env_var_venv): searchForVenvDir();
+                py::object venv_dir = env_var_venv != nullptr ? Path(env_var_venv): py::none();
 
                 if (!venv_dir.is_none() && py::bool_(venv_dir.attr("is_dir")())) {
                     // Resolve the full path
@@ -303,18 +274,7 @@ namespace utils {
                     //std::string r(env_var_venv);
                     return std::string(env_var_venv);
                 }
-                py::object venv_dir;
-                venv_dir = searchForVenvDir();
-                if(venv_dir.is_none()){
-                    return std::string("None");
-                }
-                if(py::bool_(venv_dir.attr("is_dir")())) {
-                    // Probably better to not resolve symlinks so you can see where it was found...
-                    //venv_dir = venv_dir.attr("resolve")();
-                    return py::str(venv_dir);
-                }
-                assert("Unexpected value of venv_dir in InterpreterUtil::getDiscoveredVenvPath()!");
-                return ""; // silence warning
+                return std::string("None");
             }
 
         protected:


### PR DESCRIPTION
Fixes #546, #557

## Changes

- Drop code that searched anywhere other than `$VIRTUAL_ENV` for a potential virtual environment to stick in the Python interpreter's system path.

## Testing

Hopefully, CI wasn't relying on this behavior too ...

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
