### PR TITLE
Install boost from package manager, not source

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -106,18 +106,15 @@ runs:
           run: git submodule update --init --recursive
           shell: bash
 
-        - name: Cache Boost Dependency
-          id: cache-boost-dep
-          uses: actions/cache@v3
-          with:
-            path: boost_1_72_0
-            key: unix-boost-dep
-
-        - name: Get Boost Dependency
-          if: steps.cache-boost-dep.outputs.cache-hit != 'true'
+        - name: Install Boost
           run: |
-            curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
-            tar xjf boost_1_72_0.tar.bz2
+            if [ ${{ runner.os }} == 'Linux' ]
+            then
+              sudo apt-get install -y libboost-dev
+            elif [ ${{ runner.os }} == 'macOS' ]
+            then
+              brew install boost
+            fi
           shell: bash
 
         - name: Cache Python Dependencies

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -165,11 +165,9 @@ runs:
         - name: Cmake Initialization
           id: cmake_init
           run: |
-            export BOOST_ROOT="$(pwd)/boost_1_72_0"
             export CFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer"
             export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -pedantic-errors"
             . .venv/bin/activate
-            [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} \
               -DBMI_C_LIB_ACTIVE:BOOL=${{ inputs.bmi_c }} \
               -DNGEN_ACTIVATE_PYTHON:BOOL=${{ inputs.use_python }} \


### PR DESCRIPTION
This'll make the pipelines somewhat less flaky, since they won't rely on an unsupported download source.

It'll also exercise a broader range of versions of Boost than the fixed 1.72 that we were previously testing.

## Changes

- In Github CI jobs that don't build a Docker image, get Boost from apt on Ubuntu and brew on macOS

## Testing

1. Impacts only CI pipelines

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS
