### PR TITLE
Download Boost source from Sourceforge instead of Jfrog to avoid registration wall

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -116,7 +116,7 @@ runs:
         - name: Get Boost Dependency
           if: steps.cache-boost-dep.outputs.cache-hit != 'true'
           run: |
-            curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+            curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
             tar xjf boost_1_72_0.tar.bz2
           shell: bash
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,7 @@ cd ngen
 **Download the Boost Libraries:**
 
 ```shell
-curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 \
+curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download \
     && tar -xjf boost_1_72_0.tar.bz2 \
     && rm boost_1_72_0.tar.bz2
 ```

--- a/docker/CENTOS_4.8.5_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_4.8.5_NGEN_RUN.dockerfile
@@ -19,7 +19,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/CENTOS_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_NGEN_RUN.dockerfile
@@ -9,7 +9,7 @@ RUN yum update -y \
     && dnf clean all \
   	&& rm -rf /var/cache/yum
 
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 \
+RUN curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download \
     && tar -xjf boost_1_72_0.tar.bz2 \
     && rm boost_1_72_0.tar.bz2
 

--- a/docker/CENTOS_TEST.dockerfile
+++ b/docker/CENTOS_TEST.dockerfile
@@ -11,7 +11,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/CENTOS_latest_NGEN_RUN.dockerfile
+++ b/docker/CENTOS_latest_NGEN_RUN.dockerfile
@@ -13,7 +13,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/RHEL_TEST.dockerfile
+++ b/docker/RHEL_TEST.dockerfile
@@ -10,7 +10,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN curl -L -O https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 RUN tar -xjf boost_1_72_0.tar.bz2
 

--- a/docker/Ubuntu_20_10_Test_MPI.dockerfile
+++ b/docker/Ubuntu_20_10_Test_MPI.dockerfile
@@ -10,7 +10,7 @@ ENV CXX=/usr/bin/g++
 
 RUN git submodule update --init --recursive -- test/googletest
 
-RUN wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+RUN curl -L -o boost_1_72_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 RUN tar -xjf boost_1_72_0.tar.bz2
 ENV BOOST_ROOT="boost_1_72_0"
 


### PR DESCRIPTION
Automated downloads from Jfrog started failing all of our CI jobs.

## Changes

- Switch from Jfrog download URL to Sourceforge download URL

## Testing

This is entirely about getting CI to pass again

## Notes

- Ideally, we'd shift toward packaged versions as in #698 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS
