### PR TITLE
Move get_var_value_as_double up hierarchy, as it was inadvertently duplicated as a non-override

### DIFF
--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -219,7 +219,7 @@ namespace realization {
          * Get value for some BMI model variable.
          *
          * This function assumes that the given variable, while returned by the model within an array per the BMI spec,
-         * is actual a single, scalar value.  Thus, it returns what is at index 0 of the array reference.
+         * is actually a single, scalar value.  Thus, it returns what is at index 0 of the array reference.
          *
          * @param index
          * @param var_name

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -215,6 +215,38 @@ namespace realization {
             *output_text_stream << std::setprecision(output_precision);
         }
 
+        /**
+         * Get value for some BMI model variable.
+         *
+         * This function assumes that the given variable, while returned by the model within an array per the BMI spec,
+         * is actual a single, scalar value.  Thus, it returns what is at index 0 of the array reference.
+         *
+         * @param index
+         * @param var_name
+         * @return
+         */
+        virtual double get_var_value_as_double(const std::string& var_name) = 0;
+
+        /**
+         * Get value for some BMI model variable at a specific index.
+         *
+         * Function gets the value for a provided variable, returned from the backing model as an array, and returns the
+         * specific value at the desired index cast as a double type.
+         *
+         * The function makes several assumptions:
+         *
+         *     1. `index` is within array bounds
+         *     2. `var_name` is in the set of valid variable names for the model
+         *     3. the type for output variable allows the value to be cast to a `double` appropriately
+         *
+         * It falls to user (functions) of this function to ensure these assumptions hold before invoking.
+         *
+         * @param index
+         * @param var_name
+         * @return
+         */
+        virtual double get_var_value_as_double(const int& index, const std::string& var_name) = 0;
+
     protected:
 
         /** Object to help with converting numeric output values to text. */

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -462,39 +462,6 @@ namespace realization {
         const time_t &get_bmi_model_start_time_forcing_offset_s() override {
             return bmi_model_start_time_forcing_offset_s;
         }
-
-        /**
-         * Get value for some BMI model variable.
-         *
-         * This function assumes that the given variable, while returned by the model within an array per the BMI spec,
-         * is actual a single, scalar value.  Thus, it returns what is at index 0 of the array reference.
-         *
-         * @param index
-         * @param var_name
-         * @return
-         */
-        virtual double get_var_value_as_double(const std::string& var_name) = 0;
-
-        /**
-         * Get value for some BMI model variable at a specific index.
-         *
-         * Function gets the value for a provided variable, returned from the backing model as an array, and returns the
-         * specific value at the desired index cast as a double type.
-         *
-         * The function makes several assumptions:
-         *
-         *     1. `index` is within array bounds
-         *     2. `var_name` is in the set of valid variable names for the model
-         *     3. the type for output variable allows the value to be cast to a `double` appropriately
-         *
-         * It falls to user (functions) of this function to ensure these assumptions hold before invoking.
-         *
-         * @param index
-         * @param var_name
-         * @return
-         */
-        virtual double get_var_value_as_double(const int& index, const std::string& var_name) = 0;
-
         /**
          * Universal logic applied when creating a BMI-backed formulation from NGen config.
          *

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -546,7 +546,7 @@ namespace realization {
          * @param var_name
          * @return
          */
-        double get_var_value_as_double(const std::string &var_name) {
+        double get_var_value_as_double(const std::string &var_name) override {
             return get_var_value_as_double(0, var_name);
         }
 
@@ -574,7 +574,7 @@ namespace realization {
          * @param var_name
          * @return
          */
-        double get_var_value_as_double(const int& index, const std::string& var_name) {
+        double get_var_value_as_double(const int& index, const std::string& var_name) override {
             auto data_provider_iter = availableData.find(var_name);
             if (data_provider_iter == availableData.end()) {
                 throw external::ExternalIntegrationException(


### PR DESCRIPTION
This method exists in both `Bmi_Module_Formulation` (from which it's overridden by the language-specific implementations) and `Bmi_Multi_Formulation`, with the exact same interface and apparent intended use.

## Changes

- Declare `get_var_value_as_double` at the common base class, not separately in different child classes

## Testing

- Ordinary CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
