### PR TITLE
Update ngen build timeout to 20 minutes

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -73,7 +73,7 @@ jobs:
           #is this required for this test?
           bmi_c: 'ON'
           bmi_fortran: 'ON'
-        timeout-minutes: 15
+        timeout-minutes: 20
 
       - name: Run surfacebmi plus cfebmi
         run: |


### PR DESCRIPTION
Give runner a little more time to build ngen successfully before timing out.