### PR TITLE
Refactor get_available_variable_names to return a span<string> rather than a concrete vector<string>

### DIFF
--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -222,7 +222,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         return is_param_sum_over_time_step(name);
     }
 
-    const std::vector<std::string> &get_available_variable_names() override {
+    boost::span<const std::string> get_available_variable_names() override {
         return available_forcings;
     }
 

--- a/include/forcing/DataProvider.hpp
+++ b/include/forcing/DataProvider.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <span.hpp>
 
 namespace data_access
 {
@@ -32,7 +33,7 @@ namespace data_access
 
         /** Return the variables that are accessable by this data provider */
 
-        virtual const std::vector<std::string>& get_available_variable_names() = 0;
+        virtual boost::span<const std::string> get_available_variable_names() = 0;
 
         /** Return the first valid time for which data from the request variable  can be requested */
 

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -70,7 +70,7 @@ namespace data_access {
          * @return The names of the outputs for which this instance is (or will be) able to provide values.
          */
 
-        boost::span<const std::string> get_available_variable_names() {
+        boost::span<const std::string> get_available_variable_names() override {
             return providedOutputs;
         }
 

--- a/include/forcing/DeferredWrappedProvider.hpp
+++ b/include/forcing/DeferredWrappedProvider.hpp
@@ -70,7 +70,7 @@ namespace data_access {
          * @return The names of the outputs for which this instance is (or will be) able to provide values.
          */
 
-        const std::vector<std::string> &get_available_variable_names() {
+        boost::span<const std::string> get_available_variable_names() {
             return providedOutputs;
         }
 
@@ -137,7 +137,7 @@ namespace data_access {
             }
 
             // Confirm this will provide everything needed
-            const std::vector<std::string> &available = provider->get_available_variable_names();
+            const auto available = provider->get_available_variable_names();
             for (const std::string &requiredName : providedOutputs) {
                 if (std::find(available.begin(), available.end(), requiredName) == available.end()) {
                     setMessage = "Given provider does not provide the required " + requiredName;

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -67,7 +67,7 @@ namespace data_access
         ~NetCDFPerFeatureDataProvider();
 
         /** Return the variables that are accessable by this data provider */
-        const std::vector<std::string>& get_available_variable_names() override;
+        boost::span<const std::string> get_available_variable_names() override;
 
         /** return a list of ids in the current file */
         const std::vector<std::string>& get_ids() const;

--- a/include/forcing/NullForcingProvider.hpp
+++ b/include/forcing/NullForcingProvider.hpp
@@ -48,7 +48,7 @@ class NullForcingProvider : public data_access::GenericDataProvider
         throw std::runtime_error("Got request for variable " + name + " but no such variable is provided by NullForcingProvider." + SOURCE_LOC);
     }
 
-    const std::vector<std::string> &get_available_variable_names() override {
+    boost::span<const std::string> get_available_variable_names() override {
         return available_forcings;
     }
 

--- a/include/forcing/NullForcingProvider.hpp
+++ b/include/forcing/NullForcingProvider.hpp
@@ -49,13 +49,8 @@ class NullForcingProvider : public data_access::GenericDataProvider
     }
 
     boost::span<const std::string> get_available_variable_names() override {
-        return available_forcings;
+        return {};
     }
-
-    private:
-    
-    std::vector<std::string> available_forcings;
-
 };
 
 #endif // NGEN_NULLFORCING_H

--- a/include/forcing/OptionalWrappedDataProvider.hpp
+++ b/include/forcing/OptionalWrappedDataProvider.hpp
@@ -397,7 +397,7 @@ namespace data_access {
         std::map<std::string, int> defaultUsageWaits;
 
         static bool isSuppliedByProvider(const std::string &outputName, GenericDataProvider *provider) {
-            const std::vector<std::string> &available = provider->get_available_variable_names();
+            auto available = provider->get_available_variable_names();
             return find(available.begin(), available.end(), outputName) != available.end();
         }
 

--- a/include/forcing/WrappedDataProvider.hpp
+++ b/include/forcing/WrappedDataProvider.hpp
@@ -51,7 +51,7 @@ namespace data_access {
          * @return const std::vector<std::string>& the names of available data variables
          */
 
-        const std::vector<std::string> &get_available_variable_names() override {
+        boost::span<const std::string> get_available_variable_names() override {
             return wrapped_provider->get_available_variable_names();
         }
 

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -70,8 +70,7 @@ namespace realization {
          * @return The collection of forcing output property names this instance can provide.
          * @see ForcingProvider
          */
-        //const vector<std::string> &get_available_forcing_outputs() {
-        const std::vector<std::string> &get_available_variable_names() override {
+        boost::span<const std::string> get_available_variable_names() override {
             if (is_model_initialized() && available_forcings.empty()) {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);
@@ -81,10 +80,6 @@ namespace realization {
             }
             return available_forcings;
         }
-
-        //inline const vector<std::string> &get_available_variable_names() override {
-        //    return get_available_forcing_outputs();
-        //}
 
         /**
          * Get the inclusive beginning of the period of time over which this instance can provide data for this forcing.
@@ -219,8 +214,7 @@ namespace realization {
             std::string output_units = selector.get_output_units();
 
             // First make sure this is an available output
-            //const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
-            const std::vector<std::string> forcing_outputs = get_available_variable_names();
+            auto forcing_outputs = get_available_variable_names();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
                 throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
             }
@@ -288,8 +282,7 @@ namespace realization {
             std::string output_units = selector.get_output_units();
 
             // First make sure this is an available output
-            //const std::vector<std::string> forcing_outputs = get_available_forcing_outputs();
-            const std::vector<std::string> forcing_outputs = get_available_variable_names();
+            auto forcing_outputs = get_available_variable_names();
             if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
                 throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
             }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -116,9 +116,7 @@ namespace realization {
          * @return The collection of forcing output property names this instance can provide.
          * @see ForcingProvider
          */
-        //const vector<std::string> &get_available_forcing_outputs();
-        //const vector<std::string> &get_available_variable_names() override { return get_available_forcing_outputs(); }
-        const std::vector<std::string> &get_available_variable_names() override;
+        boost::span <const std::string> get_available_variable_names() override;
 
         /**
         * Get the input variables of 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -262,7 +262,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
 
 NetCDFPerFeatureDataProvider::~NetCDFPerFeatureDataProvider() = default;
 
-const std::vector<std::string>& NetCDFPerFeatureDataProvider::get_available_variable_names()
+boost::span<const std::string> NetCDFPerFeatureDataProvider::get_available_variable_names()
 {
     return variable_names;
 }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -179,8 +179,7 @@ const bool &Bmi_Multi_Formulation::get_allow_model_exceed_end_time() const {
  * @return The collection of forcing output property names this instance can provide.
  * @see ForcingProvider
  */
-//const vector<std::string> &Bmi_Multi_Formulation::get_available_forcing_outputs() {
-const std::vector<std::string> &Bmi_Multi_Formulation::get_available_variable_names() {
+boost::span<const std::string> Bmi_Multi_Formulation::get_available_variable_names() {
     if (is_model_initialized() && available_forcings.empty()) {
         for (const nested_module_ptr &module: modules) {
             for (const std::string &out_var_name: module->get_bmi_output_variables()) {

--- a/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
+++ b/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
@@ -169,7 +169,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataUnitConversion)
 ///Test AORC Forcing Object
 TEST_F(CsvPerFeatureForcingProviderTest, TestGetAvailableForcingOutputs)
 {
-    const std::vector<std::string>& afos = Forcing_Object->get_available_variable_names();
+    auto afos = Forcing_Object->get_available_variable_names();
     EXPECT_EQ(afos.size(), 18);
     EXPECT_TRUE(std::find(afos.begin(), afos.end(), "DLWRF_surface") != afos.end());
     EXPECT_TRUE(std::find(afos.begin(), afos.end(), CSDMS_STD_NAME_SOLAR_LONGWAVE) != afos.end());

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -23,7 +23,7 @@ namespace data_access {
                 outputs.push_back(OUTPUT_NAME_1);
             }
                                   
-            const std::vector<std::string>& get_available_variable_names() override {
+            boost::span<const std::string> get_available_variable_names() override {
                 return outputs;
             }
 


### PR DESCRIPTION
This allows implementations to vary how they store and provide the available names (to some extent), potentially cutting memory overhead.

## Changes

- Change `DataProvider` interface and all implementations to return `span<string>`
- Use `auto` at call sites, since they uniformly don't actually care that they've gotten a vector, as opposed to a `find()`-able collection

## Notes

- Inspired by this comment: https://github.com/NOAA-OWP/ngen/pull/601/files#r1330439844 which marks a spot that is now changed in tandem

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
