### PR TITLE
Strictly follow C++14 standard

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -166,7 +166,7 @@ runs:
           run: |
             export BOOST_ROOT="$(pwd)/boost_1_72_0"
             export CFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer"
-            export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer"
+            export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -pedantic-errors"
             . .venv/bin/activate
             [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} \

--- a/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
+++ b/extern/test_bmi_cpp/src/test_bmi_cpp.cpp
@@ -356,7 +356,7 @@ void TestBmiCpp::read_init_config(std::string config_file)
   if (fp == NULL)
     throw std::runtime_error("Invalid config file \""+config_file+"\"" SOURCE_LOC);
 
-  char config_line[max_config_line_length + 1];
+  std::vector<char> config_line(max_config_line_length + 1);
 
   // TODO: may need to add other variables to track that everything that was required was properly set
 
@@ -365,9 +365,9 @@ void TestBmiCpp::read_init_config(std::string config_file)
 
   for (size_t i = 0; i < config_line_count; i++) {
     char *param_key, *param_value;
-    fgets(config_line, max_config_line_length + 1, fp);
+    fgets(config_line.data(), max_config_line_length + 1, fp);
 
-    char* config_line_ptr = config_line;
+    char* config_line_ptr = config_line.data();
     config_line_ptr = strsep(&config_line_ptr, "\n");
     param_key = strsep(&config_line_ptr, "=");
     param_value = strsep(&config_line_ptr, "=");

--- a/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
@@ -675,7 +675,7 @@ namespace models {
 
                 // Must get the names from the model as an array of C strings
                 // The array can be on the stack ...
-                char* names_array[variableCount];
+                std::vector<char*> names_array(variableCount);
                 // ... but allocate the space for the individual C strings (i.e., the char * elements)
                 for (int i = 0; i < variableCount; i++) {
                     names_array[i] = static_cast<char *>(malloc(sizeof(char) * BMI_MAX_VAR_NAME));
@@ -684,10 +684,10 @@ namespace models {
                 // With the necessary char** in hand, get the names from the model
                 int names_result;
                 if (is_input_variables) {
-                    names_result = get_input_var_names(bmi_model.get(), names_array);
+                    names_result = get_input_var_names(bmi_model.get(), names_array.data());
                 }
                 else {
-                    names_result = get_output_var_names(bmi_model.get(), names_array);
+                    names_result = get_output_var_names(bmi_model.get(), names_array.data());
                 }
                 if (names_result != BMI_SUCCESS) {
                     throw std::runtime_error(model_name + " failed to get array of " + varType + " variables names.");

--- a/include/realizations/catchment/Bmi_Py_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Py_Adapter.hpp
@@ -389,8 +389,8 @@ namespace models {
              */
             int get_sum_of_grid_nodes_per_face(const int grid) {
                 int grid_node_face_count = GetGridFaceCount(grid);
-                int grid_nodes_per_face[grid_node_face_count];
-                GetGridNodesPerFace(grid, grid_nodes_per_face);
+                std::vector<int> grid_nodes_per_face(grid_node_face_count);
+                GetGridNodesPerFace(grid, grid_nodes_per_face.data());
                 int nodes_per_face_sum = 0;
                 for (int i = 0; i < grid_node_face_count; ++i)
                     nodes_per_face_sum += grid_nodes_per_face[i];
@@ -702,8 +702,8 @@ namespace models {
                 std::string grid_type = GetGridType(grid);
                 if( grid_type == "uniform_rectilinear" || grid_type == "rectilinear"){
                     int rank = GetGridRank(grid);
-                    int shape[rank];
-                    GetGridShape(grid, shape);
+                    std::vector<int> shape(rank);
+                    GetGridShape(grid, shape.data());
                     get_and_copy_grid_array<double>(name, grid, dest, shape[rank-index-1], "float");
                     return;
                 }else{

--- a/src/realizations/catchment/Bmi_C_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_C_Adapter.cpp
@@ -308,8 +308,7 @@ std::shared_ptr<std::vector<std::string>> Bmi_C_Adapter::inner_get_variable_name
             std::vector<std::string>(variableCount));
 
     // Must get the names from the model as an array of C strings
-    // The array can be on the stack ...
-    char* names_array[variableCount];
+    std::vector<char*> names_array(variableCount);
     // ... but allocate the space for the individual C strings (i.e., the char * elements)
     for (int i = 0; i < variableCount; i++) {
         names_array[i] = static_cast<char *>(malloc(sizeof(char) * BMI_MAX_VAR_NAME));
@@ -318,10 +317,10 @@ std::shared_ptr<std::vector<std::string>> Bmi_C_Adapter::inner_get_variable_name
     // With the necessary char** in hand, get the names from the model
     int names_result;
     if (is_input_variables) {
-        names_result = bmi_model->get_input_var_names(bmi_model.get(), names_array);
+        names_result = bmi_model->get_input_var_names(bmi_model.get(), names_array.data());
     }
     else {
-        names_result = bmi_model->get_output_var_names(bmi_model.get(), names_array);
+        names_result = bmi_model->get_output_var_names(bmi_model.get(), names_array.data());
     }
     if (names_result != BMI_SUCCESS) {
         throw std::runtime_error(model_name + " failed to get array of output variables names.");

--- a/test/realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Adapter_Test.cpp
@@ -449,8 +449,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridSize_0_b) {
     std::vector<int> shape = {3,3};
     adapter->SetValue("grid_1_shape", shape.data());
     //Must be int to align with fortran c_int
-    int grid_shape[rank+1];
-    adapter->GetGridShape(grd, grid_shape);
+    std::vector<int> grid_shape(rank+1);
+    adapter->GetGridShape(grd, grid_shape.data());
 
     // FIXME embed the expected value directly in the test and remove from "expected_input_grid_size"...
     // since the shape is dictated in this test...
@@ -506,8 +506,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridShape_0_a) {
     int rank = adapter->GetGridRank(grd);
     ASSERT_EQ(rank, 0);
     //Must be int to align with fortran c_int
-    int shape[rank+1];
-    adapter->GetGridShape(grd, shape);
+    std::vector<int> shape(rank+1);
+    adapter->GetGridShape(grd, shape.data());
     //shape not defined for scalars, so should be 0
     ASSERT_EQ(shape[0], 0);
 }
@@ -523,8 +523,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridShape_0_b) {
     std::vector<int> shape = {3,4};
     adapter->SetValue("grid_1_shape", shape.data());
     //Must be int to align with fortran c_int
-    int grid_shape[rank];
-    adapter->GetGridShape(grd, grid_shape);
+    std::vector<int> grid_shape(rank);
+    adapter->GetGridShape(grd, grid_shape.data());
     ASSERT_EQ(shape[0], grid_shape[0]);
     ASSERT_EQ(shape[1], grid_shape[1]);
 }
@@ -537,8 +537,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridSpacing_0_a) {
     int grd = adapter->GetVarGrid(variable_name);
     int rank = adapter->GetGridRank(grd);
     ASSERT_EQ(rank, 0);
-    double spacing[rank+1];
-    adapter->GetGridSpacing(grd, spacing);
+    std::vector<double> spacing(rank+1);
+    adapter->GetGridSpacing(grd, spacing.data());
     //spacing undefined for scalar, so should be 0
     ASSERT_EQ(spacing[0], 0);
 }
@@ -551,8 +551,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridSpacing_0_b) {
     int grd = adapter->GetVarGrid(variable_name);
     int rank = adapter->GetGridRank(grd);
     ASSERT_EQ(rank, 2);
-    double grid_spacing[rank];
-    adapter->GetGridSpacing(grd, grid_spacing);
+    std::vector<double> grid_spacing(rank);
+    adapter->GetGridSpacing(grd, grid_spacing.data());
     //spacing not yet established for grid, so should be 0, 0
     ASSERT_EQ(grid_spacing[0], 0.0);
     ASSERT_EQ(grid_spacing[1], 0.0);
@@ -569,8 +569,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridSpacing_0_c) {
     //NOTE spacing in BMI is again ij order, so this is `dy, dx`
     std::vector<double> spacing = {2.0, 2.0}; //TODO if this isn't double, the results are wacky...but it doesn't crash...
     adapter->SetValue("grid_1_spacing", spacing.data());
-    double grid_spacing[rank];
-    adapter->GetGridSpacing(grd, grid_spacing);
+    std::vector<double> grid_spacing(rank);
+    adapter->GetGridSpacing(grd, grid_spacing.data());
     ASSERT_EQ(grid_spacing[0], spacing[0]);
     ASSERT_EQ(grid_spacing[1], spacing[1]);
 }
@@ -586,8 +586,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridSpacing_0_d) {
     //NOTE spacing in BMI is again ij order, so this is `dy, dx`
     std::vector<int> units= {1, 1}; //The enum value for `m` or `meters` in bmi_grid.f90 must be int type
     adapter->SetValue("grid_1_units", units.data());
-    int grid_units[rank];
-    adapter->GetValue("grid_1_units", grid_units);
+    std::vector<int> grid_units(rank);
+    adapter->GetValue("grid_1_units", grid_units.data());
     ASSERT_EQ(grid_units[0], units[0]);
     ASSERT_EQ(grid_units[1], units[1]);
 }
@@ -600,8 +600,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridOrigin_0_a) {
     int grd = adapter->GetVarGrid(variable_name);
     int rank = adapter->GetGridRank(grd);
     ASSERT_EQ(rank, 0);
-    double origin[rank+1];
-    adapter->GetGridOrigin(grd, origin);
+    std::vector<double> origin(rank+1);
+    adapter->GetGridOrigin(grd, origin.data());
     //origin undefined for scalar, so should be 0
     ASSERT_EQ(origin[0], 0);
 }
@@ -614,8 +614,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridOrigin_0_b) {
     int grd = adapter->GetVarGrid(variable_name);
     int rank = adapter->GetGridRank(grd);
     ASSERT_EQ(rank, 2);
-    double origin[rank];
-    adapter->GetGridOrigin(grd, origin);
+    std::vector<double> origin(rank);
+    adapter->GetGridOrigin(grd, origin.data());
     //origin not yet established for grid, should be 0,0
     ASSERT_EQ(origin[0], 0);
     ASSERT_EQ(origin[1], 0);
@@ -632,8 +632,8 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridOrigin_0_c) {
     //NOTE origin is also ij order, so this is `y0,x0`
     std::vector<double> _origin = {42.0, 42.0}; //TODO if this isn't double, the results are wacky...but it doesn't crash...
     adapter->SetValue("grid_1_origin", _origin.data());
-    double origin[rank];
-    adapter->GetGridOrigin(grd, origin);
+    std::vector<double> origin(rank);
+    adapter->GetGridOrigin(grd, origin.data());
     for(int i = 0; i < rank; i++){
         ASSERT_EQ(origin[i], _origin[i]);
     }

--- a/test/realizations/catchments/Bmi_Py_Adapter_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Adapter_Test.cpp
@@ -924,9 +924,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridShape_0_a) {
     int rank = examples[ex_index].adapter->GetGridRank(grid_id);
 
     ASSERT_EQ(rank, 0);
-    int grid_shape[rank+1];
+    std::vector<int> grid_shape(rank+1);
 
-    examples[ex_index].adapter->GetGridShape(grid_id, grid_shape);
+    examples[ex_index].adapter->GetGridShape(grid_id, grid_shape.data());
     ASSERT_EQ(grid_shape[0], 0);
 }
 
@@ -948,9 +948,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridShape_0_b) {
     int rank = examples[ex_index].adapter->GetGridRank(grid_id);
 
     ASSERT_EQ(rank, 2);
-    int grid_shape[rank];
+    std::vector<int> grid_shape(rank);
 
-    examples[ex_index].adapter->GetGridShape(grid_id, grid_shape);
+    examples[ex_index].adapter->GetGridShape(grid_id, grid_shape.data());
     ASSERT_EQ(grid_shape[0], shape[0]);
     ASSERT_EQ(grid_shape[1], shape[1]);
 }
@@ -968,9 +968,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridSpacing_0_a) {
     int rank = examples[ex_index].adapter->GetGridRank(grid_id);
 
     ASSERT_EQ(rank, 0);
-    double grid_spacing[rank+1];
+    std::vector<double> grid_spacing(rank+1);
 
-    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_spacing);
+    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_spacing.data());
     ASSERT_EQ(grid_spacing[0], 0);
 }
 
