### PR TITLE
Drown `using namespace std`

### DIFF
--- a/include/forcing/AorcForcing.hpp
+++ b/include/forcing/AorcForcing.hpp
@@ -28,8 +28,6 @@
 
 #include <map>
 
-//using namespace std// causes build error on gcc-12 with boost::geometry
-
 /**
  * @brief forcing_params providing configuration information for forcing time period and source.
  */

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -7,8 +7,6 @@
 #include <algorithm>
 #include "WrappedDataProvider.hpp"
 
-using namespace std;
-
 namespace data_access {
 
     /**
@@ -41,14 +39,14 @@ namespace data_access {
          *
          * @param providedOutputs The collection of the names of outputs this instance will need to provide.
          */
-        explicit DeferredWrappedProvider(vector<string> providedOutputs) : WrappedDataProvider(nullptr), providedOutputs(std::move(providedOutputs)) { }
+        explicit DeferredWrappedProvider(std::vector<std::string> providedOutputs) : WrappedDataProvider(nullptr), providedOutputs(std::move(providedOutputs)) { }
 
         /**
          * Convenience constructor for when there is only one provided output name.
          *
          * @param outputName The name of the single output this instance will need to provide.
          */
-        explicit DeferredWrappedProvider(const string& outputName) : DeferredWrappedProvider(vector<string>(1)) {
+        explicit DeferredWrappedProvider(const std::string& outputName) : DeferredWrappedProvider(std::vector<std::string>(1)) {
             providedOutputs[0] = outputName;
         }
 
@@ -85,7 +83,7 @@ namespace data_access {
          *
          * @return The message string for the last call to @ref setWrappedProvider.
          */
-        inline const string &getSetMessage() {
+        inline const std::string &getSetMessage() {
             return setMessage;
         }
 
@@ -140,7 +138,7 @@ namespace data_access {
 
             // Confirm this will provide everything needed
             const vector<string> &available = provider->get_available_variable_names();
-            for (const string &requiredName : providedOutputs) {
+            for (const std::string &requiredName : providedOutputs) {
                 if (std::find(available.begin(), available.end(), requiredName) == available.end()) {
                     setMessage = "Given provider does not provide the required " + requiredName;
                     return false;
@@ -155,7 +153,7 @@ namespace data_access {
 
     protected:
         /** The collection of names of the outputs this type can/will be able to provide from its wrapped source. */
-        vector<string> providedOutputs;
+        std::vector<std::string> providedOutputs;
 
         /**
          * A message providing information from the last @ref setWrappedProvider call.
@@ -163,7 +161,7 @@ namespace data_access {
          * The value will be empty if the function returned ``true``.  If it returned ``false``, this will have an
          * info message set explaining more detail on the failure.
          */
-        string setMessage;
+        std::string setMessage;
     };
 
 }

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -137,7 +137,7 @@ namespace data_access {
             }
 
             // Confirm this will provide everything needed
-            const vector<string> &available = provider->get_available_variable_names();
+            const std::vector<std::string> &available = provider->get_available_variable_names();
             for (const std::string &requiredName : providedOutputs) {
                 if (std::find(available.begin(), available.end(), requiredName) == available.end()) {
                     setMessage = "Given provider does not provide the required " + requiredName;

--- a/include/forcing/OptionalWrappedDataProvider.hpp
+++ b/include/forcing/OptionalWrappedDataProvider.hpp
@@ -5,8 +5,6 @@
 
 #include "DeferredWrappedProvider.hpp"
 
-using namespace std;
-
 namespace data_access {
 
     /**
@@ -55,7 +53,7 @@ namespace data_access {
          * @param providedOuts The collection of the names of outputs this instance will need to provide.
          * @param defaultVals Mapping of some or all provided output defaults, keyed by output name.
          */
-        OptionalWrappedDataProvider(vector<string> providedOuts, map<string, double> defaultVals)
+        OptionalWrappedDataProvider(std::vector<std::string> providedOuts, std::map<std::string, double> defaultVals)
                 : DeferredWrappedProvider(std::move(providedOuts)), defaultValues(std::move(defaultVals))
         {
             // Validate the provided map of default values to ensure there aren't any unrecognized keys, as this
@@ -64,7 +62,7 @@ namespace data_access {
                 for (const auto &def_vals_it : defaultValues) {
                     auto name_it = find(providedOutputs.begin(), providedOutputs.end(), def_vals_it.first);
                     if (name_it == providedOutputs.end()) {
-                        string msg = "Invalid default values for OptionalWrappedDataProvider: default value given for "
+                        std::string msg = "Invalid default values for OptionalWrappedDataProvider: default value given for "
                                      "unknown output with name '" + def_vals_it.first + "' (expected names are ["
                                      + providedOutputs[0];
                         for (int i = 1; i < providedOutputs.size(); ++i) {
@@ -87,8 +85,8 @@ namespace data_access {
          * @param defaultWaits Map of the number of default usages for each provided output that the instance must wait
          *                     before using values from the backing provider.
          */
-        OptionalWrappedDataProvider(vector<string> providedOuts, map<string, double> defaultVals,
-                                map<string, int> defaultWaits)
+        OptionalWrappedDataProvider(std::vector<std::string> providedOuts, std::map<std::string, double> defaultVals,
+                                std::map<std::string, int> defaultWaits)
                 : OptionalWrappedDataProvider(std::move(providedOuts), std::move(defaultVals))
         {
             // Validate that all keys/names in the defaultWaits map have corresponding key in defaultValues
@@ -97,7 +95,7 @@ namespace data_access {
                 for (const auto &wait_it : defaultWaits) {
                     auto def_it = defaultValues.find(wait_it.first);
                     if (def_it == defaultValues.end()) {
-                        string msg = "Invalid default usage waits for OptionalWrappedDataProvider: wait count given for "
+                        std::string msg = "Invalid default usage waits for OptionalWrappedDataProvider: wait count given for "
                                      "non-default output '" + wait_it.first + "' (outputs with defaults set are [";
                         def_it = defaultValues.begin();
                         msg += def_it->first;
@@ -120,15 +118,15 @@ namespace data_access {
          *
          * @param providedOutputs The collection of the names of outputs this instance will need to provide.
          */
-        explicit OptionalWrappedDataProvider(vector<string> providedOutputs)
-            : OptionalWrappedDataProvider(std::move(providedOutputs), map<string, double>()) { }
+        explicit OptionalWrappedDataProvider(std::vector<std::string> providedOutputs)
+            : OptionalWrappedDataProvider(std::move(providedOutputs), std::map<std::string, double>()) { }
 
         /**
          * Convenience constructor for when there is only one provided output name, which does not have a default.
          *
          * @param outputName The name of the single output this instance will need to provide.
          */
-        explicit OptionalWrappedDataProvider(const string& outputName) : OptionalWrappedDataProvider(vector<string>(1)) {
+        explicit OptionalWrappedDataProvider(const std::string& outputName) : OptionalWrappedDataProvider(std::vector<std::string>(1)) {
             providedOutputs[0] = outputName;
         }
 
@@ -145,7 +143,7 @@ namespace data_access {
          * @param defaultUsageWait The number of default usages that the instance must wait before using values from
          *                          the backing provider.
          */
-        OptionalWrappedDataProvider(const string& outputName, double defaultValue, int defaultUsageWait)
+        OptionalWrappedDataProvider(const std::string& outputName, double defaultValue, int defaultUsageWait)
             : OptionalWrappedDataProvider(outputName)
         {
             defaultValues[providedOutputs[0]] = defaultValue;
@@ -160,7 +158,7 @@ namespace data_access {
          * @param outputName The name of the single output this instance will need to provide.
          * @param defaultValue The default to associate with the given output.
          */
-        OptionalWrappedDataProvider(const string& outputName, double defaultValue)
+        OptionalWrappedDataProvider(const std::string& outputName, double defaultValue)
             : OptionalWrappedDataProvider(outputName, defaultValue, 0) { }
 
         /**
@@ -194,10 +192,10 @@ namespace data_access {
          */
         double get_value(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
         {
-            string output_name = selector.get_variable_name();
+            std::string output_name = selector.get_variable_name();
             time_t init_time = selector.get_init_time();
             const long duration_s = selector.get_duration_secs();
-            const string output_units = selector.get_output_units();
+            const std::string output_units = selector.get_output_units();
             
             // Balk if not in this instance's collection of outputs
             if (find(providedOutputs.begin(), providedOutputs.end(), output_name) == providedOutputs.end()) {
@@ -248,7 +246,7 @@ namespace data_access {
          * @see get_value
          * @see recordUsingDefault
          */
-        bool isDefaultOverride(const string &output_name) {
+        bool isDefaultOverride(const std::string &output_name) {
             // First, there must be a default, and there must be something to override
             if (!isSuppliedWithDefault(output_name) || !isSuppliedByWrappedProvider(output_name)) {
                 return false;
@@ -284,7 +282,7 @@ namespace data_access {
          * @param outputName The output in question.
          * @return Whether a default value is available for this output.
          */
-        inline bool isSuppliedWithDefault(const string &outputName) {
+        inline bool isSuppliedWithDefault(const std::string &outputName) {
             return defaultValues.find(outputName) != defaultValues.end();
         }
 
@@ -323,7 +321,7 @@ namespace data_access {
 
             // Check this provides everything needed, accounting for defaults (and also tallying the outputs provided)
             unsigned short providedByProviderCount = 0;
-            for (const string &requiredName : providedOutputs) {
+            for (const std::string &requiredName : providedOutputs) {
                 // If supplied by the provider, increment our count and continue to the next required output name
                 if (isSuppliedByProvider(requiredName, provider)) {
                     ++providedByProviderCount;
@@ -367,7 +365,7 @@ namespace data_access {
          *
          * @param output_name The name of the output for which a default was used.
          */
-        virtual void recordUsingDefault(const string &output_name) {
+        virtual void recordUsingDefault(const std::string &output_name) {
             // Don't bother doing anything if there aren't waits assigned for this output
             // Also, in this implementation, don't count usages until there is a backing provider that can provide this
             auto waits_it = defaultUsageWaits.find(output_name);
@@ -389,21 +387,21 @@ namespace data_access {
         /**
          * A collection of mapped default values for some or all of the provided outputs.
          */
-        map<string, double> defaultValues;
+        std::map<std::string, double> defaultValues;
         /**
          * The number of times a default value should still be used before beginning to proxy a backing provider value.
          *
          * Note than all elements should have values greater than zero.  Any elements that would have their value
          * reduced to zero should instead be removed.
          */
-        map<string, int> defaultUsageWaits;
+        std::map<std::string, int> defaultUsageWaits;
 
-        static bool isSuppliedByProvider(const string &outputName, GenericDataProvider *provider) {
-            const vector<string> &available = provider->get_available_variable_names();
+        static bool isSuppliedByProvider(const std::string &outputName, GenericDataProvider *provider) {
+            const std::vector<std::string> &available = provider->get_available_variable_names();
             return find(available.begin(), available.end(), outputName) != available.end();
         }
 
-        inline bool isSuppliedByWrappedProvider(const string &outputName) {
+        inline bool isSuppliedByWrappedProvider(const std::string &outputName) {
             return wrapped_provider != nullptr && isSuppliedByProvider(outputName, wrapped_provider);
         }
 

--- a/include/forcing/OptionalWrappedDataProvider.hpp
+++ b/include/forcing/OptionalWrappedDataProvider.hpp
@@ -69,7 +69,7 @@ namespace data_access {
                             msg += ", " + providedOutputs[i];
                         }
                         msg += "])";
-                        throw runtime_error(msg);
+                        throw std::runtime_error(msg);
                     }
                 }
             }
@@ -105,7 +105,7 @@ namespace data_access {
                             def_it++;
                         }
                         msg += "])";
-                        throw runtime_error(msg);
+                        throw std::runtime_error(msg);
                     }
                 }
                 // Assuming the mapping is valid, set it for the instance
@@ -199,11 +199,11 @@ namespace data_access {
             
             // Balk if not in this instance's collection of outputs
             if (find(providedOutputs.begin(), providedOutputs.end(), output_name) == providedOutputs.end()) {
-                throw runtime_error("Unknown output " + output_name + " requested from wrapped provider");
+                throw std::runtime_error("Unknown output " + output_name + " requested from wrapped provider");
             }
             // Balk if this instance is not ready
             if (!isReadyToProvideData()) {
-                throw runtime_error("Cannot get value for " + output_name
+                throw std::runtime_error("Cannot get value for " + output_name
                                     + " from optional wrapped provider before it is ready");
             }
 

--- a/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
+++ b/include/realizations/catchment/AbstractCLibBmiAdapter.hpp
@@ -26,7 +26,7 @@ namespace models {
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
-            AbstractCLibBmiAdapter(const string &type_name, std::string library_file_path, std::string bmi_init_config,
+            AbstractCLibBmiAdapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                                    std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                                    std::string registration_func, utils::StreamHandler output)
                     : Bmi_Adapter<C>(type_name, std::move(bmi_init_config), std::move(forcing_file_path),
@@ -91,7 +91,7 @@ namespace models {
                 if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {
                     //Try alternative extension...
                     size_t idx = bmi_lib_file.rfind(".");
-                    if(idx == string::npos){
+                    if(idx == std::string::npos){
                         idx = bmi_lib_file.length()-1;
                     }
                     std::string alt_bmi_lib_file;  

--- a/include/realizations/catchment/Bmi_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Adapter.hpp
@@ -9,8 +9,6 @@
 #include "State_Exception.hpp"
 #include "StreamHandler.hpp"
 
-using namespace std;
-
 namespace models {
     namespace bmi {
         /**
@@ -21,7 +19,7 @@ namespace models {
         class Bmi_Adapter : public ::bmi::Bmi {
         public:
 
-            Bmi_Adapter(string model_name, string bmi_init_config, string forcing_file_path, bool allow_exceed_end,
+            Bmi_Adapter(std::string model_name, std::string bmi_init_config, std::string forcing_file_path, bool allow_exceed_end,
                         bool has_fixed_time_step, utils::StreamHandler output)
                 : model_name(std::move(model_name)),
                   bmi_init_config(std::move(bmi_init_config)),
@@ -37,7 +35,7 @@ namespace models {
                 if (!utils::FileChecker::file_is_readable(this->bmi_init_config)) {
                     init_exception_msg = "Cannot create and initialize " + this->model_name + " using unreadable file '"
                             + this->bmi_init_config + "'";
-                    throw runtime_error(init_exception_msg);
+                    throw std::runtime_error(init_exception_msg);
                 }
             }
 
@@ -93,7 +91,7 @@ namespace models {
              * @param time_convert_factor A reference to set to the determined conversion factor.
              */
             void acquire_time_conversion_factor(double &time_convert_factor) {
-                string time_units = GetTimeUnits();
+                std::string time_units = GetTimeUnits();
                 if (time_units == "s" || time_units == "sec" || time_units == "second" || time_units == "seconds")
                     time_convert_factor = 1.0;
                 else if (time_units == "m" || time_units == "min" || time_units == "minute" ||
@@ -104,7 +102,7 @@ namespace models {
                 else if (time_units == "d" || time_units == "day" || time_units == "days")
                     time_convert_factor = 86400.0;
                 else
-                    throw runtime_error(
+                    throw std::runtime_error(
                             "Invalid model time step units ('" + time_units + "') in " + model_name + ".");
             }
 
@@ -177,7 +175,7 @@ namespace models {
                 // If there was previous init attempt but w/ failure exception, throw runtime error and include previous
                 // message
                 if (model_initialized && !init_exception_msg.empty()) {
-                    throw runtime_error(
+                    throw std::runtime_error(
                             "Previous " + model_name + " init attempt had exception: \n\t" + init_exception_msg);
                 }
                     // If there was previous init attempt w/ (implicitly) no exception on previous attempt, just return
@@ -187,7 +185,7 @@ namespace models {
                 else if (!utils::FileChecker::file_is_readable(bmi_init_config)) {
                     init_exception_msg = "Cannot initialize " + model_name + " using unreadable file '"
                             + bmi_init_config + "'";
-                    throw runtime_error(init_exception_msg);
+                    throw std::runtime_error(init_exception_msg);
                 }
                 else {
                     try {
@@ -198,7 +196,7 @@ namespace models {
                         acquire_time_conversion_factor(bmi_model_time_convert_factor);
                     }
                         // Record the exception message before re-throwing to handle subsequent function calls properly
-                    catch (exception& e) {
+                    catch (std::exception& e) {
                         // Make sure this is set to 'true' after this function call finishes
                         model_initialized = true;
                         throw e;
@@ -224,9 +222,9 @@ namespace models {
              * @throws models::external::State_Exception   If `initialize()` in nested model is not successful.
              * @throws runtime_error If already initialized but using a different file than the passed argument.
              */
-            void Initialize(string config_file) override {
+            void Initialize(std::string config_file) override {
                 if (config_file != bmi_init_config && model_initialized) {
-                    throw runtime_error(
+                    throw std::runtime_error(
                             "Model init previously attempted; cannot change config from " + bmi_init_config + " to "
                             + config_file);
                 }
@@ -243,7 +241,7 @@ namespace models {
                     throw e;
                 }
                 catch (std::exception &e) {
-                    throw runtime_error(e.what());
+                    throw std::runtime_error(e.what());
                 }
             }
 
@@ -270,28 +268,28 @@ namespace models {
             /** Whether model ``Update`` calls are allowed and handled in some way by the backing model. */
             bool allow_model_exceed_end_time = false;
             /** Path (as a string) to the BMI config file for initializing the backing model (empty if none). */
-            string bmi_init_config;
+            std::string bmi_init_config;
             /** Pointer to backing BMI model instance. */
-            shared_ptr<T> bmi_model = nullptr;
+            std::shared_ptr<T> bmi_model = nullptr;
             /** Whether this particular model has a time step size that cannot be changed internally or externally. */
             bool bmi_model_has_fixed_time_step = true;
             /** Conversion factor for converting values for model time in model's unit type to equivalent in seconds. */
             double bmi_model_time_convert_factor;
             /** Pointer to stored time step size value of backing model, if it is fixed and has been retrieved. */
-            shared_ptr<double> bmi_model_time_step_size = nullptr;
+            std::shared_ptr<double> bmi_model_time_step_size = nullptr;
             /** Whether this particular model implementation directly reads input data from the forcing file. */
             bool bmi_model_uses_forcing_file;
-            string forcing_file_path;
+            std::string forcing_file_path;
             /** Message from an exception (if encountered) on the first attempt to initialize the backing model. */
-            string init_exception_msg;
+            std::string init_exception_msg;
             /** Pointer to collection of input variable names for backing model, used by ``GetInputVarNames()``. */
-            shared_ptr<vector<string>> input_var_names;
+            std::shared_ptr<std::vector<std::string>> input_var_names;
             /** Whether the backing model has been initialized yet, which is always initially ``false``. */
             bool model_initialized = false;
-            string model_name;
+            std::string model_name;
             utils::StreamHandler output;
             /** Pointer to collection of output variable names for backing model, used by ``GetOutputVarNames()``. */
-            shared_ptr<vector<string>> output_var_names;
+            std::shared_ptr<std::vector<std::string>> output_var_names;
 
             /**
              * Construct the backing BMI model object, then call its BMI-native ``Initialize()`` function.

--- a/include/realizations/catchment/Bmi_C_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_C_Adapter.hpp
@@ -36,7 +36,7 @@ namespace models {
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
-            explicit Bmi_C_Adapter(const string &type_name, std::string library_file_path, std::string forcing_file_path,
+            explicit Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string forcing_file_path,
                                    bool allow_exceed_end, bool has_fixed_time_step,
                                    const std::string& registration_func, utils::StreamHandler output);
 
@@ -53,7 +53,7 @@ namespace models {
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
-            Bmi_C_Adapter(const string &type_name, std::string library_file_path, std::string bmi_init_config,
+            Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                           std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                           std::string registration_func, utils::StreamHandler output);
 
@@ -81,7 +81,7 @@ namespace models {
              * @param output The output stream handler.
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
-            Bmi_C_Adapter(const string &type_name, std::string library_file_path, std::string bmi_init_config,
+            Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                           std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                           std::string registration_func, utils::StreamHandler output, bool do_initialization);
 
@@ -124,7 +124,7 @@ namespace models {
                 finalizeForCAdapter();
             }
 
-            string GetComponentName() override;
+            std::string GetComponentName() override;
 
             /**
              * Get the backing model's current time.

--- a/include/realizations/catchment/Bmi_Cpp_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Cpp_Adapter.hpp
@@ -134,7 +134,7 @@ namespace models {
                 finalizeForCppAdapter();
             }
 
-            string GetComponentName() override;
+            std::string GetComponentName() override;
 
             /**
              * Get the backing model's current time.

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -41,8 +41,6 @@ class Bmi_Formulation_Test;
 class Bmi_C_Formulation_Test;
 class Bmi_C_Pet_IT;
 
-using namespace std;
-
 namespace realization {
 
     /**
@@ -99,15 +97,15 @@ namespace realization {
          */
         virtual const bool &get_allow_model_exceed_end_time() const = 0;
 
-        virtual const vector<string> get_bmi_input_variables() = 0;
+        virtual const std::vector<std::string> get_bmi_input_variables() = 0;
 
-        const string &get_bmi_main_output_var() const {
+        const std::string &get_bmi_main_output_var() const {
             return bmi_main_output_var;
         }
 
         virtual const time_t &get_bmi_model_start_time_forcing_offset_s() = 0;
 
-        virtual const vector<string> get_bmi_output_variables() = 0;
+        virtual const std::vector<std::string> get_bmi_output_variables() = 0;
 
         /**
          * When possible, translate a variable name for a BMI model to an internally recognized name.
@@ -131,7 +129,7 @@ namespace realization {
          */
         virtual const double get_model_end_time() = 0;
 
-        virtual const string &get_forcing_file_path() const = 0;
+        virtual const std::string &get_forcing_file_path() const = 0;
 
         /**
          * Get the name of the specific type of the backing model object.
@@ -147,7 +145,7 @@ namespace realization {
          *
          * @return The values making up the header line from get_output_header_line() organized as a vector.
          */
-        const vector<std::string> &get_output_header_fields() const {
+        const std::vector<std::string> &get_output_header_fields() const {
             return output_header_fields;
         }
 
@@ -159,7 +157,7 @@ namespace realization {
          *
          * @return An appropriate header line for this type.
          */
-        string get_output_header_line(string delimiter) override {
+        std::string get_output_header_line(std::string delimiter) override {
             return boost::algorithm::join(get_output_header_fields(), delimiter);
         }
 
@@ -172,15 +170,15 @@ namespace realization {
          * @return
          */
         // TODO: rename this function to make it more clear it is FORMULATION output contents, not simply BMI variables
-        const vector<string> &get_output_variable_names() const {
+        const std::vector<std::string> &get_output_variable_names() const {
             return output_variable_names;
         }
 
-        const vector<std::string> &get_required_parameters() override {
+        const std::vector<std::string> &get_required_parameters() override {
             return REQUIRED_PARAMETERS;
         }
 
-        virtual bool is_bmi_input_variable(const string &var_name) = 0;
+        virtual bool is_bmi_input_variable(const std::string &var_name) = 0;
 
         /**
          * Test whether backing model has fixed time step size.
@@ -189,7 +187,7 @@ namespace realization {
          */
         virtual bool is_bmi_model_time_step_fixed() = 0;
 
-        virtual bool is_bmi_output_variable(const string &var_name) = 0;
+        virtual bool is_bmi_output_variable(const std::string &var_name) = 0;
 
         /**
          * Whether the backing model uses/reads the forcing file directly for getting input data.
@@ -226,7 +224,7 @@ namespace realization {
             return output_precision;
         }
 
-        void set_bmi_main_output_var(const string &main_output_var) {
+        void set_bmi_main_output_var(const std::string &main_output_var) {
             bmi_main_output_var = main_output_var;
         }
 
@@ -239,7 +237,7 @@ namespace realization {
             model_type_name = std::move(type_name);
         }
 
-        void set_output_header_fields(const vector<std::string> &output_headers) {
+        void set_output_header_fields(const std::vector<std::string> &output_headers) {
             output_header_fields = output_headers;
         }
 
@@ -251,7 +249,7 @@ namespace realization {
          *
          * @param out_var_names the names of variables in formulation output, in the order they should appear.
          */
-        void set_output_variable_names(const vector<string> &out_var_names) {
+        void set_output_variable_names(const std::vector<std::string> &out_var_names) {
             output_variable_names = out_var_names;
         }
 

--- a/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
@@ -25,7 +25,7 @@ namespace models {
 
         public:
 
-            explicit Bmi_Fortran_Adapter(const string &type_name, std::string library_file_path,
+            explicit Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path,
                                          std::string forcing_file_path,
                                          bool allow_exceed_end, bool has_fixed_time_step,
                                          const std::string &registration_func, utils::StreamHandler output)
@@ -33,7 +33,7 @@ namespace models {
                                           has_fixed_time_step,
                                           registration_func, output) {}
 
-            Bmi_Fortran_Adapter(const string &type_name, std::string library_file_path, std::string bmi_init_config,
+            Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                                 std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                                 std::string registration_func,
                                 utils::StreamHandler output) : AbstractCLibBmiAdapter(type_name,
@@ -67,7 +67,7 @@ namespace models {
                     model_initialized = true;
                     throw e;
                 }
-                catch (exception &e) {
+                catch (std::exception &e) {
                     //This will catch any other exception, but the it will be cast to this base type.
                     //This means it looses it any specific type/message information.  So if construct_and_init_backing_model_for_fortran
                     //throws an exception besides runtime_error, catch that type explicitly.
@@ -76,7 +76,7 @@ namespace models {
                 }
             }
 
-            string GetComponentName() override;
+            std::string GetComponentName() override;
 
             /**
              * Get the backing model's current time.

--- a/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
@@ -46,7 +46,7 @@ namespace realization {
          * @param timestep The time step for which data is desired.
          * @return A delimited string with all the output variable values for the given time step.
          */
-        string get_output_line_for_timestep(int timestep, std::string delimiter) override;
+        std::string get_output_line_for_timestep(int timestep, std::string delimiter) override;
 
         /**
          * Get the model response for a time step.
@@ -102,9 +102,9 @@ namespace realization {
             return (time_t) (get_bmi_model()->convert_model_time_to_seconds(model_time));
         }
 
-        double get_var_value_as_double(const string &var_name) override;
+        double get_var_value_as_double(const std::string &var_name) override;
 
-        double get_var_value_as_double(const int &index, const string &var_name) override;
+        double get_var_value_as_double(const int &index, const std::string &var_name) override;
 
         friend class Bmi_Multi_Formulation;
 

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -260,7 +260,7 @@ namespace realization {
                 }
             }
             //This is unlikely (impossible?) to throw since a pre-check on available names is done above. Assert instead?
-            throw runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
+            throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
         }
 
         /**
@@ -325,7 +325,7 @@ namespace realization {
             }
 
             //This is unlikely (impossible?) to throw since a pre-check on available names is done above. Assert instead?
-            throw runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
+            throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
         }
 
         bool is_bmi_input_variable(const std::string &var_name) override {

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -71,7 +71,7 @@ namespace realization {
          * @see ForcingProvider
          */
         //const vector<std::string> &get_available_forcing_outputs() {
-        const vector<std::string> &get_available_variable_names() override {
+        const std::vector<std::string> &get_available_variable_names() override {
             if (is_model_initialized() && available_forcings.empty()) {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);
@@ -97,7 +97,7 @@ namespace realization {
          */
         time_t get_variable_time_begin(const std::string &variable_name) {
             // TODO: come back and implement if actually necessary for this type; for now don't use
-            throw runtime_error("Bmi_Modular_Formulation does not yet implement get_variable_time_begin");
+            throw std::runtime_error("Bmi_Modular_Formulation does not yet implement get_variable_time_begin");
         }
 
         /**
@@ -126,16 +126,16 @@ namespace realization {
         //time_t get_forcing_output_time_end(const std::string &output_name) {
         time_t get_variable_time_end(const std::string &varibale_name) {
             // TODO: come back and implement if actually necessary for this type; for now don't use
-            throw runtime_error("Bmi_Module_Formulation does not yet implement get_variable_time_end");
+            throw std::runtime_error("Bmi_Module_Formulation does not yet implement get_variable_time_end");
         }
 
         long get_data_stop_time() override {
             // TODO: come back and implement if actually necessary for this type; for now don't use
-            throw runtime_error("Bmi_Module_Formulation does not yet implement get_data_stop_time");
+            throw std::runtime_error("Bmi_Module_Formulation does not yet implement get_data_stop_time");
         }
 
         long record_duration() override {
-            throw runtime_error("Bmi_Module_Formulation does not yet implement record_duration");
+            throw std::runtime_error("Bmi_Module_Formulation does not yet implement record_duration");
         }
 
         /**
@@ -156,7 +156,7 @@ namespace realization {
             return get_bmi_model()->GetEndTime();
         }
 
-        const vector<std::string> &get_required_parameters() override {
+        const std::vector<std::string> &get_required_parameters() override {
             return REQUIRED_PARAMETERS;
         }
 
@@ -197,7 +197,7 @@ namespace realization {
          */
         size_t get_ts_index_for_time(const time_t &epoch_time) override {
             // TODO: come back and implement if actually necessary for this type; for now don't use
-            throw runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
+            throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
         }
 
         /**
@@ -222,7 +222,7 @@ namespace realization {
             //const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
             const std::vector<std::string> forcing_outputs = get_available_variable_names();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
-                throw runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
+                throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
             }
             // TODO: do this, or something better, later; right now, just assume anything using this as a provider is
             //  consistent with times
@@ -291,7 +291,7 @@ namespace realization {
             //const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
             const std::vector<std::string> forcing_outputs = get_available_variable_names();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
-                throw runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
+                throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
             }
             // TODO: do this, or something better, later; right now, just assume anything using this as a provider is
             //  consistent with times
@@ -363,11 +363,11 @@ namespace realization {
             return true;
         }
 
-        const vector<string> get_bmi_input_variables() override {
+        const std::vector<std::string> get_bmi_input_variables() override {
             return get_bmi_model()->GetInputVarNames();
         }
 
-        const vector<string> get_bmi_output_variables() override {
+        const std::vector<std::string> get_bmi_output_variables() override {
             return get_bmi_model()->GetOutputVarNames();
         }
 
@@ -449,7 +449,7 @@ namespace realization {
             return allow_model_exceed_end_time;
         }
 
-        const string &get_bmi_init_config() const {
+        const std::string &get_bmi_init_config() const {
             return bmi_init_config;
         }
 
@@ -462,7 +462,7 @@ namespace realization {
             return bmi_model;
         }
 
-        const string &get_forcing_file_path() const override {
+        const std::string &get_forcing_file_path() const override {
             return forcing_file_path;
         }
 
@@ -733,7 +733,7 @@ namespace realization {
             allow_model_exceed_end_time = allow_exceed_end;
         }
 
-        void set_bmi_init_config(const string &init_config) {
+        void set_bmi_init_config(const std::string &init_config) {
             bmi_init_config = init_config;
         }
 
@@ -763,7 +763,7 @@ namespace realization {
             bmi_using_forcing_file = uses_forcing_file;
         }
 
-        void set_forcing_file_path(const string &forcing_path) {
+        void set_forcing_file_path(const std::string &forcing_path) {
             forcing_file_path = forcing_path;
         }
 

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -13,8 +13,6 @@
 #define BMI_REALIZATION_CFG_PARAM_REQ__MODULES "modules"
 #define BMI_REALIZATION_CFG_PARAM_OPT__DEFAULT_OUT_VALS "default_output_values"
 
-using namespace std;
-
 class Bmi_Multi_Formulation_Test;
 class Bmi_Cpp_Multi_Array_Test;
 
@@ -38,7 +36,7 @@ namespace realization {
          * @param forcing_config
          * @param output_stream
          */
-        Bmi_Multi_Formulation(string id, std::shared_ptr<data_access::GenericDataProvider> forcing_provider, utils::StreamHandler output_stream)
+        Bmi_Multi_Formulation(std::string id, std::shared_ptr<data_access::GenericDataProvider> forcing_provider, utils::StreamHandler output_stream)
                 : Bmi_Formulation(std::move(id), forcing_provider, output_stream) { };
 
         virtual ~Bmi_Multi_Formulation() {};
@@ -120,7 +118,7 @@ namespace realization {
          */
         //const vector<std::string> &get_available_forcing_outputs();
         //const vector<std::string> &get_available_variable_names() override { return get_available_forcing_outputs(); }
-        const vector<std::string> &get_available_variable_names() override;
+        const std::vector<std::string> &get_available_variable_names() override;
 
         /**
         * Get the input variables of 
@@ -128,7 +126,7 @@ namespace realization {
         *
         * @return The input variables of the first nested BMI model.
         */
-        const vector<string> get_bmi_input_variables() override {
+        const std::vector<string> get_bmi_input_variables() override {
             return modules[0]->get_bmi_input_variables();
         }
 
@@ -139,7 +137,7 @@ namespace realization {
          *
          * @return The output variables of the last nested BMI model.
          */
-        const vector<string> get_bmi_output_variables() override {
+        const std::vector<string> get_bmi_output_variables() override {
             return modules.back()->get_bmi_output_variables();
         }
 
@@ -163,7 +161,7 @@ namespace realization {
          * @see get_config_mapped_variable_name(string, bool, bool)
          * @see get_config_mapped_variable_name(string, shared_ptr, shared_ptr)
          */
-        const string &get_config_mapped_variable_name(const string &model_var_name) override;
+        const std::string &get_config_mapped_variable_name(const std::string &model_var_name) override;
 
         /**
          * When possible, translate a variable name for the first or last BMI model to an internally recognized name.
@@ -181,7 +179,7 @@ namespace realization {
          * @param check_last Whether an output variable mapping for the last module should sought.
          * @return Either the translated equivalent variable name, or the provided name if there is not a mapping entry.
          */
-        const string &get_config_mapped_variable_name(const string &model_var_name, bool check_first, bool check_last);
+        const std::string &get_config_mapped_variable_name(const std::string &model_var_name, bool check_first, bool check_last);
 
         /**
          * When possible, translate the name of an output variable for one BMI model to an input variable for another.
@@ -207,11 +205,11 @@ namespace realization {
          * @param in_module The module needing a translation of ``output_var_name`` to one of its input variable names.
          * @return Either the translated equivalent variable name, or the provided name if there is not a mapping entry.
          */
-        const string &get_config_mapped_variable_name(const string &output_var_name,
+        const std::string &get_config_mapped_variable_name(const std::string &output_var_name,
                                                       const shared_ptr<Bmi_Formulation>& out_module,
                                                       const shared_ptr<Bmi_Formulation>& in_module);
 
-        const string &get_forcing_file_path() const override;
+        const std::string &get_forcing_file_path() const override;
 
         /**
          * Get the inclusive beginning of the period of time over which this instance can provide data for this forcing.
@@ -372,7 +370,7 @@ namespace realization {
             return modules[get_index_for_primary_module()]->get_data_start_time();
         }
 
-        string get_output_line_for_timestep(int timestep, std::string delimiter) override;
+        std::string get_output_line_for_timestep(int timestep, std::string delimiter) override;
 
         double get_response(time_step_t t_index, time_step_t t_delta) override;
 
@@ -442,7 +440,7 @@ namespace realization {
             return availableData[output_name]->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),output_name, init_time, duration_s, output_units), m);
         }
 
-        bool is_bmi_input_variable(const string &var_name) override;
+        bool is_bmi_input_variable(const std::string &var_name) override;
 
         /**
          * Test whether all backing models have fixed time step size.
@@ -451,7 +449,7 @@ namespace realization {
          */
         bool is_bmi_model_time_step_fixed() override;
 
-        bool is_bmi_output_variable(const string &var_name) override;
+        bool is_bmi_output_variable(const std::string &var_name) override;
 
         bool is_bmi_using_forcing_file() const override;
 
@@ -480,7 +478,7 @@ namespace realization {
          * @param name The name of the forcing property for which the current value is desired.
          * @return Whether the property's value is an aggregate sum.
          */
-        bool is_property_sum_over_time_step(const string &name) override {
+        bool is_property_sum_over_time_step(const std::string &name) override {
             if (availableData.empty() || availableData.find(name) == availableData.end()) {
                 throw runtime_error(
                         get_formulation_type() + " cannot get whether unknown property " + name + " is summation");

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -126,7 +126,7 @@ namespace realization {
         *
         * @return The input variables of the first nested BMI model.
         */
-        const std::vector<string> get_bmi_input_variables() override {
+        const std::vector<std::string> get_bmi_input_variables() override {
             return modules[0]->get_bmi_input_variables();
         }
 
@@ -137,7 +137,7 @@ namespace realization {
          *
          * @return The output variables of the last nested BMI model.
          */
-        const std::vector<string> get_bmi_output_variables() override {
+        const std::vector<std::string> get_bmi_output_variables() override {
             return modules.back()->get_bmi_output_variables();
         }
 
@@ -258,7 +258,7 @@ namespace realization {
             }
             // If not found ...
             if (availableData.empty() || availableData.find(var_name) == availableData.end()) {
-                throw runtime_error(get_formulation_type() + " cannot get output time for unknown \"" + variable_name + "\"");
+                throw std::runtime_error(get_formulation_type() + " cannot get output time for unknown \"" + variable_name + "\"");
             }
             return availableData[var_name]->get_data_start_time();
         }
@@ -310,7 +310,7 @@ namespace realization {
             }
             // If not found ...
             if (availableData.empty() || availableData.find(var_name) == availableData.end()) {
-                throw runtime_error(get_formulation_type() + " cannot get output time for unknown \"" + variable_name + "\"");
+                throw std::runtime_error(get_formulation_type() + " cannot get output time for unknown \"" + variable_name + "\"");
             }
             return availableData[var_name]->get_data_stop_time();
         }
@@ -334,7 +334,7 @@ namespace realization {
 
             // If not found ...
             if (availableData.empty() || availableData.find(var_name) == availableData.end()) {
-                throw runtime_error(get_formulation_type() + " cannot get output record duration for unknown \"" + var_name + "\"");
+                throw std::runtime_error(get_formulation_type() + " cannot get output record duration for unknown \"" + var_name + "\"");
             }
             return availableData[var_name]->record_duration();
         }
@@ -389,7 +389,7 @@ namespace realization {
          */
         size_t get_ts_index_for_time(const time_t &epoch_time) override {
             // TODO: come back and implement if actually necessary for this type; for now don't use
-            throw runtime_error("Bmi_Multi_Formulation does not yet implement get_ts_index_for_time");
+            throw std::runtime_error("Bmi_Multi_Formulation does not yet implement get_ts_index_for_time");
         }
 
         /**
@@ -422,7 +422,7 @@ namespace realization {
             
             // If not found ...
             if (availableData.empty() || availableData.find(output_name) == availableData.end()) {
-                throw runtime_error(get_formulation_type() + " cannot get output value for unknown " + output_name + SOURCE_LOC);
+                throw std::runtime_error(get_formulation_type() + " cannot get output value for unknown " + output_name + SOURCE_LOC);
             }
             return availableData[output_name]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),output_name, init_time, duration_s, output_units), m);
         }
@@ -435,7 +435,7 @@ namespace realization {
             std::string output_units = selector.get_output_units();
 
             if (availableData.empty() || availableData.find(output_name) == availableData.end()) {
-                throw runtime_error(get_formulation_type() + " cannot get output values for unknown " + output_name + SOURCE_LOC);
+                throw std::runtime_error(get_formulation_type() + " cannot get output values for unknown " + output_name + SOURCE_LOC);
             }
             return availableData[output_name]->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),output_name, init_time, duration_s, output_units), m);
         }
@@ -480,7 +480,7 @@ namespace realization {
          */
         bool is_property_sum_over_time_step(const std::string &name) override {
             if (availableData.empty() || availableData.find(name) == availableData.end()) {
-                throw runtime_error(
+                throw std::runtime_error(
                         get_formulation_type() + " cannot get whether unknown property " + name + " is summation");
             }
             return availableData[name]->is_property_sum_over_time_step(name);

--- a/include/realizations/catchment/Bmi_Py_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Py_Adapter.hpp
@@ -22,7 +22,6 @@ class Bmi_Py_Adapter_Test;
 namespace py = pybind11;
 
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality
-using namespace std;
 
 namespace models {
     namespace bmi {
@@ -35,10 +34,10 @@ namespace models {
 
         public:
 
-            Bmi_Py_Adapter(const string &type_name, std::string bmi_init_config, const string &bmi_python_type,
+            Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
                            bool allow_exceed_end, bool has_fixed_time_step, utils::StreamHandler output);
 
-            Bmi_Py_Adapter(const string &type_name, std::string bmi_init_config, const string &bmi_python_type,
+            Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
                            std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                            utils::StreamHandler output);
 
@@ -51,7 +50,7 @@ namespace models {
              *             variable, which is assume to be of the necessary size.
              */
             template <typename T>
-            void copy_to_array(const string& name, T *dest)
+            void copy_to_array(const std::string& name, T *dest)
             {
                 py::array_t<T> backing_array = bmi_model->attr("get_value_ptr")(name);
                 auto uncheck_proxy = backing_array.template unchecked<1>();
@@ -68,7 +67,7 @@ namespace models {
              * @return A vector containing the values of the desired BMI variable.
              */
             template <typename T>
-            std::vector<T> copy_to_vector(const string& name)
+            std::vector<T> copy_to_vector(const std::string& name)
             {
                 py::array_t<T> backing_array = bmi_model->attr("get_value_ptr")(name);
                 std::vector<T> dest(backing_array.size());
@@ -83,7 +82,7 @@ namespace models {
                 bmi_model->attr("finalize")();
             }
 
-            string GetComponentName() override;
+            std::string GetComponentName() override;
 
             double GetCurrentTime() override;
 
@@ -91,11 +90,11 @@ namespace models {
 
             int GetInputItemCount() override;
 
-            vector<std::string> GetInputVarNames() override;
+            std::vector<std::string> GetInputVarNames() override;
 
             int GetOutputItemCount() override;
 
-            vector<std::string> GetOutputVarNames() override;
+            std::vector<std::string> GetOutputVarNames() override;
 
             int GetGridEdgeCount(const int grid) override {
                 return py::int_(bmi_model->attr("get_grid_edge_count")(grid));
@@ -153,7 +152,7 @@ namespace models {
                 get_and_copy_grid_array<double>("get_grid_spacing", grid, spacing, GetGridRank(grid), "float");
             }
 
-            string GetGridType(const int grid) override {
+            std::string GetGridType(const int grid) override {
                 return py::str(bmi_model->attr("get_grid_type")(grid));
             }
 
@@ -189,13 +188,13 @@ namespace models {
 
             double GetStartTime() override;
 
-            string GetTimeUnits() override;
+            std::string GetTimeUnits() override;
 
             double GetTimeStep() override;
 
-            string GetVarType(std::string name) override;
+            std::string GetVarType(std::string name) override;
 
-            string GetVarUnits(std::string name) override;
+            std::string GetVarUnits(std::string name) override;
 
             int GetVarGrid(std::string name) override;
 
@@ -203,7 +202,7 @@ namespace models {
 
             int GetVarNbytes(std::string name) override;
 
-            string GetVarLocation(std::string name) override;
+            std::string GetVarLocation(std::string name) override;
 
             void GetValue(std::string name, void *dest) override;
 
@@ -417,10 +416,10 @@ namespace models {
              * @throws runtime_error Thrown if @ref GetVarType and @ref GetVarItemsize functions return a combination for
              *                       which there is not support for mapping to a native type in the framework.
              */
-            void get_value_at_indices(const string& name, void *dest, int *inds, int count, bool is_all_indices) {
-                string val_type = GetVarType(name);
+            void get_value_at_indices(const std::string& name, void *dest, int *inds, int count, bool is_all_indices) {
+                std::string val_type = GetVarType(name);
                 size_t val_item_size = (size_t)GetVarItemsize(name);
-                vector<string> in_v = GetInputVarNames();
+                std::vector<string> in_v = GetInputVarNames();
 
                 // The available types and how they are handled here should match what is in SetValueAtIndices
                 if (val_type == "int" && val_item_size == sizeof(short))
@@ -468,10 +467,10 @@ namespace models {
              * @return
              */
             template <typename T>
-            py::array_t<T> get_via_numpy_array(const string& name, void *dest, const int *indices, int item_count,
+            py::array_t<T> get_via_numpy_array(const std::string& name, void *dest, const int *indices, int item_count,
                                                size_t item_size, bool is_all_indices)
             {
-                string val_type = GetVarType(name);
+                std::string val_type = GetVarType(name);
                 py::array_t<T, py::array::c_style> dest_array
                     = np.attr("zeros")(item_count, "dtype"_a = val_type, "order"_a = "C");
                 if (is_all_indices) {
@@ -607,8 +606,8 @@ namespace models {
              * @param np_type The name of the Python dtype to use for the wrapped Numpy array of update values.
              */
             template <typename T>
-            void set_value_at_indices(const string &name, const int *inds, int count, void* cxx_array,
-                                      const string &np_type)
+            void set_value_at_indices(const std::string &name, const int *inds, int count, void* cxx_array,
+                                      const std::string &np_type)
             {
                 py::array_t<int> index_array(py::buffer_info(inds, count));
                 py::array_t<T> src_array(py::buffer_info((T*)cxx_array, count));
@@ -633,7 +632,7 @@ namespace models {
         private:
 
             /** Fully qualified Python type name for backing module. */
-            string bmi_type_py_full_name;
+            std::string bmi_type_py_full_name;
             /** A binding to the Python numpy package/module. */
             py::object np;
             /** A pointer to a string with the parent package name of the Python type referenced by ``py_bmi_type_ref``. */
@@ -656,7 +655,7 @@ namespace models {
                     return;
                 try {
                     separate_package_and_simple_name();
-                    vector<string> moduleComponents = {*bmi_type_py_module_name, *bmi_type_py_class_name};
+                    std::vector<string> moduleComponents = {*bmi_type_py_module_name, *bmi_type_py_class_name};
                     // This is a class object for the BMI module Python class
                     py::object bmi_py_class = utils::ngenPy::InterpreterUtil::getPyModule(moduleComponents);
                     // This is the actual backing model object
@@ -668,8 +667,8 @@ namespace models {
                 }
                 // Record the exception message before re-throwing to handle subsequent function calls properly
                 // TODO: handle exceptions in better detail, without losing type information
-                catch (exception& e) {
-                    init_exception_msg = string(e.what());
+                catch (std::exception& e) {
+                    init_exception_msg = std::string(e.what());
                     // Make sure this is non-empty to be consistent with the above logic
                     if (init_exception_msg.empty()) {
                         init_exception_msg = "Unknown Python model initialization exception.";
@@ -722,13 +721,13 @@ namespace models {
              */
             inline void separate_package_and_simple_name() {
                 if (!model_initialized) {
-                    vector<string> split_name;
-                    string delimiter = ".";
-                    string name_string = bmi_type_py_full_name;
+                    std::vector<string> split_name;
+                    std::string delimiter = ".";
+                    std::string name_string = bmi_type_py_full_name;
 
                     size_t pos = 0;
-                    string token;
-                    while ((pos = name_string.find(delimiter)) != string::npos) {
+                    std::string token;
+                    while ((pos = name_string.find(delimiter)) != std::string::npos) {
                         token = name_string.substr(0, pos);
                         split_name.emplace_back(token);
                         name_string.erase(0, pos + delimiter.length());

--- a/include/realizations/catchment/Bmi_Py_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Py_Adapter.hpp
@@ -246,7 +246,7 @@ namespace models {
                 } else if (py_type_name == "float" && item_size == sizeof(long double)) {
                     return "long double";
                 } else {
-                    throw runtime_error(
+                    throw std::runtime_error(
                             "(Bmi_Py_Adapter) Failed determining analogous C++ type for Python model '" + py_type_name +
                             "' type with size " + std::to_string(item_size) + " bytes.");
                 }
@@ -266,7 +266,7 @@ namespace models {
                 } else if (cxx_type_name == "float" || cxx_type_name == "double" || cxx_type_name == "long double") {
                     return "double";
                 } else {
-                    throw runtime_error("(Bmi_Py_Adapter) Failed determining analogous built-in Python type for C++ '" +
+                    throw std::runtime_error("(Bmi_Py_Adapter) Failed determining analogous built-in Python type for C++ '" +
                                         cxx_type_name + "' type");
                 }
             }
@@ -303,7 +303,7 @@ namespace models {
                     }
                 }
 
-                throw runtime_error("(Bmi_Py_Adapter) Failed determining analogous Python dtype for C++ '" +
+                throw std::runtime_error("(Bmi_Py_Adapter) Failed determining analogous Python dtype for C++ '" +
                                     cxx_type_name + "' type with size " + std::to_string(item_size) + " bytes.");
             }
 
@@ -419,7 +419,7 @@ namespace models {
             void get_value_at_indices(const std::string& name, void *dest, int *inds, int count, bool is_all_indices) {
                 std::string val_type = GetVarType(name);
                 size_t val_item_size = (size_t)GetVarItemsize(name);
-                std::vector<string> in_v = GetInputVarNames();
+                std::vector<std::string> in_v = GetInputVarNames();
 
                 // The available types and how they are handled here should match what is in SetValueAtIndices
                 if (val_type == "int" && val_item_size == sizeof(short))
@@ -439,7 +439,7 @@ namespace models {
                         get_via_numpy_array<long double>(name, dest, inds, count, val_item_size, is_all_indices);
                 }
                 else
-                    throw runtime_error(
+                    throw std::runtime_error(
                             "(Bmi_Py_Adapter) Failed attempt to GET values of BMI variable '" + name + "' from '" +
                             model_name + "' model:  model advertises unsupported combination of type (" + val_type +
                             ") and size (" + std::to_string(val_item_size) + ").");
@@ -636,9 +636,9 @@ namespace models {
             /** A binding to the Python numpy package/module. */
             py::object np;
             /** A pointer to a string with the parent package name of the Python type referenced by ``py_bmi_type_ref``. */
-            shared_ptr<string> bmi_type_py_module_name;
+            std::shared_ptr<std::string> bmi_type_py_module_name;
             /** A pointer to a string with the simple name of the Python type referenced by ``py_bmi_type_ref``. */
-            shared_ptr<string> bmi_type_py_class_name;
+            std::shared_ptr<std::string> bmi_type_py_class_name;
 
             /**
              * Construct the backing BMI model object, then call its BMI-native ``Initialize()`` function.
@@ -655,11 +655,11 @@ namespace models {
                     return;
                 try {
                     separate_package_and_simple_name();
-                    std::vector<string> moduleComponents = {*bmi_type_py_module_name, *bmi_type_py_class_name};
+                    std::vector<std::string> moduleComponents = {*bmi_type_py_module_name, *bmi_type_py_class_name};
                     // This is a class object for the BMI module Python class
                     py::object bmi_py_class = utils::ngenPy::InterpreterUtil::getPyModule(moduleComponents);
                     // This is the actual backing model object
-                    bmi_model = make_shared<py::object>(bmi_py_class());
+                    bmi_model = std::make_shared<py::object>(bmi_py_class());
                     bmi_model->attr("initialize")(bmi_init_config);
                 }
                 catch (std::runtime_error& e){ //Catch specific exception types so the type/message don't get erased
@@ -706,7 +706,7 @@ namespace models {
                     get_and_copy_grid_array<double>(name, grid, dest, shape[rank-index-1], "float");
                     return;
                 }else{
-                    throw runtime_error("GetGrid<X|Y|Z> coordinates not yet implemented for Python BMI adapter for grid type "+grid_type);
+                    throw std::runtime_error("GetGrid<X|Y|Z> coordinates not yet implemented for Python BMI adapter for grid type "+grid_type);
                 }
 
             }
@@ -721,7 +721,7 @@ namespace models {
              */
             inline void separate_package_and_simple_name() {
                 if (!model_initialized) {
-                    std::vector<string> split_name;
+                    std::vector<std::string> split_name;
                     std::string delimiter = ".";
                     std::string name_string = bmi_type_py_full_name;
 
@@ -737,7 +737,7 @@ namespace models {
                                                  + "'; expected format is <python_module>.<python_class>");
                     }
                     // What's left should be the class name
-                    bmi_type_py_class_name = make_shared<string>(name_string);
+                    bmi_type_py_class_name = std::make_shared<std::string>(name_string);
                     //split_name.pop_back();
                     // And then the split name should contain the module
                     // TODO: going to need to look at this again in the future; right now, assuming the format
@@ -745,7 +745,7 @@ namespace models {
                     //  module, but the current logic is going to interpret any complex parent module name as a single
                     //  top-level namespace package; e.g., ngen.namespacepackage.model works if ngen.namespacepackage is
                     //  a namespace package, but there would be problems with something like ngenpkg.innermodule1.model.
-                    bmi_type_py_module_name = make_shared<string>(boost::algorithm::join(split_name, delimiter));
+                    bmi_type_py_module_name = std::make_shared<std::string>(boost::algorithm::join(split_name, delimiter));
                 }
             }
 

--- a/include/realizations/catchment/Bmi_Py_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Py_Formulation.hpp
@@ -23,9 +23,9 @@ namespace realization {
 
         Bmi_Py_Formulation(std::string id, std::shared_ptr<data_access::GenericDataProvider> forcing, utils::StreamHandler output_stream);
 
-        const vector<string> get_bmi_input_variables() override;
+        const std::vector<std::string> get_bmi_input_variables() override;
 
-        const vector<string> get_bmi_output_variables() override;
+        const std::vector<std::string> get_bmi_output_variables() override;
 
         std::string get_formulation_type() override;
 
@@ -51,7 +51,7 @@ namespace realization {
          * @param timestep The time step for which data is desired.
          * @return A delimited string with all the output variable values for the given time step.
          */
-        string get_output_line_for_timestep(int timestep, std::string delimiter) override;
+        std::string get_output_line_for_timestep(int timestep, std::string delimiter) override;
 
         /**
          * Get the model response for a time step.
@@ -89,19 +89,19 @@ namespace realization {
          */
         double get_response(time_step_t t_index, time_step_t t_delta) override;
 
-        bool is_bmi_input_variable(const string &var_name) override;
+        bool is_bmi_input_variable(const std::string &var_name) override;
 
-        bool is_bmi_output_variable(const string &var_name) override;
+        bool is_bmi_output_variable(const std::string &var_name) override;
 
     protected:
 
-        shared_ptr<models::bmi::Bmi_Py_Adapter> construct_model(const geojson::PropertyMap &properties) override;
+        std::shared_ptr<models::bmi::Bmi_Py_Adapter> construct_model(const geojson::PropertyMap &properties) override;
 
         time_t convert_model_time(const double &model_time) override;
 
-        double get_var_value_as_double(const string &var_name) override;
+        double get_var_value_as_double(const std::string &var_name) override;
 
-        double get_var_value_as_double(const int &index, const string &var_name) override;
+        double get_var_value_as_double(const int &index, const std::string &var_name) override;
 
         /**
          * Test whether backing model has run BMI ``Initialize``.

--- a/include/realizations/catchment/State_Exception.hpp
+++ b/include/realizations/catchment/State_Exception.hpp
@@ -4,8 +4,6 @@
 #include <exception>
 #include <utility>
 
-using namespace std;
-
 namespace models {
     namespace external {
 

--- a/include/routing/Routing_Params.h
+++ b/include/routing/Routing_Params.h
@@ -1,7 +1,7 @@
-//#ifndef ROUTING_PARAMS
-//#define ROUTING_PARAMS
+#ifndef NGEN_ROUTING_ROUTING_PARAMS
+#define NGEN_ROUTING_ROUTING_PARAMS
 
-using namespace std;
+#include <string>
 
 /**
  * @brief routing_params providing configuration information for routing.
@@ -28,4 +28,4 @@ struct routing_params
 };
 
 
-//#endif // ROUTING_PARAMS
+#endif // NGEN_ROUTING_ROUTING_PARAMS

--- a/include/simulation_time/Simulation_Time.h
+++ b/include/simulation_time/Simulation_Time.h
@@ -4,8 +4,6 @@
 #include <ctime>
 #include <time.h>
 
-using namespace std;
-
 /**
  * @brief simulation_time_params providing configuration information for simulation time period.
  */

--- a/include/utilities/ExternalIntegrationException.hpp
+++ b/include/utilities/ExternalIntegrationException.hpp
@@ -4,8 +4,6 @@
 #include <exception>
 #include <utility>
 
-using namespace std;
-
 namespace external {
     /**
          * Custom exception indicating a problem when integrating with some external component.
@@ -13,7 +11,7 @@ namespace external {
          * Custom exception for indicating that the framework encountered a problem interoperating with some type of
          * external component with which it should be integrated.
          */
-    class ExternalIntegrationException : public exception {
+    class ExternalIntegrationException : public std::exception {
 
     public:
 

--- a/include/utilities/ExternalIntegrationException.hpp
+++ b/include/utilities/ExternalIntegrationException.hpp
@@ -15,7 +15,7 @@ namespace external {
 
     public:
 
-        ExternalIntegrationException(char const *const message) noexcept : ExternalIntegrationException(string(message)) {}
+        ExternalIntegrationException(char const *const message) noexcept : ExternalIntegrationException(std::string(message)) {}
 
         ExternalIntegrationException(std::string message) noexcept : std::exception(), what_message(std::move(message)) {}
 

--- a/include/utilities/parallel_utils.h
+++ b/include/utilities/parallel_utils.h
@@ -27,8 +27,6 @@
 #include "python/HydrofabricSubsetter.hpp"
 #endif // ACTIVATE_PYTHON
 
-using namespace std;
-
 namespace parallel {
 
     /**
@@ -469,8 +467,8 @@ namespace parallel {
      * @param partitionConfigFile The path to distributed processing hydrofabric partitioning config.
      * @return Whether subdividing was successful.
      */
-    bool subdivide_hydrofabric(int mpi_rank, int mpi_num_procs, const string &catchmentDataFile,
-                               const string &nexusDataFile, const string &partitionConfigFile)
+    bool subdivide_hydrofabric(int mpi_rank, int mpi_num_procs, const std::string &catchmentDataFile,
+                               const std::string &nexusDataFile, const std::string &partitionConfigFile)
     {
         // Track whether things are good, meaning ok to continue and, at the end, whether successful
         // Start with a value of true

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -79,8 +79,8 @@ int main(int argc, char *argv[]) {
     //arg 7 is the partition file path
     //arg 8 is an optional flag that driver should, if not already preprocessed this way, subdivided the hydrofabric
 
-    std::vector<string> catchment_subset_ids;
-    std::vector<string> nexus_subset_ids;
+    std::vector<std::string> catchment_subset_ids;
+    std::vector<std::string> nexus_subset_ids;
 
     if( argc < 2) {
         // Usage
@@ -91,8 +91,8 @@ int main(int argc, char *argv[]) {
                   << "Use \"all\" as explicit argument when no subset is needed." << std::endl;
 
         // Build and environment information
-        cout<<std::endl<<"Build Info:"<<std::endl;
-        cout<<"  NGen version: " // This is here mainly so that there will be *some* output if somehow no other options are enabled.
+        std::cout<<std::endl<<"Build Info:"<<std::endl;
+        std::cout<<"  NGen version: " // This is here mainly so that there will be *some* output if somehow no other options are enabled.
           << ngen_VERSION_MAJOR << "."
           << ngen_VERSION_MINOR << "."
           << ngen_VERSION_PATCH << std::endl;
@@ -100,32 +100,32 @@ int main(int argc, char *argv[]) {
         cout<<"  Parallel build"<<std::endl;
         #endif
         #ifdef NETCDF_ACTIVE
-        cout<<"  NetCDF lumped forcing enabled"<<std::endl;
+        std::cout<<"  NetCDF lumped forcing enabled"<<std::endl;
         #endif
         #ifdef NGEN_BMI_FORTRAN_ACTIVE
-        cout<<"  Fortran BMI enabled"<<std::endl;
+        std::cout<<"  Fortran BMI enabled"<<std::endl;
         #endif
         #ifdef NGEN_C_LIB_ACTIVE
         cout<<"  C BMI enabled"<<std::endl;
         #endif
         #ifdef ACTIVATE_PYTHON
-        cout<<"  Python active"<<std::endl;
-        cout<<"    Embedded interpreter version: "<<PY_MAJOR_VERSION<<"."<<PY_MINOR_VERSION<<"."<<PY_MICRO_VERSION<<std::endl;
+        std::cout<<"  Python active"<<std::endl;
+        std::cout<<"    Embedded interpreter version: "<<PY_MAJOR_VERSION<<"."<<PY_MINOR_VERSION<<"."<<PY_MICRO_VERSION<<std::endl;
         #endif
         #ifdef NGEN_ROUTING_ACTIVE
-        cout<<"  Routing active"<<std::endl;
+        std::cout<<"  Routing active"<<std::endl;
         #endif
         #ifdef ACTIVATE_PYTHON
-        cout<<std::endl<<"Python Environment Info:"<<std::endl;
-        cout<<"  VIRTUAL_ENV environment variable: "<<(std::getenv("VIRTUAL_ENV") == nullptr ? "(not set)" : std::getenv("VIRTUAL_ENV"))<<std::endl;
-        cout<<"  Discovered venv: "<<_interp->getDiscoveredVenvPath()<<std::endl;
+        std::cout<<std::endl<<"Python Environment Info:"<<std::endl;
+        std::cout<<"  VIRTUAL_ENV environment variable: "<<(std::getenv("VIRTUAL_ENV") == nullptr ? "(not set)" : std::getenv("VIRTUAL_ENV"))<<std::endl;
+        std::cout<<"  Discovered venv: "<<_interp->getDiscoveredVenvPath()<<std::endl;
         auto paths = _interp->getSystemPath();
-        cout<<"  System paths:"<<std::endl;
+        std::cout<<"  System paths:"<<std::endl;
         for(std::string& path: std::get<1>(paths)){
-          cout<<"    "<<path<<std::endl;
+          std::cout<<"    "<<path<<std::endl;
         }
         #endif
-        cout<<std::endl;
+        std::cout<<std::endl;
         exit(0); // Unsure if this path should have a non-zero exit code?
     } else if( argc < 6) {
         std::cout << "Missing required args:" << std::endl;
@@ -342,7 +342,7 @@ int main(int argc, char *argv[]) {
         //std::cout<<"Running cat "<<id<<std::endl;
         auto r = features.catchment_at(id);
         //TODO redesign to avoid this cast
-        auto r_c = dynamic_pointer_cast<realization::Catchment_Formulation>(r);
+        auto r_c = std::dynamic_pointer_cast<realization::Catchment_Formulation>(r);
         double response = r_c->get_response(output_time_index, 3600.0);
         std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
                              r_c->get_output_line_for_timestep(output_time_index)+"\n";

--- a/src/realizations/catchment/Bmi_C_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_C_Adapter.cpp
@@ -19,7 +19,7 @@ using namespace models::bmi;
  * @param registration_func The name for the @see bmi_registration_function.
  * @param output The output stream handler.
  */
-Bmi_C_Adapter::Bmi_C_Adapter(const string &type_name, std::string library_file_path, std::string forcing_file_path,
+Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string forcing_file_path,
                              bool allow_exceed_end, bool has_fixed_time_step,
                              const std::string& registration_func, utils::StreamHandler output)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), "", std::move(forcing_file_path),
@@ -38,7 +38,7 @@ Bmi_C_Adapter::Bmi_C_Adapter(const string &type_name, std::string library_file_p
  * @param registration_func The name for the @see bmi_registration_function.
  * @param output The output stream handler.
  */
-Bmi_C_Adapter::Bmi_C_Adapter(const string &type_name, std::string library_file_path, std::string bmi_init_config,
+Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                              std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                              std::string registration_func, utils::StreamHandler output)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
@@ -67,7 +67,7 @@ Bmi_C_Adapter::Bmi_C_Adapter(const string &type_name, std::string library_file_p
  * @param output The output stream handler.
  * @param do_initialization Whether initialization should be performed during construction or deferred.
  */
-Bmi_C_Adapter::Bmi_C_Adapter(const string &type_name, std::string library_file_path, std::string bmi_init_config,
+Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                              std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                              std::string registration_func, utils::StreamHandler output, bool do_initialization)
                              : AbstractCLibBmiAdapter<C_Bmi>(type_name, library_file_path, std::move(bmi_init_config), std::move(forcing_file_path), allow_exceed_end,
@@ -96,7 +96,7 @@ Bmi_C_Adapter::Bmi_C_Adapter(const string &type_name, std::string library_file_p
             model_initialized = true;
             throw e;
         }
-        catch (exception& e) {
+        catch (std::exception& e) {
             // Make sure this is set to 'true' after this function call finishes
             model_initialized = true;
             throw e;
@@ -135,7 +135,7 @@ Bmi_C_Adapter::Bmi_C_Adapter(Bmi_C_Adapter &adapter) : model_name(adapter.model_
 
 Bmi_C_Adapter::Bmi_C_Adapter(Bmi_C_Adapter &&adapter) noexcept : AbstractCLibBmiAdapter<C_Bmi>(std::move(adapter)) { }
 
-string Bmi_C_Adapter::GetComponentName() {
+std::string Bmi_C_Adapter::GetComponentName() {
     char component_name[BMI_MAX_COMPONENT_NAME];
     if (bmi_model->get_component_name(bmi_model.get(), component_name) != BMI_SUCCESS) {
         throw std::runtime_error(model_name + " failed to get model component name.");
@@ -267,7 +267,7 @@ std::string Bmi_C_Adapter::GetGridType(int grid_id) {
     char gridtype_c_str[BMI_MAX_TYPE_NAME];
     int success = bmi_model->get_grid_type(bmi_model.get(), grid_id, gridtype_c_str);
     if (success != BMI_SUCCESS) {
-        throw std::runtime_error(model_name + " failed to get grid type for grid ID " + to_string(grid_id) + ".");
+        throw std::runtime_error(model_name + " failed to get grid type for grid ID " + std::to_string(grid_id) + ".");
     }
     return std::string(gridtype_c_str);
 }
@@ -276,7 +276,7 @@ int Bmi_C_Adapter::GetGridRank(int grid_id) {
     int gridrank;
     int success = bmi_model->get_grid_rank(bmi_model.get(), grid_id, &gridrank);
     if (success != BMI_SUCCESS) {
-        throw std::runtime_error(model_name + " failed to get grid rank for grid ID " + to_string(grid_id) + ".");
+        throw std::runtime_error(model_name + " failed to get grid rank for grid ID " + std::to_string(grid_id) + ".");
     }
     return gridrank;
 }
@@ -285,7 +285,7 @@ int Bmi_C_Adapter::GetGridSize(int grid_id) {
     int gridsize;
     int success = bmi_model->get_grid_size(bmi_model.get(), grid_id, &gridsize);
     if (success != BMI_SUCCESS) {
-        throw std::runtime_error(model_name + " failed to get grid size for grid ID " + to_string(grid_id) + ".");
+        throw std::runtime_error(model_name + " failed to get grid size for grid ID " + std::to_string(grid_id) + ".");
     }
     return gridsize;
 }

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -188,7 +188,7 @@ bool Bmi_C_Formulation::is_bmi_input_variable(const std::string &var_name) {
     return std::any_of(names.cbegin(), names.cend(), [var_name](const std::string &s){ return var_name == s; });
 }
 
-bool Bmi_C_Formulation::is_bmi_output_variable(const string &var_name) {
+bool Bmi_C_Formulation::is_bmi_output_variable(const std::string &var_name) {
     const std::vector<std::string> names = get_bmi_model()->GetOutputVarNames();
     return std::any_of(names.cbegin(), names.cend(), [var_name](const std::string &s){ return var_name == s; });
 }

--- a/src/realizations/catchment/Bmi_Cpp_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_Cpp_Adapter.cpp
@@ -48,7 +48,7 @@ Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string libra
             throw e;
         }
         catch (...) {
-            const std::exception_ptr& e = current_exception();
+            const std::exception_ptr& e = std::current_exception();
             // Make sure this is set to 'true' after this function call finishes
             //TODO: This construct may not be necessary for the C++ adapter because the shared_ptr has a lambda set up to destroy the model?
             model_initialized = true;

--- a/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
@@ -187,7 +187,7 @@ bool Bmi_Cpp_Formulation::is_bmi_input_variable(const std::string &var_name) {
     return std::any_of(names.cbegin(), names.cend(), [var_name](const std::string &s){ return var_name == s; });
 }
 
-bool Bmi_Cpp_Formulation::is_bmi_output_variable(const string &var_name) {
+bool Bmi_Cpp_Formulation::is_bmi_output_variable(const std::string &var_name) {
     const std::vector<std::string> names = get_bmi_model()->GetOutputVarNames();
     return std::any_of(names.cbegin(), names.cend(), [var_name](const std::string &s){ return var_name == s; });
 }

--- a/src/realizations/catchment/Bmi_Fortran_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Adapter.cpp
@@ -3,7 +3,7 @@
 
 using namespace models::bmi;
 
-string Bmi_Fortran_Adapter::GetComponentName() {
+std::string Bmi_Fortran_Adapter::GetComponentName() {
     char component_name[BMI_MAX_COMPONENT_NAME];
     if (get_component_name(&bmi_model->handle, component_name) != BMI_SUCCESS) {
         throw std::runtime_error(model_name + " failed to get model component name.");
@@ -126,7 +126,7 @@ int Bmi_Fortran_Adapter::GetVarGrid(std::string name) {
 std::string Bmi_Fortran_Adapter::GetGridType(int grid_id) {
     char gridtype_c_str[BMI_MAX_TYPE_NAME];
     if (get_grid_type(&bmi_model->handle, &grid_id, gridtype_c_str) != BMI_SUCCESS) {
-        throw std::runtime_error(model_name + " failed to get grid type for grid ID " + to_string(grid_id) + ".");
+        throw std::runtime_error(model_name + " failed to get grid type for grid ID " + std::to_string(grid_id) + ".");
     }
     return std::string(gridtype_c_str);
 }
@@ -134,7 +134,7 @@ std::string Bmi_Fortran_Adapter::GetGridType(int grid_id) {
 int Bmi_Fortran_Adapter::GetGridRank(int grid_id) {
     int gridrank;
     if (get_grid_rank(&bmi_model->handle, &grid_id, &gridrank) != BMI_SUCCESS) {
-        throw std::runtime_error(model_name + " failed to get grid rank for grid ID " + to_string(grid_id) + ".");
+        throw std::runtime_error(model_name + " failed to get grid rank for grid ID " + std::to_string(grid_id) + ".");
     }
     return gridrank;
 }
@@ -142,7 +142,7 @@ int Bmi_Fortran_Adapter::GetGridRank(int grid_id) {
 int Bmi_Fortran_Adapter::GetGridSize(int grid_id) {
     int gridsize;
     if (get_grid_size(&bmi_model->handle, &grid_id, &gridsize) != BMI_SUCCESS) {
-        throw std::runtime_error(model_name + " failed to get grid size for grid ID " + to_string(grid_id) + ".");
+        throw std::runtime_error(model_name + " failed to get grid size for grid ID " + std::to_string(grid_id) + ".");
     }
     return gridsize;
 }

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -45,11 +45,11 @@ std::string Bmi_Fortran_Formulation::get_formulation_type() {
     return "bmi_fortran";
 }
 
-double Bmi_Fortran_Formulation::get_var_value_as_double(const string &var_name) {
+double Bmi_Fortran_Formulation::get_var_value_as_double(const std::string &var_name) {
     return get_var_value_as_double(0, var_name);
 }
 
-double Bmi_Fortran_Formulation::get_var_value_as_double(const int &index, const string &var_name) {
+double Bmi_Fortran_Formulation::get_var_value_as_double(const int &index, const std::string &var_name) {
     // TODO: consider different way of handling (and how to document) cases like long double or unsigned long long that
     //  don't fit or might convert inappropriately
     std::string type = get_bmi_model()->GetVarType(var_name);
@@ -92,7 +92,7 @@ double Bmi_Fortran_Formulation::get_var_value_as_double(const int &index, const 
     " as double: no logic for converting variable type " + type);
 }
 
-string Bmi_Fortran_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
+std::string Bmi_Fortran_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
     // TODO: something must be added to store values if more than the current time step is wanted
     // TODO: if such a thing is added, it should probably be configurable to turn it off
 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -74,12 +74,12 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             #endif // ACTIVATE_PYTHON
         }
         if (inactive_type_requested) {
-            throw runtime_error(
+            throw std::runtime_error(
                     get_formulation_type() + " could not initialize sub formulation of type " + type_name +
                     " due to support for this type not being activated.");
         }
         if (module == nullptr) {
-            throw runtime_error(get_formulation_type() + " received unexpected subtype formulation " + type_name);
+            throw std::runtime_error(get_formulation_type() + " received unexpected subtype formulation " + type_name);
         }
         modules[i] = module;
 
@@ -180,7 +180,7 @@ const bool &Bmi_Multi_Formulation::get_allow_model_exceed_end_time() const {
  * @see ForcingProvider
  */
 //const vector<std::string> &Bmi_Multi_Formulation::get_available_forcing_outputs() {
-const vector<std::string> &Bmi_Multi_Formulation::get_available_variable_names() {
+const std::vector<std::string> &Bmi_Multi_Formulation::get_available_variable_names() {
     if (is_model_initialized() && available_forcings.empty()) {
         for (const nested_module_ptr &module: modules) {
             for (const std::string &out_var_name: module->get_bmi_output_variables()) {
@@ -213,17 +213,17 @@ const time_t &Bmi_Multi_Formulation::get_bmi_model_start_time_forcing_offset_s()
  * @return Either the translated equivalent variable name, or the provided name if there is not a mapping entry.
  * @see get_config_mapped_variable_name(string, shared_ptr, shared_ptr)
  */
-const string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const string &model_var_name) {
+const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const std::string &model_var_name) {
     return get_config_mapped_variable_name(model_var_name, true, true);
 }
 
-const string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const string &model_var_name, bool check_first,
+const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const std::string &model_var_name, bool check_first,
                                                                      bool check_last)
 {
     if (check_first) {
         // If an input var in first module, see if we get back a mapping (i.e., not the same thing), and return if so
         if (modules[0]->is_bmi_input_variable(model_var_name)) {
-            const string &mapped_name = modules[0]->get_config_mapped_variable_name(model_var_name);
+            const std::string &mapped_name = modules[0]->get_config_mapped_variable_name(model_var_name);
             if (mapped_name != model_var_name)
                 return mapped_name;
         }
@@ -261,19 +261,19 @@ const string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const strin
  * @param in_module The module needing a translation of ``output_var_name`` to one of its input variable names.
  * @return Either the translated equivalent variable name, or the provided name if there is not a mapping entry.
  */
-const string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const string &output_var_name,
+const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const std::string &output_var_name,
                                                                      const shared_ptr<Bmi_Formulation>& out_module,
                                                                      const shared_ptr<Bmi_Formulation>& in_module)
 {
     if (!out_module->is_bmi_output_variable(output_var_name))
         return output_var_name;
 
-    const string &mapped_output = out_module->get_config_mapped_variable_name(output_var_name);
+    const std::string &mapped_output = out_module->get_config_mapped_variable_name(output_var_name);
     if (in_module->is_bmi_input_variable(mapped_output))
         return mapped_output;
 
-    for (const string &s : in_module->get_bmi_input_variables()) {
-        const string &mapped_s = in_module->get_config_mapped_variable_name(s);
+    for (const std::string &s : in_module->get_bmi_input_variables()) {
+        const std::string &mapped_s = in_module->get_config_mapped_variable_name(s);
         if (mapped_s == output_var_name || mapped_s == mapped_output)
             return mapped_s;
     }
@@ -281,11 +281,11 @@ const string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const strin
 }
 
 // TODO: remove from this level - it belongs (perhaps) as part of the ForcingProvider interface, but is general to it
-const string &Bmi_Multi_Formulation::get_forcing_file_path() const {
+const std::string &Bmi_Multi_Formulation::get_forcing_file_path() const {
     return modules[0]->get_forcing_file_path();
 }
 
-string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
+std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
     // TODO: have to do some figuring out to make sure this isn't ambiguous (i.e., same output var name from two modules)
     // TODO: need to verify that output variable names are valid, or else warn and return default
 
@@ -412,11 +412,11 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
         return get_module_var_value_as_double<Bmi_Py_Formulation>(get_bmi_main_output_var(), modules[index]);
     }
     #endif // ACTIVATE_PYTHON
-    throw runtime_error(get_formulation_type() + " unimplemented type " + module_types[index] +
+    throw std::runtime_error(get_formulation_type() + " unimplemented type " + module_types[index] +
                         " in get_response for main return value");
 }
 
-bool Bmi_Multi_Formulation::is_bmi_input_variable(const string &var_name) {
+bool Bmi_Multi_Formulation::is_bmi_input_variable(const std::string &var_name) {
     return modules[0]->is_bmi_input_variable(var_name);
 }
 
@@ -425,7 +425,7 @@ bool Bmi_Multi_Formulation::is_bmi_model_time_step_fixed() {
                        [](const std::shared_ptr<Bmi_Formulation>& m) { return m->is_bmi_model_time_step_fixed(); });
 }
 
-bool Bmi_Multi_Formulation::is_bmi_output_variable(const string &var_name) {
+bool Bmi_Multi_Formulation::is_bmi_output_variable(const std::string &var_name) {
     return modules.back()->is_bmi_output_variable(var_name);
 }
 

--- a/src/realizations/catchment/Bmi_Py_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_Py_Adapter.cpp
@@ -6,16 +6,15 @@
 #include "Bmi_Py_Adapter.hpp"
 
 using namespace models::bmi;
-using namespace std;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality
 
-Bmi_Py_Adapter::Bmi_Py_Adapter(const string &type_name, string bmi_init_config, const string &bmi_python_type,
+Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
                                bool allow_exceed_end, bool has_fixed_time_step, utils::StreamHandler output)
         : Bmi_Py_Adapter(type_name, std::move(bmi_init_config), bmi_python_type, "", allow_exceed_end, has_fixed_time_step,
                          std::move(output)) {}
 
-Bmi_Py_Adapter::Bmi_Py_Adapter(const string &type_name, string bmi_init_config, const string &bmi_python_type,
-                               string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
+                               std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                                utils::StreamHandler output)
         : Bmi_Adapter<py::object>(type_name + " (BMI Py)", std::move(bmi_init_config),
                                   std::move(forcing_file_path), allow_exceed_end, has_fixed_time_step,
@@ -34,14 +33,14 @@ Bmi_Py_Adapter::Bmi_Py_Adapter(const string &type_name, string bmi_init_config, 
         throw e;
     }
     // Record the exception message before re-throwing to handle subsequent function calls properly
-    catch (exception &e) {
+    catch (std::exception &e) {
         // Make sure this is set to 'true' after this function call finishes
         model_initialized = true;
         throw e;
     }
 }
 
-string Bmi_Py_Adapter::GetComponentName() {
+std::string Bmi_Py_Adapter::GetComponentName() {
     return py::str(bmi_model->attr("get_component_name")());
 }
 
@@ -59,12 +58,12 @@ int Bmi_Py_Adapter::GetInputItemCount() {
     return py::int_(bmi_model->attr("get_input_item_count")());
 }
 
-vector<string> Bmi_Py_Adapter::GetInputVarNames() {
-    vector<string> in_var_names(GetInputItemCount());
+std::vector<std::string> Bmi_Py_Adapter::GetInputVarNames() {
+    std::vector<std::string> in_var_names(GetInputItemCount());
     py::tuple in_var_names_tuple = bmi_model->attr("get_input_var_names")();
     int i = 0;
     for (auto && tuple_item : in_var_names_tuple) {
-        string var_name = py::str(tuple_item);
+        std::string var_name = py::str(tuple_item);
         in_var_names[i++] = var_name;
     }
     return in_var_names;
@@ -74,12 +73,12 @@ int Bmi_Py_Adapter::GetOutputItemCount() {
     return py::int_(bmi_model->attr("get_output_item_count")());
 }
 
-vector<string> Bmi_Py_Adapter::GetOutputVarNames() {
-    vector<string> out_var_names(GetOutputItemCount());
+std::vector<std::string> Bmi_Py_Adapter::GetOutputVarNames() {
+    std::vector<std::string> out_var_names(GetOutputItemCount());
     py::tuple out_var_names_tuple = bmi_model->attr("get_output_var_names")();
     int i = 0;
     for (auto && tuple_item : out_var_names_tuple) {
-        string var_name = py::str(tuple_item);
+        std::string var_name = py::str(tuple_item);
         out_var_names[i++] = var_name;
     }
     return out_var_names;
@@ -90,7 +89,7 @@ double Bmi_Py_Adapter::GetStartTime() {
     return py::float_(bmi_model->attr("get_start_time")());
 }
 
-string Bmi_Py_Adapter::GetTimeUnits() {
+std::string Bmi_Py_Adapter::GetTimeUnits() {
     return py::str(bmi_model->attr("get_time_units")());
 }
 
@@ -98,15 +97,15 @@ double Bmi_Py_Adapter::GetTimeStep() {
     return py::float_(bmi_model->attr("get_time_step")());
 }
 
-void Bmi_Py_Adapter::GetValue(string name, void *dest) {
-    string cxx_type;
+void Bmi_Py_Adapter::GetValue(std::string name, void *dest) {
+    std::string cxx_type;
     try {
         cxx_type = get_analogous_cxx_type(GetVarType(name), GetVarItemsize(name));
     }
-    catch (runtime_error &e) {
-        string msg = "Encountered error getting C++ type during call to GetValue: \n";
+    catch (std::runtime_error &e) {
+        std::string msg = "Encountered error getting C++ type during call to GetValue: \n";
         msg += e.what();
-        throw runtime_error(msg);
+        throw std::runtime_error(msg);
     }
 
     if (cxx_type == "short") {
@@ -124,14 +123,14 @@ void Bmi_Py_Adapter::GetValue(string name, void *dest) {
     } else if (cxx_type == "long double") {
         copy_to_array<long double>(name, (long double *) dest);
     } else {
-        throw runtime_error("Bmi_Py_Adapter can't get value of unsupported type: " + cxx_type);
+        throw std::runtime_error("Bmi_Py_Adapter can't get value of unsupported type: " + cxx_type);
     }
 
 }
 
 void Bmi_Py_Adapter::GetValueAtIndices(std::string name, void *dest, int *inds, int count) {
-    string val_type = GetVarType(name);
-    vector<string> in_v = GetInputVarNames();
+    std::string val_type = GetVarType(name);
+    std::vector<std::string> in_v = GetInputVarNames();
     int var_total_items = GetVarNbytes(name) / GetVarItemsize(name);
     get_value_at_indices(name, dest, inds, count, count == var_total_items);
 }
@@ -149,7 +148,7 @@ int Bmi_Py_Adapter::GetVarItemsize(std::string name) {
     return py::int_(bmi_model->attr("get_var_itemsize")(name));
 }
 
-string Bmi_Py_Adapter::GetVarLocation(std::string name) {
+std::string Bmi_Py_Adapter::GetVarLocation(std::string name) {
     return py::str(bmi_model->attr("get_var_location")(name));
 }
 
@@ -157,11 +156,11 @@ int Bmi_Py_Adapter::GetVarNbytes(std::string name) {
     return py::int_(bmi_model->attr("get_var_nbytes")(name));
 }
 
-string Bmi_Py_Adapter::GetVarType(std::string name) {
+std::string Bmi_Py_Adapter::GetVarType(std::string name) {
     return py::str(bmi_model->attr("get_var_type")(name));
 }
 
-string Bmi_Py_Adapter::GetVarUnits(std::string name) {
+std::string Bmi_Py_Adapter::GetVarUnits(std::string name) {
     return py::str(bmi_model->attr("get_var_units")(name));
 }
 
@@ -191,7 +190,7 @@ std::string Bmi_Py_Adapter::get_bmi_type_simple_name() const {
  * @see set_value_at_indices
  */
 void Bmi_Py_Adapter::SetValueAtIndices(std::string name, int *inds, int count, void *src) {
-    string val_type = GetVarType(name);
+    std::string val_type = GetVarType(name);
     size_t val_item_size = (size_t)GetVarItemsize(name);
 
     // The available types and how they are handled here should match what is in get_value_at_indices
@@ -212,7 +211,7 @@ void Bmi_Py_Adapter::SetValueAtIndices(std::string name, int *inds, int count, v
     } else if (val_type == "float" && val_item_size == sizeof(long double)) {
         set_value_at_indices<long double>(name, inds, count, src, val_type);
     } else {
-        throw runtime_error(
+        throw std::runtime_error(
                 "(Bmi_Py_Adapter) Failed attempt to SET values of BMI variable '" + name + "' from '" +
                 model_name + "' model:  model advertises unsupported combination of type (" + val_type +
                 ") and size (" + std::to_string(val_item_size) + ").");

--- a/src/realizations/catchment/Bmi_Py_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Py_Formulation.cpp
@@ -36,11 +36,11 @@ time_t realization::Bmi_Py_Formulation::convert_model_time(const double &model_t
     return (time_t) (get_bmi_model()->convert_model_time_to_seconds(model_time));
 }
 
-const vector<string> Bmi_Py_Formulation::get_bmi_input_variables() {
+const std::vector<std::string> Bmi_Py_Formulation::get_bmi_input_variables() {
     return get_bmi_model()->GetInputVarNames();
 }
 
-const vector<string> Bmi_Py_Formulation::get_bmi_output_variables() {
+const std::vector<std::string> Bmi_Py_Formulation::get_bmi_output_variables() {
     return get_bmi_model()->GetOutputVarNames();
 }
 
@@ -48,7 +48,7 @@ std::string Bmi_Py_Formulation::get_formulation_type() {
     return "bmi_py";
 }
 
-string Bmi_Py_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
+std::string Bmi_Py_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
     // TODO: something must be added to store values if more than the current time step is wanted
     // TODO: if such a thing is added, it should probably be configurable to turn it off
     if (timestep != (next_time_step_index - 1)) {
@@ -113,12 +113,12 @@ double Bmi_Py_Formulation::get_response(time_step_t t_index, time_step_t t_delta
     return get_var_value_as_double( get_bmi_main_output_var());
 }
 
-double Bmi_Py_Formulation::get_var_value_as_double(const string &var_name) {
+double Bmi_Py_Formulation::get_var_value_as_double(const std::string &var_name) {
     return get_var_value_as_double(0, var_name);
 }
 
-double Bmi_Py_Formulation::get_var_value_as_double(const int &index, const string &var_name) {
-    string val_type = get_bmi_model()->GetVarType(var_name);
+double Bmi_Py_Formulation::get_var_value_as_double(const int &index, const std::string &var_name) {
+    std::string val_type = get_bmi_model()->GetVarType(var_name);
     size_t val_item_size = (size_t)get_bmi_model()->GetVarItemsize(var_name);
 
     //void *dest;
@@ -168,12 +168,12 @@ double Bmi_Py_Formulation::get_var_value_as_double(const int &index, const strin
     " as double: no logic for converting variable type " + val_type);
 }
 
-bool Bmi_Py_Formulation::is_bmi_input_variable(const string &var_name) {
+bool Bmi_Py_Formulation::is_bmi_input_variable(const std::string &var_name) {
     const std::vector<std::string> names = get_bmi_model()->GetInputVarNames();
     return std::any_of(names.cbegin(), names.cend(), [var_name](const std::string &s){ return var_name == s; });
 }
 
-bool Bmi_Py_Formulation::is_bmi_output_variable(const string &var_name) {
+bool Bmi_Py_Formulation::is_bmi_output_variable(const std::string &var_name) {
     const std::vector<std::string> names = get_bmi_model()->GetOutputVarNames();
     return std::any_of(names.cbegin(), names.cend(), [var_name](const std::string &s){ return var_name == s; });
 }

--- a/test/forcing/OptionalWrappedDataProvider_Test.cpp
+++ b/test/forcing/OptionalWrappedDataProvider_Test.cpp
@@ -4,7 +4,6 @@
 #include "TrivialForcingProvider.hpp"
 #include "OptionalWrappedDataProvider.hpp"
 
-using namespace std;
 using namespace data_access;
 
 class OptionalWrappedDataProvider_Test : public ::testing::Test {
@@ -16,7 +15,7 @@ protected:
 
     test::TrivialForcingProvider backingProvider;
 
-    vector<OptionalWrappedDataProvider> providers;
+    std::vector<OptionalWrappedDataProvider> providers;
 
 };
 

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -10,7 +10,6 @@
 #define OUTPUT_VALUE_1 42.0
 #define OUTPUT_DEFAULT_1 36.8
 
-using namespace std;
 
 namespace data_access {
     namespace test {
@@ -53,12 +52,12 @@ namespace data_access {
                 return std::vector<double>(1, get_value(selector, m));
             }
 
-            bool is_property_sum_over_time_step(const string &name) override {
+            bool is_property_sum_over_time_step(const std::string &name) override {
                 return true;
             }
 
         private:
-            vector<string> outputs;
+            std::vector<std::string> outputs;
         };
     }
 }

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -73,7 +73,7 @@ protected:
         return formulation.get_model_type_name();
     }
 
-    static double get_friend_var_value_as_double(Bmi_C_Formulation& formulation, const string& var_name) {
+    static double get_friend_var_value_as_double(Bmi_C_Formulation& formulation, const std::string& var_name) {
         return formulation.get_var_value_as_double(var_name);
     }
 

--- a/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
@@ -71,7 +71,7 @@ protected:
         return formulation.get_model_type_name();
     }
 
-    static double get_friend_var_value_as_double(Bmi_Cpp_Formulation& formulation, const string& var_name) {
+    static double get_friend_var_value_as_double(Bmi_Cpp_Formulation& formulation, const std::string& var_name) {
         return formulation.get_var_value_as_double(var_name);
     }
 

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -71,7 +71,7 @@ protected:
         return formulation.get_model_type_name();
     }
 
-    static double get_friend_var_value_as_double(Bmi_Fortran_Formulation& formulation, const string& var_name) {
+    static double get_friend_var_value_as_double(Bmi_Fortran_Formulation& formulation, const std::string& var_name) {
         return formulation.get_var_value_as_double(var_name);
     }
 

--- a/test/realizations/catchments/Bmi_Py_Adapter_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Adapter_Test.cpp
@@ -185,7 +185,7 @@ void Bmi_Py_Adapter_Test::TearDownTestSuite() {
  * @param file_basename The basename of the desired file.
  * @return The path (as a string) of the first found existing file, or empty string of no existing file was found.
  */
-std::string Bmi_Py_Adapter_Test::file_search(const vector<std::string> &parent_dir_options, const string &file_basename) {
+std::string Bmi_Py_Adapter_Test::file_search(const std::vector<std::string> &parent_dir_options, const std::string &file_basename) {
     // Build vector of paths by building combinations of the path and basename options
     std::vector<std::string> path_possibilities(parent_dir_options.size());
     for (int i = 0; i < parent_dir_options.size(); ++i)
@@ -204,8 +204,8 @@ std::string Bmi_Py_Adapter_Test::file_search(const vector<std::string> &parent_d
  * @param file_basename The collection of possible basenames for a sought file.
  * @return The path (as a string) of the first found existing file, or empty string of no existing file was found.
  */
-std::string Bmi_Py_Adapter_Test::file_search(const vector<std::string> &parent_dir_options,
-                                             const vector<std::string> &file_basenames) {
+std::string Bmi_Py_Adapter_Test::file_search(const std::vector<std::string> &parent_dir_options,
+                                             const std::vector<std::string> &file_basenames) {
     std::string foundPathForBasename;
     for (const std::string &basename : file_basenames) {
         foundPathForBasename = file_search(parent_dir_options, basename);

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -79,7 +79,7 @@ protected:
         return formulation.get_model_type_name();
     }
 
-    static double get_friend_var_value_as_double(Bmi_Py_Formulation& formulation, const string& var_name) {
+    static double get_friend_var_value_as_double(Bmi_Py_Formulation& formulation, const std::string& var_name) {
         return formulation.get_var_value_as_double(var_name);
     }
 
@@ -303,7 +303,7 @@ void Bmi_Py_Formulation_Test::generate_realization_config(int ex_idx) {
  * @param file_basename The basename of the desired file.
  * @return The path (as a string) of the first found existing file, or empty string of no existing file was found.
  */
-std::string Bmi_Py_Formulation_Test::file_search(const vector<std::string> &parent_dir_options, const string &file_basename) {
+std::string Bmi_Py_Formulation_Test::file_search(const std::vector<std::string> &parent_dir_options, const std::string &file_basename) {
     // Build vector of paths by building combinations of the path and basename options
     std::vector<std::string> path_possibilities(parent_dir_options.size());
     for (int i = 0; i < parent_dir_options.size(); ++i)
@@ -322,8 +322,8 @@ std::string Bmi_Py_Formulation_Test::file_search(const vector<std::string> &pare
  * @param file_basename The collection of possible basenames for a sought file.
  * @return The path (as a string) of the first found existing file, or empty string of no existing file was found.
  */
-std::string Bmi_Py_Formulation_Test::file_search(const vector<std::string> &parent_dir_options,
-                                                 const vector<std::string> &file_basenames) {
+std::string Bmi_Py_Formulation_Test::file_search(const std::vector<std::string> &parent_dir_options,
+                                                 const std::vector<std::string> &file_basenames) {
     std::string foundPathForBasename;
     for (const std::string &basename : file_basenames) {
         foundPathForBasename = file_search(parent_dir_options, basename);


### PR DESCRIPTION
Using `using namespace std` is poor practice. Clean it out of the code base, other than instances in zombie code that's being deleted.

## Additions

- Name qualifications

## Removals

- Occurrences of `using namespace std`

## Notes

Instances in zombie code were left alone

## Todos

- Tests

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: