### PR TITLE
Implement Nexus Writer for t-route formatted QLAT outputs

### DIFF
--- a/include/utilities/nexus_writer.hpp
+++ b/include/utilities/nexus_writer.hpp
@@ -13,6 +13,11 @@
 
 #define NGEN_NETCDF_ERROR throw std::runtime_error("NetCDF is not available")
 
+// Changing these will affect both NetCDF and CSV outputs
+#define NGEN_VARIABLE_NEXUS_ID   "feature_id"
+#define NGEN_VARIABLE_SEGMENT_ID "segment_id"
+#define NGEN_VARIABLE_Q_LATERAL  "q_lateral"
+
 namespace ngen {
 namespace utils {
 
@@ -25,7 +30,7 @@ struct nexus_writer
 
     nexus_writer() = default;
 
-    virtual ~nexus_writer() {};
+    virtual ~nexus_writer() = default;
 
     /**
      * @brief Initialize this writer
@@ -68,7 +73,7 @@ struct nexus_csv_writer : public nexus_writer
 
     nexus_csv_writer() = default;
 
-    ~nexus_csv_writer() override {};
+    ~nexus_csv_writer() override = default;
 
     void init(size_type steps) override
     {
@@ -81,7 +86,7 @@ struct nexus_csv_writer : public nexus_writer
     {
         it_++;
         it_->open(file_name + ".csv");
-        (*it_) << "nexus_id,segment_id,qSfcLatRunoff\n";
+        (*it_) << NGEN_VARIABLE_NEXUS_ID "," NGEN_VARIABLE_SEGMENT_ID "," NGEN_VARIABLE_Q_LATERAL "\n";
     }
 
     void write(const std::string& segment_id, const std::string& nexus_id, double contribution) override
@@ -109,7 +114,7 @@ struct nexus_netcdf_writer : public nexus_writer
 
     nexus_netcdf_writer() = default;
 
-    ~nexus_netcdf_writer() override {};
+    ~nexus_netcdf_writer() override = default;
 
     void init(size_type steps) override
     {
@@ -133,14 +138,14 @@ struct nexus_netcdf_writer : public nexus_writer
         out = std::make_unique<netCDF::NcFile>(file_name + ".nc", netCDF::NcFile::replace);
         const auto& dim_fid = out->addDim("feature_id", num_nexuses);
   
-        const auto& var_nexus_id = out->addVar("nexus_id", netCDF::ncString, dim_fid);
+        const auto& var_nexus_id = out->addVar(NGEN_VARIABLE_NEXUS_ID, netCDF::ncString, dim_fid);
         var_nexus_id.putAtt("description", "Contributing Nexus ID");
         
-        const auto& var_segment_id = out->addVar("segment_id", netCDF::ncString, dim_fid);
+        const auto& var_segment_id = out->addVar(NGEN_VARIABLE_SEGMENT_ID, netCDF::ncString, dim_fid);
         var_segment_id.putAtt("description", "Flowpath ID downstream from the corresponding nexus");
 
-        const auto& var_qlat = out->addVar("qSfcLatRunoff", netCDF::ncDouble, dim_fid);
-        var_qlat.putAtt("description", "Runoff from terrain routing");
+        const auto& var_qlat = out->addVar(NGEN_VARIABLE_Q_LATERAL, netCDF::ncDouble, dim_fid);
+        var_qlat.putAtt("description", "Runoff into channel reach");
         var_qlat.putAtt("units", "m3 s-1");
     
         index_ = 0;
@@ -152,9 +157,9 @@ struct nexus_netcdf_writer : public nexus_writer
 #ifndef NETCDF_ACTIVE
         NGEN_NETCDF_ERROR;
 #else
-        it_->get()->getVar("nexus_id").putVar({ index_ }, nexus_id);
-        it_->get()->getVar("segment_id").putVar({ index_ }, segment_id);
-        it_->get()->getVar("qSfcLatRunoff").putVar({ index_ }, contribution);
+        it_->get()->getVar(NGEN_VARIABLE_NEXUS_ID).putVar({ index_ }, nexus_id);
+        it_->get()->getVar(NGEN_VARIABLE_SEGMENT_ID).putVar({ index_ }, segment_id);
+        it_->get()->getVar(NGEN_VARIABLE_Q_LATERAL).putVar({ index_ }, contribution);
         index_++;
 #endif
     }
@@ -182,3 +187,6 @@ struct nexus_netcdf_writer : public nexus_writer
 #endif // NGEN_UTILITIES_QLAT_HANDLER_HPP
 
 #undef NGEN_NETCDF_ERROR
+#undef NGEN_VARIABLE_NEXUS_ID
+#undef NGEN_VARIABLE_SEGMENT_ID
+#undef NGEN_VARIABLE_Q_LATERAL

--- a/include/utilities/nexus_writer.hpp
+++ b/include/utilities/nexus_writer.hpp
@@ -1,11 +1,11 @@
 #ifndef NGEN_UTILITIES_QLAT_HANDLER_HPP
 #define NGEN_UTILITIES_QLAT_HANDLER_HPP
 
-#include <iomanip>
-#include <vector>
-#include <memory>
-
 #include <fstream>
+#include <iomanip>
+#include <memory>
+#include <stdexcept>
+#include <vector>
 
 #ifdef NETCDF_ACTIVE
 #include <netcdf>
@@ -116,7 +116,6 @@ struct nexus_netcdf_writer : public nexus_writer
 #ifndef NETCDF_ACTIVE
         NGEN_NETCDF_ERROR;
 #else
-        std::cerr << "writing at " << index_ << '\n';
         it_->get()->getVar("nexus_id").putVar({ index_ }, nexus_id);
         it_->get()->getVar("segment_id").putVar({ index_ }, segment_id);
         it_->get()->getVar("qSfcLatRunoff").putVar({ index_ }, contribution);

--- a/include/utilities/nexus_writer.hpp
+++ b/include/utilities/nexus_writer.hpp
@@ -1,0 +1,149 @@
+#ifndef NGEN_UTILITIES_QLAT_HANDLER_HPP
+#define NGEN_UTILITIES_QLAT_HANDLER_HPP
+
+#include <iomanip>
+#include <vector>
+#include <memory>
+
+#include <fstream>
+
+#ifdef NETCDF_ACTIVE
+#include <netcdf>
+#endif
+
+#define NGEN_NETCDF_ERROR throw std::runtime_error("NetCDF is not available")
+
+namespace ngen {
+namespace utils {
+
+struct nexus_writer
+{   
+    using size_type = size_t;
+
+    nexus_writer() = default;
+
+    virtual ~nexus_writer() {};
+
+    virtual void init(size_type n) = 0;
+    virtual void next(const std::string& file_name, size_type num_nexuses) = 0;
+    virtual void write(const std::string& segment_id, const std::string& nexus_id, double qlat) = 0;
+    virtual void flush() = 0;
+};
+
+struct nexus_csv_writer : public nexus_writer
+{
+    using size_type = size_t;
+
+    nexus_csv_writer() = default;
+
+    ~nexus_csv_writer() override {};
+
+    void init(size_type n) override
+    {
+        outputs_.resize(n);
+        it_ = outputs_.begin();
+        it_--;
+    }
+
+    void next(const std::string& file_name, size_type num_nexuses) override
+    {
+        it_++;
+        it_->open(file_name + ".csv");
+        (*it_) << "nexus_id,segment_id,qSfcLatRunoff\n";
+    }
+
+    void write(const std::string& segment_id, const std::string& nexus_id, double contribution) override
+    {
+        (*it_) << nexus_id << ',' << segment_id << ',' << std::setprecision(14) << contribution << '\n';
+    }
+
+    void flush() override
+    {
+        it_->flush();
+    }
+
+  private:
+    std::vector<std::ofstream> outputs_;
+    decltype(outputs_)::iterator it_;
+};
+
+struct nexus_netcdf_writer : public nexus_writer
+{
+    using size_type = size_t;
+
+    nexus_netcdf_writer() = default;
+
+    ~nexus_netcdf_writer() override {};
+
+    void init(size_type n) override
+    {
+#ifndef NETCDF_ACTIVE
+        NGEN_NETCDF_ERROR;
+#else
+        outputs_.resize(n);
+        it_ = outputs_.begin();
+        it_--;
+#endif
+    }
+
+    void next(const std::string& file_name, size_type num_nexuses) override
+    {
+#ifndef NETCDF_ACTIVE
+        NGEN_NETCDF_ERROR;
+#else
+        it_++;
+        std::unique_ptr<netCDF::NcFile>& out = *it_;
+
+        out = std::make_unique<netCDF::NcFile>(file_name + ".nc", netCDF::NcFile::replace);
+        const auto& dim_fid = out->addDim("feature_id", num_nexuses);
+  
+        const auto& var_nexus_id = out->addVar("nexus_id", netCDF::ncString, dim_fid);
+        var_nexus_id.putAtt("description", "Contributing Nexus ID");
+        
+        const auto& var_segment_id = out->addVar("segment_id", netCDF::ncString, dim_fid);
+        var_segment_id.putAtt("description", "Flowpath ID downstream from the corresponding nexus");
+
+        const auto& var_qlat = out->addVar("qSfcLatRunoff", netCDF::ncDouble, dim_fid);
+        var_qlat.putAtt("description", "Runoff from terrain routing");
+        var_qlat.putAtt("units", "m3 s-1");
+    
+        index_ = 0;
+#endif
+    }
+
+    void write(const std::string& segment_id, const std::string& nexus_id, double contribution) override
+    {
+#ifndef NETCDF_ACTIVE
+        NGEN_NETCDF_ERROR;
+#else
+        std::cerr << "writing at " << index_ << '\n';
+        it_->get()->getVar("nexus_id").putVar({ index_ }, nexus_id);
+        it_->get()->getVar("segment_id").putVar({ index_ }, segment_id);
+        it_->get()->getVar("qSfcLatRunoff").putVar({ index_ }, contribution);
+        index_++;
+#endif
+    }
+
+    void flush() override
+    {
+#ifndef NETCDF_ACTIVE
+        NGEN_NETCDF_ERROR;
+#else
+        it_->get()->close();
+#endif
+    }
+
+  private:
+#ifdef NETCDF_ACTIVE
+    std::vector<std::unique_ptr<netCDF::NcFile>> outputs_;
+    decltype(outputs_)::iterator it_;
+    size_type index_ = 0;
+#endif
+};
+
+}
+}
+
+#endif // NGEN_UTILITIES_QLAT_HANDLER_HPP
+
+#undef NGEN_NETCDF_ERROR

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -357,8 +357,6 @@ int main(int argc, char *argv[]) {
       //std::cout<<"Output Time Index: "<<output_time_index<<std::endl;
       if(output_time_index%100 == 0) std::cout<<"Running timestep "<<output_time_index<<std::endl;
       std::string current_timestamp = manager->Simulation_Time_Object->get_timestamp(output_time_index);
-    
-      nexus_output->next(manager->get_output_root() + "qlat_" + current_timestamp, num_nexuses);
 
       for(const auto& id : features.catchments()) {
         //std::cout<<"Running cat "<<id<<std::endl;
@@ -393,6 +391,13 @@ int main(int argc, char *argv[]) {
       //At this point, could make an internal routing pass, extracting flows from nexuses and routing
       //across the flowpath to the next nexus.
       //Once everything is updated for this timestep, dump the nexus output
+
+      std::string output_timestamp = current_timestamp;
+      boost::algorithm::erase_all(output_timestamp, "-");
+      boost::algorithm::erase_all(output_timestamp, " ");
+      boost::algorithm::erase_all(output_timestamp, ":");
+      nexus_output->next(manager->get_output_root() + output_timestamp + "NEXOUT", num_nexuses);
+    
       for(const auto& id : features.nexuses()) {
   #ifdef NGEN_MPI_ACTIVE
         if (!features.is_remote_sender_nexus(id)) { //Ensures only one side of the dual sided remote nexus actually doing this...
@@ -412,7 +417,7 @@ int main(int argc, char *argv[]) {
           }
 
           double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, output_time_index, 100.0);
-
+  
           nexus_output->write(
             nexus_collection->get_feature(id)->get_property("toid").as_string(),
             id,

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -396,6 +396,8 @@ int main(int argc, char *argv[]) {
       boost::algorithm::erase_all(output_timestamp, "-");
       boost::algorithm::erase_all(output_timestamp, " ");
       boost::algorithm::erase_all(output_timestamp, ":");
+      // Remove Seconds
+      output_timestamp = output_timestamp.substr(0, output_timestamp.size() - 2);
       nexus_output->next(manager->get_output_root() + output_timestamp + "NEXOUT", num_nexuses);
     
       for(const auto& id : features.nexuses()) {

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -398,7 +398,7 @@ int main(int argc, char *argv[]) {
       boost::algorithm::erase_all(output_timestamp, ":");
       // Remove Seconds
       output_timestamp = output_timestamp.substr(0, output_timestamp.size() - 2);
-      nexus_output->next(manager->get_output_root() + output_timestamp + "NEXOUT", num_nexuses);
+      nexus_output->next(manager->get_output_root() + output_timestamp + "NEXOUT", num_nexuses, output_timestamp);
     
       for(const auto& id : features.nexuses()) {
   #ifdef NGEN_MPI_ACTIVE
@@ -420,11 +420,7 @@ int main(int argc, char *argv[]) {
 
           double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, output_time_index, 100.0);
   
-          nexus_output->write(
-            nexus_collection->get_feature(id)->get_property("toid").as_string(),
-            id,
-            contribution_at_t 
-          );
+          nexus_output->write(id, contribution_at_t);
 
   #ifdef NGEN_MPI_ACTIVE
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,6 +138,7 @@ ngen_add_test(
         core/nexus/NexusTests.cpp
     LIBRARIES
         NGen::core_nexus
+        ${NETCDF_LIBRARIES}
 )
 
 ########################## MPI Remote Nexus Tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,9 +136,10 @@ ngen_add_test(
     test_nexus
     OBJECTS
         core/nexus/NexusTests.cpp
+        utils/nexus_writer_Test.cpp
     LIBRARIES
         NGen::core_nexus
-        ${NETCDF_LIBRARIES}
+        NetCDF
 )
 
 ########################## MPI Remote Nexus Tests

--- a/test/utils/nexus_writer_Test.cpp
+++ b/test/utils/nexus_writer_Test.cpp
@@ -21,11 +21,11 @@ class nexus_writer_Test : public ::testing::Test
     std::string write_to_file()
     {
         std::unique_ptr<ngen::utils::nexus_writer> writer = std::make_unique<WriterType>();
-
+        
         writer->init(1);
-        writer->next(tempfile, 2);
-        writer->write("wb-1", "nex-1", 5);
-        writer->write("wb-2", "nex-2", 10);
+        writer->next(tempfile, 2, timestamp_);
+        writer->write("nex-1", 5);
+        writer->write("nex-2", 10);
         writer->flush();
 
         return tempfile + (
@@ -34,6 +34,8 @@ class nexus_writer_Test : public ::testing::Test
             : ".csv"
         );
     }
+
+    const std::string timestamp_ = "202308250000";
 
   private:
     std::string tempfile = testing::TempDir() + "/ngen_nexus_writer__test";
@@ -49,11 +51,11 @@ TEST_F(nexus_writer_Test, csv_writer)
     
     std::string line;
     stream >> line;
-    ASSERT_EQ(line, "feature_id,segment_id,q_lateral");
+    ASSERT_EQ(line, "feature_id," + timestamp_);
     stream >> line;
-    ASSERT_EQ(line, "nex-1,wb-1,5");
+    ASSERT_EQ(line, "nex-1,5");
     stream >> line;
-    ASSERT_EQ(line, "nex-2,wb-2,10");
+    ASSERT_EQ(line, "nex-2,10");
     stream.close();
 }
 
@@ -75,25 +77,12 @@ TEST_F(nexus_writer_Test, netcdf_writer)
     
     const auto& var_nexus_id = stream.getVar("feature_id");
     ASSERT_FALSE(var_nexus_id.isNull());
-    char* nex_id_1 = nullptr;
+    std::string nex_id_1(5, ' ');
     var_nexus_id.getVar({ 0 }, &nex_id_1);
-    char* nex_id_2 = nullptr;
+    std::string nex_id_2(5, ' ');
     var_nexus_id.getVar({ 1 }, &nex_id_2);
-    ASSERT_STREQ(nex_id_1, "nex-1");
-    ASSERT_STREQ(nex_id_2, "nex-2");
-    delete nex_id_1;
-    delete nex_id_2;
-
-    const auto& var_segment_id = stream.getVar("segment_id");
-    ASSERT_FALSE(var_segment_id.isNull());
-    char* seg_id_1 = nullptr;
-    var_segment_id.getVar({ 0 }, &seg_id_1);
-    char* seg_id_2 = nullptr;
-    var_segment_id.getVar({ 1 }, &seg_id_2);
-    ASSERT_STREQ(seg_id_1, "wb-1");
-    ASSERT_STREQ(seg_id_2, "wb-2");
-    delete seg_id_1;
-    delete seg_id_2;
+    ASSERT_EQ(nex_id_1, "nex-1");
+    ASSERT_EQ(nex_id_2, "nex-2");
 
     const auto& var_qlat = stream.getVar("q_lateral");
     ASSERT_FALSE(var_qlat.isNull());

--- a/test/utils/nexus_writer_Test.cpp
+++ b/test/utils/nexus_writer_Test.cpp
@@ -9,12 +9,12 @@
 class nexus_writer_Test : public ::testing::Test
 {
   protected:
-    ~nexus_writer_Test() override {};
+    ~nexus_writer_Test() override = default;
 
     void TearDown() override
     {
         unlink((tempfile + ".csv").c_str());
-        // unlink((tempfile + ".nc").c_str());
+        unlink((tempfile + ".nc").c_str());
     }
 
     template<typename WriterType>
@@ -49,7 +49,7 @@ TEST_F(nexus_writer_Test, csv_writer)
     
     std::string line;
     stream >> line;
-    ASSERT_EQ(line, "nexus_id,segment_id,qSfcLatRunoff");
+    ASSERT_EQ(line, "feature_id,segment_id,q_lateral");
     stream >> line;
     ASSERT_EQ(line, "nex-1,wb-1,5");
     stream >> line;
@@ -73,11 +73,11 @@ TEST_F(nexus_writer_Test, netcdf_writer)
     ASSERT_FALSE(dim.isNull());
     ASSERT_EQ(dim.getSize(), 2);
     
-    const auto& var_nexus_id = stream.getVar("nexus_id");
+    const auto& var_nexus_id = stream.getVar("feature_id");
     ASSERT_FALSE(var_nexus_id.isNull());
-    char* nex_id_1;
+    char* nex_id_1 = nullptr;
     var_nexus_id.getVar({ 0 }, &nex_id_1);
-    char* nex_id_2;
+    char* nex_id_2 = nullptr;
     var_nexus_id.getVar({ 1 }, &nex_id_2);
     ASSERT_STREQ(nex_id_1, "nex-1");
     ASSERT_STREQ(nex_id_2, "nex-2");
@@ -86,16 +86,16 @@ TEST_F(nexus_writer_Test, netcdf_writer)
 
     const auto& var_segment_id = stream.getVar("segment_id");
     ASSERT_FALSE(var_segment_id.isNull());
-    char* seg_id_1;
+    char* seg_id_1 = nullptr;
     var_segment_id.getVar({ 0 }, &seg_id_1);
-    char* seg_id_2;
+    char* seg_id_2 = nullptr;
     var_segment_id.getVar({ 1 }, &seg_id_2);
     ASSERT_STREQ(seg_id_1, "wb-1");
     ASSERT_STREQ(seg_id_2, "wb-2");
     delete seg_id_1;
     delete seg_id_2;
 
-    const auto& var_qlat = stream.getVar("qSfcLatRunoff");
+    const auto& var_qlat = stream.getVar("q_lateral");
     ASSERT_FALSE(var_qlat.isNull());
     double qlat_1 = 0;
     var_qlat.getVar({ 0 }, &qlat_1);

--- a/test/utils/nexus_writer_Test.cpp
+++ b/test/utils/nexus_writer_Test.cpp
@@ -1,0 +1,109 @@
+#include <nexus_writer.hpp>
+
+#include <gtest/gtest.h>
+
+#ifdef NETCDF_ACTIVE
+#include <netcdf>
+#endif
+
+class nexus_writer_Test : public ::testing::Test
+{
+  protected:
+    ~nexus_writer_Test() override {};
+
+    void TearDown() override
+    {
+        unlink((tempfile + ".csv").c_str());
+        // unlink((tempfile + ".nc").c_str());
+    }
+
+    template<typename WriterType>
+    std::string write_to_file()
+    {
+        std::unique_ptr<ngen::utils::nexus_writer> writer = std::make_unique<WriterType>();
+
+        writer->init(1);
+        writer->next(tempfile, 2);
+        writer->write("wb-1", "nex-1", 5);
+        writer->write("wb-2", "nex-2", 10);
+        writer->flush();
+
+        return tempfile + (
+            std::is_same<WriterType, ngen::utils::nexus_netcdf_writer>::value
+            ? ".nc"
+            : ".csv"
+        );
+    }
+
+  private:
+    std::string tempfile = testing::TempDir() + "/ngen_nexus_writer__test";
+};
+
+TEST_F(nexus_writer_Test, csv_writer)
+{
+    std::string output = this->write_to_file<ngen::utils::nexus_csv_writer>();
+
+    std::ifstream stream{ output, std::ios::in };
+    if (!stream.good())
+        FAIL() << "Failed to open stream";
+    
+    std::string line;
+    stream >> line;
+    ASSERT_EQ(line, "nexus_id,segment_id,qSfcLatRunoff");
+    stream >> line;
+    ASSERT_EQ(line, "nex-1,wb-1,5");
+    stream >> line;
+    ASSERT_EQ(line, "nex-2,wb-2,10");
+    stream.close();
+}
+
+TEST_F(nexus_writer_Test, netcdf_writer)
+{
+#ifndef NETCDF_ACTIVE
+    GTEST_SKIP() << "NetCDF is not available";
+#else
+    std::string output = this->write_to_file<ngen::utils::nexus_netcdf_writer>();
+
+    netCDF::NcFile stream{ output, netCDF::NcFile::read };
+
+    ASSERT_EQ(stream.getDimCount(), 1);
+    ASSERT_EQ(stream.getVarCount(), 3);
+
+    const auto& dim = stream.getDim("feature_id");
+    ASSERT_FALSE(dim.isNull());
+    ASSERT_EQ(dim.getSize(), 2);
+    
+    const auto& var_nexus_id = stream.getVar("nexus_id");
+    ASSERT_FALSE(var_nexus_id.isNull());
+    char* nex_id_1;
+    var_nexus_id.getVar({ 0 }, &nex_id_1);
+    char* nex_id_2;
+    var_nexus_id.getVar({ 1 }, &nex_id_2);
+    ASSERT_STREQ(nex_id_1, "nex-1");
+    ASSERT_STREQ(nex_id_2, "nex-2");
+    delete nex_id_1;
+    delete nex_id_2;
+
+    const auto& var_segment_id = stream.getVar("segment_id");
+    ASSERT_FALSE(var_segment_id.isNull());
+    char* seg_id_1;
+    var_segment_id.getVar({ 0 }, &seg_id_1);
+    char* seg_id_2;
+    var_segment_id.getVar({ 1 }, &seg_id_2);
+    ASSERT_STREQ(seg_id_1, "wb-1");
+    ASSERT_STREQ(seg_id_2, "wb-2");
+    delete seg_id_1;
+    delete seg_id_2;
+
+    const auto& var_qlat = stream.getVar("qSfcLatRunoff");
+    ASSERT_FALSE(var_qlat.isNull());
+    double qlat_1 = 0;
+    var_qlat.getVar({ 0 }, &qlat_1);
+    double qlat_2 = 0;
+    var_qlat.getVar({ 1 }, &qlat_2);
+    ASSERT_EQ(qlat_1, 5);
+    ASSERT_EQ(qlat_2, 10);
+
+    stream.close();
+#endif
+}


### PR DESCRIPTION
This PR implements the `ngen::utils::nexus_writer` base class with `ngen::utils::nexus_csv_writer` and `ngen::utils::nexus_netcdf_writer` derived classes. This implements part 1 of #605.

See https://github.com/NOAA-OWP/t-route/pull/636 for the output schema. Output file names are formatted as: `{%Y%m%d%H%M}NEXOUT.{nc|csv}`, based on t-route's parsing logic.

### Usage

The following modifications should be made before using this:

- Before running `ngen`, export the `NGEN_QLAT_FORMAT` environment variable to be either `netcdf` or `csv`.
- in your routing config file, ensure `forcing_parameters.qlat_file_pattern_filter` is set to `*NEXOUT.csv` or `*NEXOUT.nc`, depending on the format you output.
- Optional, but recommended: set `output_root` in your realization config so that the outputs are aggregated under a single directory.
- Ensure your `forcing_parameters.qlat_input_folder` points to the same location as your realization config's `output_root`, if set.

## Additions

- Adds `ngen::utils::nexus_writer`
- Adds `ngen::utils::nexus_csv_writer`
- Adds `ngen::utils::nexus_netcdf_writer`
- Adds environment variable checking for user to choose QLAT output. For example, setting `NGEN_QLAT_FORMAT=netcdf` will output NetCDF files, or otherwise CSV files.
  > This is a temporary workaround until a decision is made on whether this should be set in the realization configuration files.

## Changes

- Modifies CSV outputs to conform to NetCDF format.
- Modifies `src/NGen.cpp` to include the logic for using `ngen::utils::nexus_writer`.
- Modifies `src/NGen.cpp` to prevent destruction of `nexus_collection`, since the flowpath/segment IDs are needed for method calls to `nexus_writer`.

## Notes

- If NetCDF is not available at compile-time, but `NGEN_QLAT_FORMAT` is set to "NetCDF" at run-time, then a `std::runtime_error` will be thrown when any of `nexus_netcdf_writer`'s methods are called.

## Testing

- Adds unit tests for ensuring output formats are correct by parsing temporary outputs for both CSV and NetCDF.

## Todos

- [x] Unit Testing for Nexus Writers
- [X] Corresponding `t-route` PR (waiting on inland hydraulics)
- [ ] MPI handling (?)

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
