### PR TITLE
Update vendored cfe submodule

### DIFF
--- a/data/example_bmi_multi_realization_config.json
+++ b/data/example_bmi_multi_realization_config.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -68,7 +68,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/data/example_bmi_multi_realization_config_w_netcdf.json
+++ b/data/example_bmi_multi_realization_config_w_netcdf.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -68,7 +68,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/data/example_bmi_multi_realization_config_w_nfp.json
+++ b/data/example_bmi_multi_realization_config_w_nfp.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
                                     "ice_fraction_schaake(1,double,m,node)": 0.0,
-                                    "ice_fraction_xinan(1,double,1,node)": 0.0,
+                                    "ice_fraction_xinanjiang(1,double,1,node)": 0.0,
                                     "soil_moisture_profile(1,double,1,node)": 0.0,
                                     "land_surface_air__temperature(1,double,K,node)": 285.8000183105469,
                                     "atmosphere_water__liquid_equivalent_precipitation_rate(1,double,mm/s,node)": 0.1,

--- a/data/example_bmi_multi_realization_config_w_noah_pet_cfe.json
+++ b/data/example_bmi_multi_realization_config_w_noah_pet_cfe.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -84,7 +84,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/data/example_bmi_multi_realization_config_w_routing.json
+++ b/data/example_bmi_multi_realization_config_w_routing.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
                                     "ice_fraction_schaake(1,double,m,node)": 0.0,
-                                    "ice_fraction_xinan(1,double,none,node)": 0.0,
+                                    "ice_fraction_xinanjiang(1,double,none,node)": 0.0,
                                     "soil_moisture_profile(1,double,none,node)": 0.0
                                 }
                             }

--- a/data/gauge_01073000/example_bmi_multi_realization_config_w_routing.json
+++ b/data/gauge_01073000/example_bmi_multi_realization_config_w_routing.json
@@ -26,7 +26,7 @@
                                 },
                                 "model_params": {
                                     "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-                                    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+                                    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
                                     "sloth_smp(1,double,1,node)": 0.0
                                 }
                             }
@@ -80,7 +80,7 @@
                                     "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
                                     "water_potential_evaporation_flux": "water_potential_evaporation_flux",
                                     "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-                                    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
                                     "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/data/test_bmi_multi_realization_config.json
+++ b/data/test_bmi_multi_realization_config.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -68,7 +68,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/data/test_bmi_multi_realization_config_w_netcdf.json
+++ b/data/test_bmi_multi_realization_config_w_netcdf.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -68,7 +68,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/data/test_bmi_multi_realization_config_w_noah_pet_cfe.json
+++ b/data/test_bmi_multi_realization_config_w_noah_pet_cfe.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -84,7 +84,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false

--- a/extern/cfe/CMakeLists.txt
+++ b/extern/cfe/CMakeLists.txt
@@ -13,16 +13,16 @@ set(CFE_LIB_DESC_CMAKE "OWP CFE BMI Module Shared Library")
 add_compile_definitions(BMI_ACTIVE)
 
 if(WIN32)
-    add_library(cfebmi cfe/src/bmi_cfe.c cfe/src/cfe.c cfe/src/giuh.c)
+    add_library(cfebmi cfe/src/bmi_cfe.c cfe/src/cfe.c cfe/src/giuh.c cfe/src/conceptual_reservoir.c)
 else()
-    add_library(cfebmi SHARED cfe/src/bmi_cfe.c cfe/src/cfe.c cfe/src/giuh.c)
+    add_library(cfebmi SHARED cfe/src/bmi_cfe.c cfe/src/cfe.c cfe/src/giuh.c cfe/src/conceptual_reservoir.c)
 endif()
 
 target_include_directories(cfebmi PRIVATE cfe/include)
 
 set_target_properties(cfebmi PROPERTIES VERSION ${PROJECT_VERSION})
 
-set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER cfe/bmi_cfe.h)
+set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER cfe/include/bmi_cfe.h)
 
 # Code requires minimum of C99 standard to compile
 set_target_properties(cfebmi PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Update the vendored version of the cfe submodule. Several additions and changes are introduced in this update. To the best of my abilities, these additions and changes are listed below. 

Note, with this update, `extern/cfe/CMakeList.txt` is now out of date and will not build all portions of cfe. Before merging this PR, the `CMakeList` in `extern/cfe` either needs to be updated or removed. In the mean time, the latest version of `cfe` can be built (from the root of the `ngen` repo) using:

```shell
cmake -DNGEN=ON -B extern/cfe/cfe/cmake_build -S extern/cfe/cfe 
cmake --build extern/cfe/cfe/cmake_build
```

## Additions

- New output variable `SOIL_TO_GW_FLUX` (percolation) added (https://github.com/NOAA-OWP/cfe/pull/92).

## Changes

- Variable name `ice_fraction_xinan` is now named `ice_fraction_xinanjiang`(https://github.com/NOAA-OWP/cfe/pull/94).
- Cmake updated to support building for BMI (https://github.com/NOAA-OWP/cfe/pull/81).
- Potential `char` overflow in `read_file_line_counts` fixed (https://github.com/NOAA-OWP/cfe/pull/85).

## Todos

- [x] Update ~/ remove~ `extern/cfe/CMakeList.txt`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: