### PR TITLE
Symlink data directories into build directories

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,11 +9,15 @@ add_dependencies(ngen testbmicppmodel)
 
 # =============================================================================
 
-# Create a symlink between the root data directory in the source tree and the build tree
-file(CREATE_LINK "${NGEN_ROOT_DIR}/data" "${PROJECT_BINARY_DIR}/data" SYMBOLIC)
+# If ${NGEN_ROOT_DIR} and ${PROJECT_BINARY_DIR} are the same, then we have an in-source build
+# and this is not necessary.
+if(NOT NGEN_ROOT_DIR STREQUAL PROJECT_BINARY_DIR)
+    # Create a symlink between the root data directory in the source tree and the build tree
+    file(CREATE_LINK "${NGEN_ROOT_DIR}/data" "${PROJECT_BINARY_DIR}/data" SYMBOLIC)
 
-# Create a symlink between the test data directory in the source tree and the build tree
-file(CREATE_LINK "${CMAKE_CURRENT_LIST_DIR}/data" "${PROJECT_BINARY_DIR}/test/data" SYMBOLIC)
+    # Create a symlink between the test data directory in the source tree and the build tree
+    file(CREATE_LINK "${CMAKE_CURRENT_LIST_DIR}/data" "${PROJECT_BINARY_DIR}/test/data" SYMBOLIC)
+endif()
 
 # =============================================================================
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,16 @@ git_update_submodule(${NGEN_EXT_DIR}/bmi-cxx)
 add_subdirectory(${TEST_BMI_CPP_DIR} ${TEST_BMI_CPP_DIR}/cmake_build)
 add_dependencies(ngen testbmicppmodel)
 
+# =============================================================================
+
+# Create a symlink between the root data directory in the source tree and the build tree
+file(CREATE_LINK "${NGEN_ROOT_DIR}/data" "${PROJECT_BINARY_DIR}/data" SYMBOLIC)
+
+# Create a symlink between the test data directory in the source tree and the build tree
+file(CREATE_LINK "${CMAKE_CURRENT_LIST_DIR}/data" "${PROJECT_BINARY_DIR}/test/data" SYMBOLIC)
+
+# =============================================================================
+
 if (NGEN_WITH_PYTHON)
     add_compile_definitions(NGEN_BMI_PY_TESTS_ACTIVE)
 endif()


### PR DESCRIPTION
This PR adds symlinks to the `data/` and `test/data/` directories in out-of-source build directories. This is done through CMake's `file(CREATE_LINK ...)` command.

## Additions

- `file()` call to symlink `<root>/data -> <build>/data`
- `file()` call to symlink `<root>/test/data -> <build>/test/data`

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
- [x] macOS
