### PR TITLE
Enable testing with out-of-tree builds

### DIFF
--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -290,8 +290,8 @@ jobs:
       - name: run_bmi_python_tests
         run: |
           . .venv/bin/activate
-          cd ./cmake_build/test/
-          ./test_bmi_python
+          cd ./cmake_build/
+          ./test/test_bmi_python
           cd ../../
         timeout-minutes: 15
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ if(NGEN_WITH_PYTHON)
     add_compile_definitions(ACTIVATE_PYTHON=true)
     find_package(Python 3.6.8 REQUIRED COMPONENTS Interpreter Development NumPy)
     set(PYTHON_EXECUTABLE ${Python_EXECUTABLE}) # Case-sensitive difference
-    add_subdirectory(extern/pybind11)
+    add_subdirectory(extern/pybind11 pybind11)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -98,7 +98,7 @@ namespace models {
                         this->init_exception_msg =
                                 "Can't init " + this->model_name + "; library file path is empty";
                         throw std::runtime_error(this->init_exception_msg);
-                    }                
+                    }
                     if(bmi_lib_file.substr(idx) == ".so"){
                         alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".dylib";
                     } else if(bmi_lib_file.substr(idx) == ".dylib"){

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ if(NOT NGEN_ROOT_DIR STREQUAL PROJECT_BINARY_DIR)
 
     # Create a symlink between the extern directory in the source tree and the build tree
     file(CREATE_LINK "${NGEN_ROOT_DIR}/extern" "${PROJECT_BINARY_DIR}/extern" SYMBOLIC)
+    file(CREATE_LINK "${NGEN_ROOT_DIR}/extern" "${PROJECT_BINARY_DIR}/test/extern" SYMBOLIC)
 endif()
 
 # =============================================================================

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,9 @@ if(NOT NGEN_ROOT_DIR STREQUAL PROJECT_BINARY_DIR)
 
     # Create a symlink between the test data directory in the source tree and the build tree
     file(CREATE_LINK "${CMAKE_CURRENT_LIST_DIR}/data" "${PROJECT_BINARY_DIR}/test/data" SYMBOLIC)
+
+    # Create a symlink between the extern directory in the source tree and the build tree
+    file(CREATE_LINK "${NGEN_ROOT_DIR}/extern" "${PROJECT_BINARY_DIR}/extern" SYMBOLIC)
 endif()
 
 # =============================================================================

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -150,16 +150,8 @@ void Bmi_Py_Adapter_Test::TearDown() {
 }
 
 void Bmi_Py_Adapter_Test::SetUpTestSuite() {
+    // Add the extern dir with our test lib to Python system path
     std::string module_directory = "./extern/";
-
-    #if 0
-    // Add the package dir from a local virtual environment directory also, if there is one
-    std::string venv_dir = py_dir_search({repo_root + "/.venv", repo_root + "/venv"});
-    if (!venv_dir.empty()) {
-        InterpreterUtil::addToPyPath(py_find_venv_site_packages_dir(venv_dir));
-    }
-    #endif
-    // Also add the extern dir with our test lib to Python system path
     InterpreterUtil::addToPyPath(module_directory);
 }
 

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -88,13 +88,6 @@ protected:
     static std::string py_dir_search(const std::vector<std::string> &dir_options);
 
     /**
-     * Find the repo root directory, starting from the current directory and working upward.
-     *
-     * @return The absolute path of the repo root, as a string.
-     */
-    static std::string py_find_repo_root();
-
-    /**
      * Find the virtual environment site packages directory, starting from an assumed valid venv directory.
      *
      * @param venv_dir The virtual environment directory.
@@ -128,9 +121,6 @@ std::shared_ptr<InterpreterUtil> Bmi_Py_Adapter_Test::interperter = InterpreterU
 py::object Bmi_Py_Adapter_Test::Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});
 
 void Bmi_Py_Adapter_Test::SetUp() {
-
-    //std::string repo_root = py_find_repo_root();
-
     example_scenario template_ex_struct;
     // These should be safe for all examples
     template_ex_struct.module_name = "test_bmi_py.bmi_model";
@@ -160,7 +150,6 @@ void Bmi_Py_Adapter_Test::TearDown() {
 }
 
 void Bmi_Py_Adapter_Test::SetUpTestSuite() {
-    //std::string repo_root = py_find_repo_root();
     std::string module_directory = "./extern/";
 
     #if 0
@@ -232,25 +221,6 @@ std::string Bmi_Py_Adapter_Test::py_dir_search(const std::vector<std::string> &d
             return dir;
     }
     return "";
-}
-
-/**
- * Find the repo root directory, starting from the current directory and working upward.
- *
- * @return The absolute path of the repo root, as a string.
- */
-std::string Bmi_Py_Adapter_Test::py_find_repo_root() {
-    py::object dir = Path(".").attr("resolve")();
-    while (!dir.equal(dir.attr("parent"))) {
-        // If there is a child .git dir and a child .github dir, then dir is the root
-        py::bool_ is_git_dir = py::bool_(dir.attr("joinpath")(".git").attr("is_dir")());
-        py::bool_ is_github_dir = py::bool_(dir.attr("joinpath")(".github").attr("is_dir")());
-        if (is_git_dir && is_github_dir) {
-            return py::str(dir);
-        }
-        dir = dir.attr("parent");
-    }
-    throw std::runtime_error("Can't find repo root starting at " + std::string(py::str(Path(".").attr("resolve")())));
 }
 
 /**

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -129,12 +129,12 @@ py::object Bmi_Py_Adapter_Test::Path = InterpreterUtil::getPyModule(std::vector<
 
 void Bmi_Py_Adapter_Test::SetUp() {
 
-    std::string repo_root = py_find_repo_root();
+    //std::string repo_root = py_find_repo_root();
 
     example_scenario template_ex_struct;
     // These should be safe for all examples
     template_ex_struct.module_name = "test_bmi_py.bmi_model";
-    template_ex_struct.module_directory = repo_root + "/extern/";
+    template_ex_struct.module_directory = "./extern/";
 
     // Now generate the examples vector based on the above template example
     size_t num_example_scenarios = 1;
@@ -143,11 +143,11 @@ void Bmi_Py_Adapter_Test::SetUp() {
         examples[i] = template_ex_struct;
     }
 
-    examples[0].forcing_file = repo_root + "/data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv";
+    examples[0].forcing_file = "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv";
 
     // We can handle setting the right init config and initializing the adapter in a loop
     for (int i = 0; i < examples.size(); ++i) {
-        examples[i].bmi_init_config = repo_root + "/test/data/bmi/test_bmi_python/test_bmi_python_config_"
+        examples[i].bmi_init_config = "./test/data/bmi/test_bmi_python/test_bmi_python_config_"
                 + std::to_string(i) + ".yml";
 
         examples[i].adapter = std::make_shared<Bmi_Py_Adapter>(examples[i].module_name, examples[i].bmi_init_config,
@@ -160,14 +160,16 @@ void Bmi_Py_Adapter_Test::TearDown() {
 }
 
 void Bmi_Py_Adapter_Test::SetUpTestSuite() {
-    std::string repo_root = py_find_repo_root();
-    std::string module_directory = repo_root + "/extern/";
+    //std::string repo_root = py_find_repo_root();
+    std::string module_directory = "./extern/";
 
+    #if 0
     // Add the package dir from a local virtual environment directory also, if there is one
     std::string venv_dir = py_dir_search({repo_root + "/.venv", repo_root + "/venv"});
     if (!venv_dir.empty()) {
         InterpreterUtil::addToPyPath(py_find_venv_site_packages_dir(venv_dir));
     }
+    #endif
     // Also add the extern dir with our test lib to Python system path
     InterpreterUtil::addToPyPath(module_directory);
 }

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -403,32 +403,6 @@ private:
                 "formulations").begin()->second.get_child("params");
     }
 
-    /**
-     * Find the repo root directory using Python, starting from the current directory and working upward.
-     *
-     * This will throw a runtime error if Python functionality is not active.
-     *
-     * @return The absolute path of the repo root, as a string.
-     */
-    static std::string py_find_repo_root() {
-        #ifdef ACTIVATE_PYTHON
-        py::object Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});
-        py::object dir = Path(".").attr("resolve")();
-        while (!dir.equal(dir.attr("parent"))) {
-            // If there is a child .git dir and a child .github dir, then dir is the root
-            py::bool_ is_git_dir = py::bool_(dir.attr("joinpath")(".git").attr("is_dir")());
-            py::bool_ is_github_dir = py::bool_(dir.attr("joinpath")(".github").attr("is_dir")());
-            if (is_git_dir && is_github_dir) {
-                return py::str(dir);
-            }
-            dir = dir.attr("parent");
-        }
-        throw std::runtime_error("Can't find repo root starting at " + std::string(py::str(Path(".").attr("resolve")())));
-        #else // (i.e., if not ACTIVATE_PYTHON)
-        throw std::runtime_error("Can't use Python-based test helper function 'py_find_repo_root'; Python not active!");
-        #endif // ACTIVATE_PYTHON
-    }
-
     inline void initializeTestExample(const int ex_index, const std::string &cat_id,
                                       const std::vector<std::string> &nested_types, const std::vector<std::string> &output_variables) {
         catchment_ids[ex_index] = cat_id;
@@ -467,7 +441,6 @@ std::shared_ptr<InterpreterUtil> Bmi_Multi_Formulation_Test::interperter = Inter
 
 void Bmi_Multi_Formulation_Test::SetUpTestSuite() {
     #ifdef ACTIVATE_PYTHON
-    // std::string repo_root = py_find_repo_root();
     std::string module_directory = "./extern/";
 
     // Add the extern dir with our test lib to Python system path

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -467,8 +467,8 @@ std::shared_ptr<InterpreterUtil> Bmi_Multi_Formulation_Test::interperter = Inter
 
 void Bmi_Multi_Formulation_Test::SetUpTestSuite() {
     #ifdef ACTIVATE_PYTHON
-    std::string repo_root = py_find_repo_root();
-    std::string module_directory = repo_root + "/extern/";
+    // std::string repo_root = py_find_repo_root();
+    std::string module_directory = "./extern/";
 
     // Add the extern dir with our test lib to Python system path
     InterpreterUtil::addToPyPath(module_directory);

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -218,19 +218,9 @@ void Bmi_Py_Formulation_Test::SetUp() {
 }
 
 void Bmi_Py_Formulation_Test::SetUpTestSuite() {
+    // Add the extern dir with our test lib to Python system path
     std::string module_directory = "./extern/";
-
-    #if 0
-    // Add the package dir from a local virtual environment directory also, if there is one
-    std::string venv_dir = py_dir_search({repo_root + "/.venv", repo_root + "/venv"});
-    if (!venv_dir.empty()) {
-        InterpreterUtil::addToPyPath(py_find_venv_site_packages_dir(venv_dir));
-    }
-    #endif
-    // Also add the extern dir with our test lib to Python system path
     InterpreterUtil::addToPyPath(module_directory);
-
-
 }
 
 void Bmi_Py_Formulation_Test::TearDown() {

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -98,13 +98,6 @@ protected:
     }
 
     /**
-     * Find the repo root directory, starting from the current directory and working upward.
-     *
-     * @return The absolute path of the repo root, as a string.
-     */
-    static std::string py_find_repo_root();
-
-    /**
      * Search for and return the first existing example of a collection of directories, using Python to perform search.
      *
      * @param dir_options The options for the directories to check for existence, in the order to try them.
@@ -182,7 +175,6 @@ std::shared_ptr<InterpreterUtil> Bmi_Py_Formulation_Test::interperter = Interpre
 void Bmi_Py_Formulation_Test::SetUp() {
     Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});
     
-    //std::string repo_root = py_find_repo_root();
     std::string forcing_data_dir = "./data/forcing/";
 
     py_formulation_example_scenario template_ex_struct;
@@ -226,7 +218,6 @@ void Bmi_Py_Formulation_Test::SetUp() {
 }
 
 void Bmi_Py_Formulation_Test::SetUpTestSuite() {
-    //    std::string repo_root = py_find_repo_root();
     std::string module_directory = "./extern/";
 
     #if 0
@@ -351,26 +342,6 @@ std::string Bmi_Py_Formulation_Test::py_dir_search(const std::vector<std::string
             return dir;
     }
     return "";
-}
-
-/**
- * Find the repo root directory, starting from the current directory and working upward.
- *
- * @return The absolute path of the repo root, as a string.
- */
-std::string Bmi_Py_Formulation_Test::py_find_repo_root() {
-    py::object Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});
-    py::object dir = Path(".").attr("resolve")();
-    while (!dir.equal(dir.attr("parent"))) {
-        // If there is a child .git dir and a child .github dir, then dir is the root
-        py::bool_ is_git_dir = py::bool_(dir.attr("joinpath")(".git").attr("is_dir")());
-        py::bool_ is_github_dir = py::bool_(dir.attr("joinpath")(".github").attr("is_dir")());
-        if (is_git_dir && is_github_dir) {
-            return py::str(dir);
-        }
-        dir = dir.attr("parent");
-    }
-    throw std::runtime_error("Can't find repo root starting at " + std::string(py::str(Path(".").attr("resolve")())));
 }
 
 /**

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -182,13 +182,13 @@ std::shared_ptr<InterpreterUtil> Bmi_Py_Formulation_Test::interperter = Interpre
 void Bmi_Py_Formulation_Test::SetUp() {
     Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});
     
-    std::string repo_root = py_find_repo_root();
-    std::string forcing_data_dir = repo_root + "/data/forcing/";
+    //std::string repo_root = py_find_repo_root();
+    std::string forcing_data_dir = "./data/forcing/";
 
     py_formulation_example_scenario template_ex_struct;
     // These should be safe for all examples
     template_ex_struct.module_name = "test_bmi_py.bmi_model";
-    template_ex_struct.module_directory = repo_root + "/extern/";
+    template_ex_struct.module_directory = "./extern/";
     template_ex_struct.main_output_variable = "OUTPUT_VAR_1";
     template_ex_struct.uses_forcing_file = false;
 
@@ -205,7 +205,7 @@ void Bmi_Py_Formulation_Test::SetUp() {
     // We can handle setting the rest up in a loop
     std::string forcing_file;
     for (size_t i = 0; i < examples.size(); ++i) {
-        examples[i].bmi_init_config = repo_root + "/test/data/bmi/test_bmi_python/test_bmi_python_config_"
+        examples[i].bmi_init_config = "./test/data/bmi/test_bmi_python/test_bmi_python_config_"
                                       + std::to_string(i) + ".yml";
         forcing_file = forcing_data_dir + examples[i].catchment_id + "_2015-12-01 00_00_00_2015-12-30 23_00_00.csv";
         examples[i].forcing_params = std::make_shared<forcing_params>(forcing_file, "legacy", "2015-12-01 00:00:00",
@@ -226,14 +226,16 @@ void Bmi_Py_Formulation_Test::SetUp() {
 }
 
 void Bmi_Py_Formulation_Test::SetUpTestSuite() {
-    std::string repo_root = py_find_repo_root();
-    std::string module_directory = repo_root + "/extern/";
+    //    std::string repo_root = py_find_repo_root();
+    std::string module_directory = "./extern/";
 
+    #if 0
     // Add the package dir from a local virtual environment directory also, if there is one
     std::string venv_dir = py_dir_search({repo_root + "/.venv", repo_root + "/venv"});
     if (!venv_dir.empty()) {
         InterpreterUtil::addToPyPath(py_find_venv_site_packages_dir(venv_dir));
     }
+    #endif
     // Also add the extern dir with our test lib to Python system path
     InterpreterUtil::addToPyPath(module_directory);
 


### PR DESCRIPTION
Being able to build the code and run tests successfully should not depend on the build tree being an immediate child of the repository root. This PR makes changes necessary to lift that assumption wherever it appears in the current code.

## Changes

- Symlink to the `extern` directory inside the build tree, so that the tests don't need to hunt for it
- Relocate where pybind11 gets built inside the build tree, to make room for that `extern` symlink
- Change the tests to use that link to `extern` rather than hunting for the repo root and looking for it there
- Also change the Python-using tests to assume any relevant venv is active when the test is run, like we did for the main `ngen` binary

## Removals

- Drop code to hunt for source repo root in tests

## Testing

1. Build in an arbitrary path locally and run tests

## Notes

- There are still lots of other assumptions about working directories and relative paths throughout the tests

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS
