### PR TITLE
Work around GCC8's failure to properly parse initializer list literals

### DIFF
--- a/test/utils/mdarray_Test.cpp
+++ b/test/utils/mdarray_Test.cpp
@@ -4,20 +4,30 @@
 
 TEST(mdarray_Test, construction)
 {
-    ngen::mdarray<double> s{{{2, 2}}};
+    // Horrible workaround for GCC8 not quite getting initializer list stuff right
+    size_t indices[] = {2, 2};
+
+    ngen::mdarray<double> s{indices};
 
     EXPECT_EQ(s.rank(), 2);
 
-    ASSERT_NO_THROW(s.insert({{0, 0}}, 1));
-    EXPECT_EQ(s.at({{0, 0}}), 1);
+    indices[0] = 0;
+    indices[1] = 0;
+    ASSERT_NO_THROW(s.insert(indices, 1));
+    EXPECT_EQ(s.at(indices), 1);
 
-    ASSERT_NO_THROW(s.insert({{0, 1}}, 2));
-    EXPECT_EQ(s.at({{0, 1}}), 2);
+    indices[1] = 1;
+    ASSERT_NO_THROW(s.insert(indices, 2));
+    EXPECT_EQ(s.at(indices), 2);
 
-    EXPECT_THROW(s.at({{2, 2}}), std::out_of_range);
+    indices[0] = 2;
+    indices[1] = 2;
+    EXPECT_THROW(s.at(indices), std::out_of_range);
 
-    ASSERT_NO_THROW(s.at({{0, 0}}) = 3);
-    EXPECT_EQ(s.at({{0, 0}}), 3);
+    indices[0] = 0;
+    indices[1] = 0;
+    ASSERT_NO_THROW(s.at(indices) = 3);
+    EXPECT_EQ(s.at(indices), 3);
 }
 
 TEST(mdarray_Test, indexing)
@@ -52,39 +62,44 @@ TEST(mdarray_Test, layout)
 {
     ngen::mdarray<int> a{{2, 2, 2, 2, 2}};
 
+    size_t indices0[] = {0, 0, 0, 0, 0};
+    size_t indices1[] = {1, 0, 0, 0, 0};
     ASSERT_EQ(
-        a.index({{0, 0, 0, 0, 0}}) + 1,
-        a.index({{1, 0, 0, 0, 0}})
+        a.index(indices0) + 1,
+        a.index(indices1)
     );
 
+    size_t indices0a[] = {0, 1, 1, 0, 1};
+    size_t indices1a[] = {1, 1, 1, 0, 1};
     ASSERT_EQ(
-        a.index({{0, 1, 1, 0, 1}}) + 1,
-        a.index({{1, 1, 1, 0, 1}})
+        a.index(indices0a) + 1,
+        a.index(indices1a)
     );
 
     ngen::mdarray<int> b{{2, 2, 2}};
 
+    size_t indices0b[] = {0, 0, 0};
+    size_t indices1b[] = {1, 0, 0};
     ASSERT_EQ(
-        b.index({{0, 0, 0}}) + 1,
-        b.index({{1, 0, 0}})
+        b.index(indices0b) + 1,
+        b.index(indices1b)
     );
 
+    size_t indices0c[] = {0, 1, 1};
+    size_t indices1c[] = {1, 1, 1};
     ASSERT_EQ(
-        b.index({{0, 1, 1}}) + 1,
-        b.index({{1, 1, 1}})
+        b.index(indices0c) + 1,
+        b.index(indices1c)
     );
 
     // add `i` to prevent braces around scalar warnings
     std::initializer_list<std::size_t> i = { 2 };
     ngen::mdarray<int> c{i};
 
+    size_t index0[] = {0};
+    size_t index1[] = {1};
     ASSERT_EQ(
-        c.index({{0}}) + 1,
-        c.index({{1}})
-    );
-
-    ASSERT_EQ(
-        c.index({{0}}) + 1,
-        c.index({{1}})
+        c.index(index0) + 1,
+        c.index(index1)
     );
 }

--- a/test/utils/mdframe_Test.cpp
+++ b/test/utils/mdframe_Test.cpp
@@ -35,9 +35,18 @@ TEST(mdframe_Test, construction)
 
     EXPECT_EQ(df["2D"].size(), 100);
     EXPECT_EQ(df["2D"].rank(), 2);
-    EXPECT_NO_THROW(df["2D"].insert({{0, 0}}, 1.0));
-    EXPECT_NO_THROW(df["2D"].insert({{0, 1}}, 2));
-    EXPECT_THROW(df["2D"].insert({{10, 0}}, 3), std::out_of_range);
-    EXPECT_EQ(df["2D"].at<double>({{0, 0}}), 1);
-    EXPECT_EQ(df["2D"].at<double>({{0, 1}}), 2);
+
+
+    size_t index[] = {0, 0};
+    EXPECT_NO_THROW(df["2D"].insert(index, 1.0));
+    index[1] = 1;
+    EXPECT_NO_THROW(df["2D"].insert(index, 2));
+    index[0] = 10;
+    index[1] = 0;
+    EXPECT_THROW(df["2D"].insert(index, 3), std::out_of_range);
+    index[0] = 0;
+    index[1] = 0;
+    EXPECT_EQ(df["2D"].at<double>(index), 1);
+    index[1] = 1;
+    EXPECT_EQ(df["2D"].at<double>(index), 2);
 }


### PR DESCRIPTION
## Changes

- Convert literal braced-initializer-list constructs to standalone variables in tests, since GCC8 can't convert the literals properly

## Testing

1. Build and run the modified unit tests on UCS3 with GCC8

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
