### PR TITLE
Sqlite null fix

### DIFF
--- a/include/geojson/features/FeatureBase.hpp
+++ b/include/geojson/features/FeatureBase.hpp
@@ -397,12 +397,16 @@ namespace geojson {
             }
 
             std::string get_id(std::string alt_id) const {
+                std::string tmp = id;
                 try{
-                    return get_property(alt_id).as_string();
+                    tmp = get_property(alt_id).as_string();
+                    //if the property exists, but its value is NaN/null
+                    if(tmp == "null") tmp = id;
                 }
                 catch(...){
-                    return id;
+                    tmp = id;
                 }
+                return tmp;
             }
 
             int get_number_of_destination_features() {

--- a/src/geopackage/sqlite/iterator.cpp
+++ b/src/geopackage/sqlite/iterator.cpp
@@ -76,7 +76,13 @@ sqlite_iter& sqlite_iter::next()
         const int returncode = sqlite3_step(this->ptr());
         if (returncode == SQLITE_DONE) {
             this->iteration_finished = true;
-        } else if (returncode != SQLITE_ROW) {
+        }
+        else if( returncode == SQLITE_ROW){
+            //Update column dtypes for the next row
+            for (int i = 0; i < this->column_count && i < column_types.size(); i++) {
+                this->column_types[i] = (sqlite3_column_type(this->ptr(), i));
+            }
+        } else {
             throw sqlite_error("sqlite3_step", returncode);
         }
         this->iteration_step++;

--- a/src/geopackage/sqlite/iterator.cpp
+++ b/src/geopackage/sqlite/iterator.cpp
@@ -78,7 +78,18 @@ sqlite_iter& sqlite_iter::next()
             this->iteration_finished = true;
         }
         else if( returncode == SQLITE_ROW){
-            //Update column dtypes for the next row
+            // Update column dtypes for the next row
+            // There are a couple ways to do this, each with some nuance:
+            // 1) use sqlite3_column_type upon construction of the iterator and inspect the first row
+            //    then use those column types for all rows
+            // 2) use the sqlite3 table definition schema (i.e. PRAGMA table_info(...);) to get column types
+            // 3) check each row during iteration using sqlite3_column_type
+            // 1 & 2 may not produce consistent results because if the value in a column is NaN, 
+            // then sqlite3_column_type will report that as a 5 or NULL type, even if the schema has a datatype
+            // Using 1, when the first row contains NaN but other rows have valid data, then all types are reported as NULL.
+            // Using 2, any NaN/NULL data will get interperted as the schema type
+            // Using 3 ensures we get a non-null type if there is valid data in the column in that row, and NULL when 
+            // no data is present, with a small bit of additional iterator overhead.
             for (int i = 0; i < this->column_count && i < column_types.size(); i++) {
                 this->column_types[i] = (sqlite3_column_type(this->ptr(), i));
             }


### PR DESCRIPTION
Fix handling of null/nan enteries in hydrofabric.

## Changes

- Allow sqlite iterator to read column types per iteratorion
- Check for string `"null"` in alt_ids when referencing feature by alternative id property

## Testing

1. Tested locally, and via local use of the partition generator to generate partitions of huc01 hydrofabric.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS