### PR TITLE
Tests and cleanup for #610 (`output_variables` fallback behavior)

### DIFF
--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -311,7 +311,7 @@ string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::st
 
         // Do the rest with a leading comma
         for (int i = 1; i < output_var_names.size(); ++i) {
-            *output_text_stream << "," << get_var_value_as_double(output_var_names[i]);
+            *output_text_stream << delimiter << get_var_value_as_double(output_var_names[i]);
         }
         return output_text_stream->str();
     }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -307,7 +307,6 @@ string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::st
         if (output_var_names.empty()) { return ""; }
 
         // Do the first separately, without the leading comma
-        auto output_data_provider_iter = availableData.find(output_var_names[0]);
         *output_text_stream << get_var_value_as_double(output_var_names[0]);
 
         // Do the rest with a leading comma

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -306,23 +306,15 @@ string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::st
         // This almost certainly should never happen, but just to be safe ...
         if (output_var_names.empty()) { return ""; }
 
-        try {
-            // Do the first separately, without the leading comma
-            auto output_data_provider_iter = availableData.find(output_var_names[0]);
-            *output_text_stream << get_var_value_as_double(output_var_names[0]);
+        // Do the first separately, without the leading comma
+        auto output_data_provider_iter = availableData.find(output_var_names[0]);
+        *output_text_stream << get_var_value_as_double(output_var_names[0]);
 
-            // Do the rest with a leading comma
-            for (int i = 1; i < output_var_names.size(); ++i) {
-                *output_text_stream << "," << get_var_value_as_double(output_var_names[i]);
-            }
-            return output_text_stream->str();
+        // Do the rest with a leading comma
+        for (int i = 1; i < output_var_names.size(); ++i) {
+            *output_text_stream << "," << get_var_value_as_double(output_var_names[i]);
         }
-        catch (const std::exception &e) {
-            std::cerr << "WARN: " << e.what()
-                      << "; reverting to default behavior for multi-BMI formulation type (using last module)";
-            output_text_stream->str(std::string()); // ... clear any output contents being staged ...
-            is_out_vars_from_last_mod = true;          // ... revert to default behavior (just use last nested module)
-        }
+        return output_text_stream->str();
     }
     // Otherwise, use the default behavior, which means we either
     //   - were originally set to use the default of getting the output of the last module

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -301,7 +301,7 @@ private:
      */
     inline std::string determineNestedInputAliasValue(const int ex_index, const int nested_index) {
         // For the first two examples (i.e. not 3 or 4), have an input of all but 1st module be an output of a prior
-        if (ex_index < 2) {
+        if (ex_index < 2 || ex_index >= 4) {
             if (nested_index == 0)  return AORC_FIELD_NAME_PRECIP_RATE;
             else                    return "OUTPUT_VAR_1__" + std::to_string(nested_index - 1);
         }
@@ -484,7 +484,7 @@ void Bmi_Multi_Formulation_Test::SetUp() {
 
     // Define this manually to set how many nested modules per example, and implicitly how many examples.
     // This means 2 example scenarios with 2 nested modules
-    example_module_depth = {2, 2, 2, 2};
+    example_module_depth = {2, 2, 2, 2, 2, 2};
 
     // Initialize the members for holding required input and result test data for individual example scenarios
     setupExampleDataCollections();
@@ -520,6 +520,11 @@ void Bmi_Multi_Formulation_Test::SetUp() {
     initializeTestExample(2, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)}, {});
 
     initializeTestExample(3, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)}, {"OUTPUT_VAR_1__1", "OUTPUT_VAR_2__1", "OUTPUT_VAR_1__0", "OUTPUT_VAR_2__0", "OUTPUT_VAR_3__0", "precip_rate" });
+
+    // Cases 4 and 5 Specifically to test output_variables failure cases...
+    initializeTestExample(4, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)}, { "bogus_variable" });
+    initializeTestExample(5, "cat-27", {std::string(BMI_FORTRAN_TYPE), std::string(BMI_PYTHON_TYPE)}, { "OUTPUT_VAR_1" });
+   
 }
 
 /** Simple test to make sure the model config from example 0 initializes. */
@@ -616,6 +621,33 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_3_c) {
     for (size_t i = 0; i < deferred.size(); ++i) {
         ASSERT_TRUE(deferred[i]->isWrappedProviderSet());
     }
+}
+
+/** Test to make sure the a non-existent variable name is not allowed in `output_variables` (see issue #535). */
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_4_Fails) {
+    int ex_index = 4;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+
+    EXPECT_THROW({
+        formulation.create_formulation(config_prop_ptree[ex_index]);
+    }, std::runtime_error);
+
+
+}
+
+/** Test to make sure that a remapped variable name is not allowed in `output_variables` (see issue #535)
+ * This is not strictly part of some spec/requirement, but is the current behavior and is here to
+ * document that, and to catch any change in behavior.
+*/
+TEST_F(Bmi_Multi_Formulation_Test, Initialize_5_Fails) {
+    int ex_index = 5;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+
+    EXPECT_THROW({
+        formulation.create_formulation(config_prop_ptree[ex_index]);
+    }, std::runtime_error);
 }
 
 /**

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -483,7 +483,7 @@ void Bmi_Multi_Formulation_Test::SetUp() {
     testing::Test::SetUp();
 
     // Define this manually to set how many nested modules per example, and implicitly how many examples.
-    // This means 2 example scenarios with 2 nested modules
+    // This means example_module_depth.size() example scenarios with example_module_depth[i] nested modules in each scenario.
     example_module_depth = {2, 2, 2, 2, 2, 2};
 
     // Initialize the members for holding required input and result test data for individual example scenarios
@@ -632,8 +632,6 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_4_Fails) {
     EXPECT_THROW({
         formulation.create_formulation(config_prop_ptree[ex_index]);
     }, std::runtime_error);
-
-
 }
 
 /** Test to make sure that a remapped variable name is not allowed in `output_variables` (see issue #535)


### PR DESCRIPTION

[Short description explaining the high-level reason for the pull request]

## Additions

- Two tests for invalid entries in `output_variables`

## Removals

- Obsolete fallback condition code in Bmi_Multi_Formulation.cpp

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
