### PR TITLE
CMake: Fix old mistake to make ctest pass independent of working directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,9 +97,9 @@ function(ngen_add_test TESTNAME)
         set_target_properties(${TESTNAME} PROPERTIES FOLDER test)
         gtest_discover_tests(
             ${TESTNAME}
-            WORKING_DIRECTORY ${PROJECT_DIR}
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
             PROPERTIES
-                VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
+                VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
         )
 
         # ---------------------------------------------------------------------
@@ -421,9 +421,9 @@ ngen_add_test(
 # Discover for test_all
 gtest_discover_tests(
     test_all
-    WORKING_DIRECTORY ${PROJECT_DIR}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     PROPERTIES
-        VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
+        VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
 )
 
 if(NGEN_WITH_COVERAGE)


### PR DESCRIPTION
## Changes

- There is no variable PROJECT_DIR, it seems PROJECT_BINARY_DIR was intended.

## Testing

1. Run `ctest` in either a build tree root, or in `test/` within that tree. All tests pass either way.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [ ] Linux
- [x] macOS
