### PR TITLE
Fix using the forcing file header error.

### DIFF
--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -245,6 +245,10 @@ namespace realization {
                 for(std::map<std::string,std::shared_ptr<data_access::GenericDataProvider>>::iterator iter = availableData.begin(); iter != availableData.end(); ++iter)
                 {
                     var_name = iter->first;
+                    auto it = std::find(forcing->get_available_variable_names().begin(), forcing->get_available_variable_names().end(), var_name);
+                    if (it == forcing->get_available_variable_names().end()) {
+                        var_name = forcing->get_available_variable_names()[0];
+                    }
                     //TODO: Find a probably more performant way than trial and exception here.
                     try {
                         time_t rv = availableData[var_name]->get_data_start_time();

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -239,26 +239,10 @@ namespace realization {
 
         time_t get_variable_time_begin(const std::string &variable_name) {
             std::string var_name = variable_name;
+            // when unspecified, assume all data is available for the same range.
+            // If no var_name, use forcing ...
             if(var_name == "*" || var_name == ""){
-                // when unspecified, assume all data is available for the same range.
-                // Find one that successfully returns...
-                for(std::map<std::string,std::shared_ptr<data_access::GenericDataProvider>>::iterator iter = availableData.begin(); iter != availableData.end(); ++iter)
-                {
-                    var_name = iter->first;
-                    auto it = std::find(forcing->get_available_variable_names().begin(), forcing->get_available_variable_names().end(), var_name);
-                    if (it == forcing->get_available_variable_names().end()) {
-                        var_name = forcing->get_available_variable_names()[0];
-                    }
-                    //TODO: Find a probably more performant way than trial and exception here.
-                    try {
-                        time_t rv = availableData[var_name]->get_data_start_time();
-                        return rv;
-                    }
-                    catch (...){
-                        continue;
-                    }
-                    break;
-                }
+                return forcing->get_data_start_time();
             }
             // If not found ...
             if (availableData.empty() || availableData.find(var_name) == availableData.end()) {


### PR DESCRIPTION
The details are described in Issue #504. Briefly, when a forcing file with the following format:
```Time,RAINRATE,T2D,Q2D,U2D,V2D,PSFC,SWDOWN,LWDOWN```
```2015-12-01 00:00:00,0,285.8000183,0.0093,-2.299999952,0.100000001,100310,0,361.3000183```
is used, ngen throw a runtime " out of range" error.
The usually used header is as follows.
```time,APCP_surface,DLWRF_surface,DSWRF_surface,PRES_surface,SPFH_2maboveground,TMP_2maboveground,UGRD_10maboveground,VGRD_10maboveground,precip_rate```
```2015-12-01 00:00:00,0.0,360.8000183105469,0.0,100220.0,0.009399999864399433,285.8999938964844,-2.299999952316284,0.10000000149011612,0.0```

## Additions

-

## Removals

-

## Changes

include/realizations/catchment/Bmi_Multi_Formulation.hpp

## Testing

Run ngen test

## Screenshots


## Notes
It is found the error was caused by setting ```init_time``` to ```0``` in ```CsvPerFeatureForcingProvider.hpp```. This was ultimately traced to ```get_data_start_time()``` which call ```get_variable_time_begin(const std::string &variable_name)``` in ```Bmi_Multi_Formulation.hpp```. This function uses ```availableData``` to extract the start time. If ```var_name``` in ```availableData``` is not in ```forcing``` data, then it returns ```0``` as start time. The solution makes sure if a ```var_name``` chosen from ```availableData``` is not a forcing variable name, we use the first forcing variable name as ```var_name``` to choose start time, which is always a valid time. We could actually use any of the forcing variable names to choose the start time, here we just uses the first one for convenience.

Also note that the fix works for both CSV and netCDF data.

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [ x] Code can be automatically merged (no conflicts)
- [ x] Code follows project standards (link if applicable)
- [x ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
