### PR TITLE
Replace unused boost/bind.hpp with std's <functional>

### DIFF
--- a/include/utilities/mdframe/variable.hpp
+++ b/include/utilities/mdframe/variable.hpp
@@ -5,7 +5,7 @@
 #include "traits.hpp"
 #include "dimension.hpp"
 #include <initializer_list>
-#include <boost/bind.hpp>
+#include <functional>
 
 #include "visitors.hpp"
 


### PR DESCRIPTION
The Boost header was generating warnings about unqualified placeholder names that it was defining in the global namespace. We weren't using the Boost placeholders anyway.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
