### PR TITLE
Ensure forcing path when file_pattern configured.

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -477,11 +477,11 @@ namespace realization {
             }
 
             forcing_params get_forcing_params(geojson::PropertyMap &forcing_prop_map, std::string identifier, simulation_time_params &simulation_time_config) {
-                std::string path = "";
+                std::string path;
                 if(forcing_prop_map.count("path") != 0){
                     path = forcing_prop_map.at("path").as_string();
                 }
-                std::string provider = "";
+                std::string provider;
                 if(forcing_prop_map.count("provider") != 0){
                     provider = forcing_prop_map.at("provider").as_string();
                 }
@@ -492,6 +492,11 @@ namespace realization {
                         simulation_time_config.start_time,
                         simulation_time_config.end_time
                     );
+                }
+
+                if (path.empty()) {
+                    throw std::runtime_error("Error with NGEN config - 'path' in forcing params must be set to a "
+                                             "non-empty parent directory path when 'file_pattern' is used.");
                 }
 
                 // Since we are given a pattern, we need to identify the directory and pull out anything that matches the pattern


### PR DESCRIPTION
## TL;DR

This change enforces requiring a `path` whenever `file_pattern` is present in forcing params in a realization config.

## Explanation

The addition of `NullForcingProvider` included support for the absence of a `path` value from `forcing` in a realization config.  

```json
        "forcing": {
            "provider": "NullForcingProvider"
        }
```

Those changes did not fully account for user errors involving omitting the `path` in other situations, in particular when a `file_pattern` is configured; e.g., doing this

```json
        "forcing": {
           "file_pattern": "/dmod/datasets/forcing/regridded/regrid_01/csv/{{id}}.csv",
           "provider":  "CsvPerFeature"
        }
```

instead of this

```json
        "forcing": {
           "file_pattern": "{{id}}.csv",
           "path": "/dmod/datasets/forcing/regridded/regrid_01/csv/",
           "provider":  "CsvPerFeature"
        }
```

Now an error will be thrown explaining that `path` needs to be set to the parent directory.