### PR TITLE
Improve error message for failure when opening CSV

### DIFF
--- a/include/utilities/CSV_Reader.h
+++ b/include/utilities/CSV_Reader.h
@@ -34,8 +34,8 @@ inline std::vector<std::vector<std::string> > CSVReader::getData()
     std::ifstream file(fileName);
 
         if(file.fail()){
-            /// \todo TODO: Return appropriate error
-            throw std::runtime_error("Error: Input file " + fileName + " does not exist.");
+            throw std::runtime_error(
+                    "Errno " + std::to_string(errno) + " (" + strerror(errno) + ") opening " + fileName);
 
             /// \todo Potentially only output warning and fill array with sentinel values.
         }

--- a/include/utilities/CSV_Reader.h
+++ b/include/utilities/CSV_Reader.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <cerrno>
 
 /*
  * @brief A class to read data from a csv file.

--- a/include/utilities/CSV_Reader.h
+++ b/include/utilities/CSV_Reader.h
@@ -31,14 +31,18 @@ public:
 */
 inline std::vector<std::vector<std::string> > CSVReader::getData()
 {
+    errno = 0;
     std::ifstream file(fileName);
 
-        if(file.fail()){
-            throw std::runtime_error(
-                    "Errno " + std::to_string(errno) + " (" + strerror(errno) + ") opening " + fileName);
+    if (file.fail()) {
+        throw std::runtime_error(
+                errno == 0
+                    ? "Error: failure opening " + fileName
+                    : "Errno " + std::to_string(errno) + " (" + strerror(errno) + ") opening " + fileName
+        );
 
-            /// \todo Potentially only output warning and fill array with sentinel values.
-        }
+        /// \todo Potentially only output warning and fill array with sentinel values.
+    }
 
     std::vector<std::vector<std::string> > dataList;
 


### PR DESCRIPTION
Adding `errno` and associate description for error to runtime_error thrown when failing to create ifstream for in `CSVReader::getData()`.