### PR TITLE
escape regex characters that may appear in identifiers, fixes #680

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -503,6 +503,18 @@ namespace realization {
                 if (path.compare(path.size() - 1, 1, "/") != 0) {
                     path += "/";
                 }
+                
+                //In case an idntifier has regex specific characters, need to escape them
+                //This may not be the most optimal algorithm, but for the size of strings we care about, it should work ok for now.
+		std::string::size_type n = 0;
+                for( const char& c : {'.', '+'} ){
+
+                    while ( ( n = identifier.find( c, n ) ) != std::string::npos )
+                    {
+                        identifier.replace( n, 1, std::string("\\\\")+c );
+                        n += 5; //start next find after we replace
+                    }
+                }
 
                 std::string filepattern = forcing_prop_map.at("file_pattern").as_string();
 


### PR DESCRIPTION
## Changes

- When searching for forcing files by pattern, escape regex characters that may be in the ID string before making the pattern

## TODO

- Add test case for scientific notation ID

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
