### PR TITLE
Add timing output to the end of ngen runs

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -38,6 +38,9 @@ std::string nexusDataFile = "";
 std::string REALIZATION_CONFIG_PATH = "";
 bool is_subdivided_hydrofabric_wanted = false;
 
+// Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
+int mpi_rank = 0;
+
 #ifdef NGEN_MPI_ACTIVE
 
 #ifndef MPI_HF_SUB_CLI_FLAG
@@ -50,10 +53,7 @@ bool is_subdivided_hydrofabric_wanted = false;
 #include <HY_Features_MPI.hpp>
 
 std::string PARTITION_PATH = "";
-int mpi_rank;
 int mpi_num_procs;
-#else // NGEN_MPI_ACTIVE
-int mpi_rank = 0;
 #endif // NGEN_MPI_ACTIVE
 
 #include <Layer.hpp>

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -139,15 +139,16 @@ int main(int argc, char *argv[]) {
         MPI_Init(nullptr, nullptr);
         MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_num_procs);
+        #endif
 
         if (mpi_rank == 0)
-        #endif
         {
             std::ostringstream output;
             output << ngen::exec_info::build_summary;
             ngen::exec_info::runtime_summary(output);
             std::cout << output.str() << std::endl;
         } // if (mpi_rank == 0)
+
         #if NGEN_WITH_MPI
         MPI_Finalize();
         #endif
@@ -393,11 +394,8 @@ int main(int argc, char *argv[]) {
     //realization collection is created
     #ifdef NGEN_ROUTING_ACTIVE
     std::unique_ptr<routing_py_adapter::Routing_Py_Adapter> router;
-    #ifdef NGEN_MPI_ACTIVE
-    //If rank == 0, do routing
     if( mpi_rank == 0 )
     { // Run t-route from single process
-    #endif //NGEN_MPI_ACTIVE
     if(manager->get_using_routing()) {
       std::cout<<"Using Routing"<<std::endl;
       std::string t_route_config_file_with_path = manager->get_t_route_config_file_with_path();
@@ -406,9 +404,7 @@ int main(int argc, char *argv[]) {
     else {
       std::cout<<"Not Using Routing"<<std::endl;
     }
-    #ifdef NGEN_MPI_ACTIVE
     }
-    #endif //NGEN_MPI_ACTIVE
     #endif //NGEN_ROUTING_ACTIVE
     std::cout<<"Building Feature Index\n";
     std::string link_key = "toid";


### PR DESCRIPTION
This will allow for slightly more informative benchmark results, in which we can distinguish different elements of the runtime, and extrapolate accordingly.

## Changes

- Simplify the mixed MPI/Routing `#ifdef` logic
- Add time calls and prints

## Testing

1. Unit testing still passes

## Screenshot

From the CI job running on example data:

```
Running timestep 700
Finished 720 timesteps.
NGen top-level timings:
	NGen::init: 0.207376
	NGen::simulation: 0.230584
	NGen::routing: 1.232e-06
```

## Todos

- Improve numeric formatting

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS