### PR TITLE
Runtime debug information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,6 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 # Define project version and use via generated config header
 project(ngen VERSION 0.1.0)
 
-configure_file("${NGEN_INC_DIR}/NGenConfig.h.in" "${NGEN_INC_DIR}/NGenConfig.h")
-
 add_executable(ngen "${NGEN_SRC_DIR}/NGen.cpp")
 
 # Dependencies ================================================================
@@ -245,19 +243,23 @@ endif()
 # -----------------------------------------------------------------------------
 
 # Syntax: ngen_multiline_message("<message 1>" "<message 2>" ...)
-function(ngen_multiline_message)
+macro(ngen_multiline_message)
 set(messages "${ARGN}")
 foreach(msg IN LISTS messages)
+    set(_CONF "${NGEN_CONF_SUMMARY}")
+    string(APPEND _CONF "${msg}\n")
+    set(NGEN_CONF_SUMMARY "${_CONF}")
+
     message(STATUS "${msg}")
 endforeach()
-endfunction()
+endmacro()
 
 # Syntax: ngen_dependent_multiline_message(<variable> "<message 1>" "<message 2>" ...)
-function(ngen_dependent_multiline_message VARIABLE)
+macro(ngen_dependent_multiline_message VARIABLE)
 if(${VARIABLE})
     ngen_multiline_message(${ARGN})
 endif()
-endfunction()
+endmacro()
 
 # This is used purely for configuration output,
 # and does not affect the virtual environment used.