@@ -987,9 +987,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridSpacing_0_b) {
     int rank = examples[ex_index].adapter->GetGridRank(grid_id);
 
     ASSERT_EQ(rank, 2);
-    double grid_spacing[rank];
+    std::vector<double> grid_spacing(rank);
 
-    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_spacing);
+    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_spacing.data());
     for(int i = 0; i < rank; i++){
         ASSERT_EQ(grid_spacing[i], 0);
     }
@@ -1011,9 +1011,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridSpacing_0_c) {
     examples[ex_index].adapter->SetValue("grid_1_spacing", spacing.data());
     
     ASSERT_EQ(rank, 2);
-    double grid_spacing[rank];
+    std::vector<double> grid_spacing(rank);
 
-    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_spacing);
+    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_spacing.data());
     for(int i = 0; i < rank; i++){
         ASSERT_EQ(grid_spacing[i], 2.0);
     }
@@ -1034,8 +1034,8 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridSpacing_0_d) {
     std::vector<short> units = {1,1}; //The enum value for `m` or `meters` in bmi_grid.py
     examples[ex_index].adapter->SetValue("grid_1_units", units.data());
 
-    short grid_units[rank];
-    examples[ex_index].adapter->GetValue("grid_1_units", grid_units);
+    std::vector<short> grid_units(rank);
+    examples[ex_index].adapter->GetValue("grid_1_units", grid_units.data());
     for(int i = 0; i < rank; i++){
         ASSERT_EQ(grid_units[i], units[i]);
     }
@@ -1053,9 +1053,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridOrigin_0_a) {
     int rank = examples[ex_index].adapter->GetGridRank(grid_id);
 
     ASSERT_EQ(rank, 2);
-    double grid_origin[rank];
+    std::vector<double> grid_origin(rank);
 
-    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_origin);
+    examples[ex_index].adapter->GetGridSpacing(grid_id, grid_origin.data());
     ASSERT_EQ(grid_origin[0], 0);
     ASSERT_EQ(grid_origin[1], 0);
 }
@@ -1073,9 +1073,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridOrigin_0_b) {
     int rank = examples[ex_index].adapter->GetGridRank(grid_id);
 
     ASSERT_EQ(rank, 2);
-    double grid_origin[rank];
+    std::vector<double> grid_origin(rank);
 
-    examples[ex_index].adapter->GetGridOrigin(grid_id, grid_origin);
+    examples[ex_index].adapter->GetGridOrigin(grid_id, grid_origin.data());
     for(int i = 0; i < rank; i++){
         ASSERT_EQ(grid_origin[i], 0);
     }
@@ -1097,9 +1097,9 @@ TEST_F(Bmi_Py_Adapter_Test, GetGridOrigin_0_c) {
     examples[ex_index].adapter->SetValue("grid_1_origin", origin.data());
     
     ASSERT_EQ(rank, 2);
-    double grid_origin[rank];
+    std::vector<double> grid_origin(rank);
 
-    examples[ex_index].adapter->GetGridOrigin(grid_id, grid_origin);
+    examples[ex_index].adapter->GetGridOrigin(grid_id, grid_origin.data());
     for(int i = 0; i < rank; i++){
         ASSERT_EQ(grid_origin[i], 42.0);
     }


### PR DESCRIPTION
Since we're not testing with the Intel classic `icpc` compiler that we're currently expecting to have to support in production, we should at least ask GCC/Clang to be strict about making sure we're not using language extensions that it might not offer, or that it potentially implements differently.

## Changes

- Change all instances of stack-allocated VLA usage to `std::vector`
- Add `-pedantic-error` to CI build process to prevent future such errors

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: