### PR TITLE
Disable t-route integration test on macOS, see #505

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -90,7 +90,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # [ubuntu-latest, macos-latest] #TODO: Fix #505
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Disabling this test temporarily. Note #505 is NOT fixed by this.

## Additions

-

## Removals

- macOS from OS matrix for workflow, only Ubuntu is left now.

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
