### PR TITLE
Fix a couple more missing std:: found with grep

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
         std::cout<<"  Fortran BMI enabled"<<std::endl;
         #endif
         #ifdef NGEN_C_LIB_ACTIVE
-        cout<<"  C BMI enabled"<<std::endl;
+        std::cout<<"  C BMI enabled"<<std::endl;
         #endif
         #ifdef ACTIVATE_PYTHON
         std::cout<<"  Python active"<<std::endl;

--- a/test/realizations/catchments/Bmi_C_Pet_IT.cpp
+++ b/test/realizations/catchments/Bmi_C_Pet_IT.cpp
@@ -162,7 +162,7 @@ void Bmi_C_Pet_IT::SetUp() {
                          "}";
         std::stringstream stream;
         stream << config_json[i];
-        //cout << stream.str();
+        //std::cout << stream.str();
         boost::property_tree::ptree loaded_tree;
         boost::property_tree::json_parser::read_json(stream, loaded_tree);
         config_prop_ptree[i] = loaded_tree.get_child("catchments").get_child(catchment_ids[i]).get_child("bmi_c");


### PR DESCRIPTION
Following on #620, I went looking for other places that will stumble, and found these.

## Changes

- Add a couple more missing `std::` qualifications

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