@@ -311,6 +313,7 @@ ngen_dependent_multiline_message(NGEN_WITH_MPI
 "    Include: ${MPI_CXX_INCLUDE_DIRS}")
 ngen_dependent_multiline_message(NGEN_WITH_NETCDF
 "  NetCDF:"
+"    Version: ${NETCDF_VERSION}"
 "    Library: ${NETCDF_LIBRARY}"
 "    Library (CXX): ${NETCDF_CXX_LIBRARIES}"
 "    Include: ${NETCDF_INCLUDE_DIR}"
@@ -343,3 +346,5 @@ ngen_dependent_multiline_message(NGEN_WITH_PYTHON
 "    pybind11 Version: ${pybind11_VERSION}"
 "    pybind11 Include: ${pybind11_INCLUDE_DIR}")
 message(STATUS "---------------------------------------------------------------------")
+
+configure_file("${NGEN_INC_DIR}/NGenConfig.h.in" "${NGEN_INC_DIR}/NGenConfig.h")

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -113,11 +113,27 @@ list (APPEND NetCDF_libs "${NETCDF_C_LIBRARIES}")
 set (NETCDF_LIBRARIES ${NetCDF_libs})
 set (NETCDF_INCLUDE_DIRS ${NetCDF_includes})
 
+if(NETCDF_C_INCLUDE_DIRS)
+  file(STRINGS "${NETCDF_C_INCLUDE_DIRS}/netcdf_meta.h" _netcdf_ver
+    REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+  
+  string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_ver}")
+  string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_ver}")
+  string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_ver}")
+  string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_ver}")
+  set(NETCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+  unset(_netcdf_version_major)
+  unset(_netcdf_version_minor)
+  unset(_netcdf_version_patch)
+  unset(_netcdf_version_note)
+  unset(_netcdf_version_lines)
+endif()
+
 # handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if
 # all listed variables are TRUE
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (NetCDF
-  DEFAULT_MSG NETCDF_LIBRARIES NETCDF_INCLUDE_DIRS NETCDF_HAS_INTERFACES)
+find_package_handle_standard_args(NetCDF
+  DEFAULT_MSG NETCDF_LIBRARIES NETCDF_INCLUDE_DIRS NETCDF_HAS_INTERFACES NETCDF_VERSION)
 
 function(FindNetCDF_get_is_parallel_aware include_dir)
   file(STRINGS "${include_dir}/netcdf_meta.h" _netcdf_lines

--- a/include/NGenConfig.h.in
+++ b/include/NGenConfig.h.in
@@ -1,8 +1,57 @@
 #ifndef NGEN_NGENCONFIG_H
 #define NGEN_NGENCONFIG_H
 
+#define NGEN_STRINGIFY(x) #x
+#define NGEN_STRING(x) NGEN_STRINGIFY(x)
+
 #define ngen_VERSION_MAJOR @ngen_VERSION_MAJOR@
 #define ngen_VERSION_MINOR @ngen_VERSION_MINOR@
 #define ngen_VERSION_PATCH @ngen_VERSION_PATCH@
+#define ngen_VERSION NGEN_STRING(ngen_VERSION_MAJOR.ngen_VERSION_MINOR.ngen_VERSION_PATCH)
+
+#cmakedefine01 NGEN_WITH_MPI
+#cmakedefine01 NGEN_WITH_NETCDF
+#cmakedefine01 NGEN_WITH_SQLITE
+#cmakedefine01 NGEN_WITH_UDUNITS
+#cmakedefine01 NGEN_WITH_BMI_FORTRAN
+#cmakedefine01 NGEN_WITH_BMI_C
+#cmakedefine01 NGEN_WITH_PYTHON
+#cmakedefine01 NGEN_WITH_ROUTING
+#cmakedefine01 NGEN_WITH_TESTS
+#cmakedefine01 NGEN_QUIET
+
+#include <string>
+
+namespace ngen {
+
+struct exec_info
+{
+    // Executable version
+
+    static constexpr const char* version   = ngen_VERSION;
+
+    // Compile-time feature flags
+
+    static constexpr bool with_mpi         = NGEN_WITH_MPI;
+    static constexpr bool with_netcdf      = NGEN_WITH_NETCDF;
+    static constexpr bool with_sqlite      = NGEN_WITH_SQLITE;
+    static constexpr bool with_udunits     = NGEN_WITH_UDUNITS;
+    static constexpr bool with_bmi_fortran = NGEN_WITH_BMI_FORTRAN;
+    static constexpr bool with_bmi_c       = NGEN_WITH_BMI_C;
+    static constexpr bool with_python      = NGEN_WITH_PYTHON;
+    static constexpr bool with_routing     = NGEN_WITH_ROUTING;
+    static constexpr bool with_quiet       = NGEN_QUIET;
+
+    //! Compile-time build summary
+    static constexpr const char* build_summary = R"(@NGEN_CONF_SUMMARY@)";
+
+    static void runtime_summary(std::ostream& stream) noexcept;
+    static void runtime_usage(const std::string& cmd, std::ostream& stream) noexcept;
+};
+
+} // namespace ngen
+
+#undef NGEN_STRING
+#undef NGEN_STRINGIFY
 
 #endif //NGEN_NGENCONFIG_H

--- a/include/NGenConfig.h.in
+++ b/include/NGenConfig.h.in
@@ -24,7 +24,7 @@
 
 namespace ngen {
 
-struct exec_info
+namespace exec_info
 {
     // Executable version
 
@@ -45,8 +45,8 @@ struct exec_info
     //! Compile-time build summary
     static constexpr const char* build_summary = R"(@NGEN_CONF_SUMMARY@)";
 
-    static void runtime_summary(std::ostream& stream) noexcept;
-    static void runtime_usage(const std::string& cmd, std::ostream& stream) noexcept;
+    void runtime_summary(std::ostream& stream) noexcept;
+    void runtime_usage(const std::string& cmd, std::ostream& stream) noexcept;
 };
 
 } // namespace ngen

--- a/include/core/nexus/HY_PointHydroNexusRemote.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemote.hpp
@@ -10,6 +10,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <list>
 
 
 /** This class representa a point nexus that can have both upstream and downstream connections to catments that are

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <pybind11/gil.h>
-#include <pybind11/pytypes.h>
 #include <string>
 #include <unordered_map>
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <pybind11/embed.h>
 #include <string>
 #include <unordered_map>
 
@@ -25,6 +24,7 @@
 #endif // WRITE_PID_FILE_FOR_GDB_SERVER
 
 #ifdef ACTIVATE_PYTHON
+#include <pybind11/embed.h>
 #include "python/InterpreterUtil.hpp"
 #endif // ACTIVATE_PYTHON
     

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -63,14 +63,9 @@ void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept
     stream << "Runtime configuration summary:\n";
 
 #if NGEN_WITH_MPI
-
-    MPI_Init(nullptr, nullptr);
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpi_num_procs);
-
     stream << "  MPI:\n"
+           << "    Rank: " << mpi_rank << "\n"
            << "    Processors: " << mpi_num_procs << "\n";
-    
 #endif // NGEN_WITH_MPI
   
 #if NGEN_WITH_PYTHON // -------------------------------------------------------
@@ -131,14 +126,23 @@ void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept
 
 int main(int argc, char *argv[]) {
 
-    if (argc > 1 && std::string{argv[1]} == "info") {
+    if (argc > 1 && std::string{argv[1]} == "--info") {
+        #if NGEN_WITH_MPI
+        MPI_Init(nullptr, nullptr);
+        MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &mpi_num_procs);
+
+        if (mpi_rank == 0) {
+        #endif
+
         std::ostringstream output;
         output << ngen::exec_info::build_summary;
         ngen::exec_info::runtime_summary(output);
-
         std::cout << output.str() << std::endl;
 
         #if NGEN_WITH_MPI
+        } // if (mpi_rank == 0)
+  
         MPI_Finalize();
         #endif
 


### PR DESCRIPTION
This PR adds the capability to call `ngen --info` to provide debugging information regarding the user's environment at runtime, instead of only at build-time. This is to address the main concern of providing support to users where the capabilities of their executable are not provided, i.e. NGIAB containers.

<details>
<summary><strong>Example Output</strong></summary>

```
user$ ngen --info
NGen version: 0.1.0
Build configuration summary:
  Generator: Ninja
  Build type: Release
  System: Linux
  C Compiler: /usr/bin/clang
  CXX Compiler: /usr/bin/clang++
  Flags:
    NGEN_WITH_MPI: ON
    NGEN_WITH_NETCDF: ON
    NGEN_WITH_SQLITE: ON
    NGEN_WITH_UDUNITS: ON
    NGEN_WITH_BMI_FORTRAN: OFF
    NGEN_WITH_BMI_C: ON
    NGEN_WITH_PYTHON: ON
    NGEN_WITH_ROUTING: ON
    NGEN_WITH_TESTS: ON
    NGEN_QUIET: OFF
Environment summary:
  Boost:
    Version: 1.83.0
    Include: /usr/include
  MPI (C):
    Version: 4.0
    Library: /usr/local/lib/libmpi.so
    Include: /usr/local/include
  MPI (CXX):
    Version: 4.0
    Library: /usr/local/lib/libmpicxx.so,/usr/local/lib/libmpi.so
    Include: /usr/local/include
  NetCDF:
    Version: 4.9.2
    Library: /usr/lib/libnetcdf.so
    Library (CXX): /usr/lib/libnetcdf_c++4.so
    Include: /usr/include
    Parallel: FALSE
  SQLite:
    Version: 3.44.0
    Library: /usr/lib/libsqlite3.so
    Include: /usr/include
  UDUNITS2:
    Library: /usr/lib/libudunits2.so
    Include: /usr/include
  Python:
    Version: 3.11.5
    Virtual Env: <none>
    Executable: /usr/bin/python3.11
    Interpreter Type: Python
    Site Library: /usr/lib/python3.11/site-packages
    Include: /usr/include/python3.11
    Runtime Library: /usr/lib
    NumPy Version: 1.26.1
    NumPy Include: /usr/lib/python3.11/site-packages/numpy/core/include
    pybind11 Version: 
    pybind11 Include: /path/to/ngen/extern/pybind11/include
Runtime configuration summary:
  MPI:
    Processors: 1
  Python:
    Version: 3.11.5 (main, Sep  2 2023, 14:16:33) [GCC 13.2.1 20230801]
    Virtual Env: <none>
    Executable: /usr/bin/python3
    Site Library: /usr/lib/python3.11/site-packages
    Include: /usr/include/python3.11
    Runtime Library: /usr/lib/python3.11
    NumPy Version: 1.26.1
    NumPy Include: /usr/lib/python3.11/site-packages/numpy/core/include
```

</details>

## Additions

- Build-time configured namespace `ngen::exec_info` that has `constexpr` information for version, flags, configure-time build summary, and a runtime summary function.

## Changes

- Modifies the root `CMakeLists.txt` to capture the output of the build summary.
- Modifies the root `CMakeLists.txt` to configure the header at the end of the file, rather than after project definition.
- Modifies FindNetcdf.cmake to parse version information.
- Adds `#include <list>` to `include/core/nexus/HY_PointHydroNexusRemote.hpp` as this gave a compilation issue with clang 16.
- Modifies `ngen::main()` to support calling `ngen --info` without running a workflow.

## Testing

Manually tested output of `ngen info` using GCC 13, clang 16, and IntelLLVM.

## Notes/TODO

- Getting information about t-route when `NGEN_WITH_ROUTING=ON` would be useful, however, it's a bit tricky since t-route does not version its python package, and since it defaults to an editable install. May need a bit more thinking about how this would be implemented, i.e. hash all package files to get a combined "package hash"?

- A follow-on PR organizing the `main` function is probably needed, I think we should begin taking a look at how to better organize our CLI component, e.g. use GNU `getopt`?

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: