### PR TITLE
Fix HY_Features_MPI to match feature-type behavior of HY_Features from PR #665

### DIFF
--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -34,7 +34,7 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         destinations  = network.get_destination_ids(feat_id);
         //Find upstream ids
         origins = network.get_origination_ids(feat_id);
-        if(feat_type == "cat" || feat_type == "agg")
+        if(hy_features::identifiers::isCatchment(feat_type))
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
@@ -60,7 +60,7 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
 
           _catchments.emplace(feat_id, c);
         }
-        else if(feat_type == "nex" || feat_type == "tnx")
+        else if(hy_features::identifiers::isNexus(feat_type))
         {   //origins only contains LOCAL origin features (catchments) as read from
             //the geojson/partition subset.  We need to make sure `origins` passed to remote nexus
             //contain IDS of ALL upstream features, including those in remote partitions


### PR DESCRIPTION
#665 modified `HY_Features.cpp` to use predicate functions that recognize a broader set of identifier prefixes to describe catchments and nexuses. The corresponding change to the mostly-duplicate code in `HY_Features_MPI` was not made, so I do that here.

## Changes

- Use `isCatchment()` and `isNexus()` predicate functions

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
