### PR TITLE
Remove custom time unit conversion in favor of UDUNITS

### DIFF
--- a/include/realizations/catchment/Bmi_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Adapter.hpp
@@ -87,7 +87,7 @@ namespace models {
              * A backing BMI model may use arbitrary units for time, but it will expose what those units are via the
              * BMI ``GetTimeUnits`` function. This function retrieves (and interprets) its model's units and
              * return an appropriate factor for converting its internal time values to equivalent representations
-             * within the model, and vice versa. This function coomplies with the BMI get_time_units standard
+             * within the model, and vice versa. This function complies with the BMI get_time_units standard
              */
             double get_time_convert_factor() {
                 double value = 1.0;

--- a/include/realizations/catchment/Bmi_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Adapter.hpp
@@ -8,6 +8,7 @@
 #include "JSONProperty.hpp"
 #include "State_Exception.hpp"
 #include "StreamHandler.hpp"
+#include <UnitsHelper.hpp>
 
 namespace models {
     namespace bmi {
@@ -81,29 +82,18 @@ namespace models {
 
 
             /**
-             * Determine backing model's time units and set the reference parameter to an appropriate conversion factor.
+             * Determine backing model's time units and return an appropriate conversion factor.
              *
              * A backing BMI model may use arbitrary units for time, but it will expose what those units are via the
-             * BMI ``GetTimeUnits`` function.  This function retrieves (and interprets) its model's units and
-             * sets the given reference parameter to an appropriate factor for converting its internal time values to
-             * equivalent representations within the model, and vice versa.
-             *
-             * @param time_convert_factor A reference to set to the determined conversion factor.
+             * BMI ``GetTimeUnits`` function. This function retrieves (and interprets) its model's units and
+             * return an appropriate factor for converting its internal time values to equivalent representations
+             * within the model, and vice versa. This function coomplies with the BMI get_time_units standard
              */
-            void acquire_time_conversion_factor(double &time_convert_factor) {
-                std::string time_units = GetTimeUnits();
-                if (time_units == "s" || time_units == "sec" || time_units == "second" || time_units == "seconds")
-                    time_convert_factor = 1.0;
-                else if (time_units == "m" || time_units == "min" || time_units == "minute" ||
-                         time_units == "minutes")
-                    time_convert_factor = 60.0;
-                else if (time_units == "h" || time_units == "hr" || time_units == "hour" || time_units == "hours")
-                    time_convert_factor = 3600.0;
-                else if (time_units == "d" || time_units == "day" || time_units == "days")
-                    time_convert_factor = 86400.0;
-                else
-                    throw std::runtime_error(
-                            "Invalid model time step units ('" + time_units + "') in " + model_name + ".");
+            double get_time_convert_factor() {
+                double value = 1.0;
+                std::string input_units = GetTimeUnits();
+                std::string output_units = "s";
+                return UnitsHelper::get_converted_value(input_units, value, output_units);
             }
 
             /**
@@ -193,7 +183,7 @@ namespace models {
                         construct_and_init_backing_model();
                         // Make sure this is set to 'true' after this function call finishes
                         model_initialized = true;
-                        acquire_time_conversion_factor(bmi_model_time_convert_factor);
+                        bmi_model_time_convert_factor = get_time_convert_factor();
                     }
                         // Record the exception message before re-throwing to handle subsequent function calls properly
                     catch (std::exception& e) {

--- a/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Adapter.hpp
@@ -48,7 +48,7 @@ namespace models {
                     construct_and_init_backing_model_for_fortran();
                     // Make sure this is set to 'true' after this function call finishes
                     model_initialized = true;
-                    acquire_time_conversion_factor(bmi_model_time_convert_factor);
+                    bmi_model_time_convert_factor = get_time_convert_factor();
                 }
                     // Record the exception message before re-throwing to handle subsequent function calls properly
                 catch( models::external::State_Exception& e)

--- a/src/realizations/catchment/Bmi_C_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_C_Adapter.cpp
@@ -78,7 +78,7 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
             construct_and_init_backing_model_for_type();
             // Make sure this is set to 'true' after this function call finishes
             model_initialized = true;
-            acquire_time_conversion_factor(bmi_model_time_convert_factor);
+            bmi_model_time_convert_factor = get_time_convert_factor();
         }
         // Record the exception message before re-throwing to handle subsequent function calls properly
         catch( models::external::State_Exception& e)

--- a/src/realizations/catchment/Bmi_Cpp_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_Cpp_Adapter.cpp
@@ -39,7 +39,7 @@ Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string libra
             construct_and_init_backing_model_for_type();
             // Make sure this is set to 'true' after this function call finishes
             model_initialized = true;
-            acquire_time_conversion_factor(bmi_model_time_convert_factor);
+            bmi_model_time_convert_factor = get_time_convert_factor();
         }
         // Record the exception message before re-throwing to handle subsequent function calls properly
         catch (const std::exception &e) {

--- a/src/realizations/catchment/Bmi_Py_Adapter.cpp
+++ b/src/realizations/catchment/Bmi_Py_Adapter.cpp
@@ -26,7 +26,7 @@ Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_ini
         construct_and_init_backing_model_for_py_adapter();
         // Make sure this is set to 'true' after this function call finishes
         model_initialized = true;
-        acquire_time_conversion_factor(bmi_model_time_convert_factor);
+        bmi_model_time_convert_factor = get_time_convert_factor();
     }
     catch (std::runtime_error& e){ //Catch specific exception and re-throw so type/message isn't erased
         model_initialized = true;


### PR DESCRIPTION
Replace acquire_time_conversion_factor() function with get_time_convert_factor() function using UnitsHelper.

## Additions

-

## Removals

-

## Changes
To comply with BMI standard, the function ```acquire_time_conversion_factor()``` defined ```Bmi_Adapter.hpp``` is removed and replaced with the function ```get_time_convert_factor()``` which returns the ```bmi_model_time_convert_factor``` used in a number of code files listed below. This is faciliated by BMI interface and ```UnitsHelper``` functions.

include/realizations/catchment/Bmi_Adapter.hpp
include/realizations/catchment/Bmi_Fortran_Adapter.hpp
src/realizations/catchment/Bmi_C_Adapter.cpp
src/realizations/catchment/Bmi_Cpp_Adapter.cpp
src/realizations/catchment/Bmi_Py_Adapter.cpp

## Testing

Run ngen test

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
