### PR TITLE
Add documentation for model_params, output_variables, and output_header_fields

### DIFF
--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -125,15 +125,52 @@ There are some special BMI formulation config parameters which are required in c
   the [Bmi_Formulation.hpp](..include/realizations/catchment/Bmi_Formulation.hpp) file has a section where several supported standard names are defined and notes  
   * this can be useful in particular for informing the framework how to provide the input a model needs for execution
   * e.g.,  `"variables_names_map": {"model_variable_name": "standard_variable_name"}`
+* `model_params`
+  * can specify static or dynamic parameters passed to models as model variables.
+  * static parameters are defined inline in the realization config.
+  * dynamic parameters are derived from a given source, such as hydrofabric data.
+  * if specified, must be within the **params** config level, i.e. within a `"formulations": [..., {..., "params": {..., "model_params": {...}, ...}, ...}, ...]` object.
+  * if specified for multi-BMI, must be within the **module-params** config level, i.e. in the **params** config level for a given **module**.
+  * e.g.,
+    ```jsonc
+    // Format: { <variable_name>: <value> }
+    "model_params": {
+      // Static parameter
+      "APCP_Surface": 3.0,
+
+      // Dynamic parameter
+      "areasqkm": {
+        // where this variable is deriving from, only "hydrofabric" is supported currently
+        "source": "hydrofabric",
+        // the property name of this value,
+        // i.e. what property (area_sqkm) in the source (hydrofabric) maps to our variable (areasqkm)?
+        "from": "area_sqkm"
+      }
+    }
+    ```
 * `output_variables`
   * can specify the particular set and order of output variables to include in the realization's `get_output_line_for_timestep()` (and similar) function
   * JSON structure should be a list of strings
   * if not present, defaults to whatever it returned by the model's BMI `get_output_var_names()` function *the first time* it is invoked
+  * if specified, must be at the **root** level of a formulation object.
+  * if specified for multi-BMI, must be within the **module-root** config level, i.e. in the **root** config level for a given **module**.
+  * e.g.,
+    ```jsonc
+    // Example for CFE, which has 13 output variables
+    "output_variables": ["RAIN_RATE", "Q_OUT"]
+    ```
 * `output_header_fields`
   * can specify the header strings to use for the realization's printed output (i.e., the value returned by `get_output_header_line()`)
   * JSON structure should be a list of strings
   * when not present, the literal variable names are used
   * when present, does not do any checking for ordering/correspondence compared to the output ordering of the variable values, so users must take care that ordering is consistent
+  * if specified, must be at the **root** level of a formulation object.
+  * if specified for multi-BMI, must be within the **module-root** config level, i.e. in the **root** config level for a given **module**.
+  * e.g.,
+  ```jsonc
+  // Same as `output_variables` example with CFE, but we want to change the formatting
+  "output_header_fields": ["rain_rate", "Q"]
+  ```
 * `allow_exceed_end_time`
   * boolean value to specify whether a model is allowed to execute `Update` calls that go beyond its end time (or the max forcing data entry)
   * implied to be `false` by default

--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -153,7 +153,7 @@ There are some special BMI formulation config parameters which are required in c
   * JSON structure should be a list of strings
   * if not present, defaults to whatever it returned by the model's BMI `get_output_var_names()` function *the first time* it is invoked
   * if specified, must be at the **root** level of a formulation object.
-  * if specified for multi-BMI, must be within the **module-root** config level, i.e. in the **root** config level for a given **module**.
+  * if specified for multi-BMI, it should be within the **formulation-root** config level, i.e. in the **root** config level for a given **formulation**.
   * e.g.,
     ```jsonc
     // Example for CFE, which has 13 output variables
@@ -165,7 +165,7 @@ There are some special BMI formulation config parameters which are required in c
   * when not present, the literal variable names are used
   * when present, does not do any checking for ordering/correspondence compared to the output ordering of the variable values, so users must take care that ordering is consistent
   * if specified, must be at the **root** level of a formulation object.
-  * if specified for multi-BMI, must be within the **module-root** config level, i.e. in the **root** config level for a given **module**.
+  * if specified for multi-BMI, it should be within the **formulation-root** config level, i.e. in the **root** config level for a given **formulation**.
   * e.g.,
   ```jsonc
   // Same as `output_variables` example with CFE, but we want to change the formatting


### PR DESCRIPTION
This PR resolves #408.

## Additions

- Adds documentation for:
    * `model_params`
    * `output_variables`
    * `output_header_fields`

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
