### PR TITLE
Update README.md to include --info usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [INSTALL](INSTALL.md).
 
 ## Configuration
 
-To view the compile-time configuration of an pre-compiled NextGen binary use the `--info` arguement, as in `./ngen --info`.
+To view the compile-time configuration of an pre-compiled NextGen binary use the `--info` flag, as in `ngen --info`.
 for more info see: https://github.com/NOAA-OWP/ngen/pull/679
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ See [INSTALL](INSTALL.md).
 
 ## Configuration
 
-If the software is configurable, describe it in detail, either here or in other documentation to which you link.
+To view the compile-time configuration of an pre-compiled NextGen binary use the `--info` arguement, as in `./ngen --info`.
+for more info see: https://github.com/NOAA-OWP/ngen/pull/679
 
 ## Usage
 


### PR DESCRIPTION
Adding the new --info to the readme

## Additions

- added README line in Configuration Section about the `--info` subcommand for people to use to see what features are available in a pre-compiled NGEN binary.

## Removals

- none

## Changes

- only to README

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
