### PR TITLE
Add .clang-format and .clang-tidy files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ﻿# yaml-language-server: $schema=https://json.schemastore.org/clang-format.json
 ---
-BasedOnStyle: Google
+BasedOnStyle: LLVM
 ColumnLimit: 100
 IndentWidth: 4
 UseTab: Never
@@ -26,7 +26,6 @@ AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Empty
 AllowShortFunctionsOnASingleLine: None
-AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakTemplateDeclarations: Yes

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,45 @@
+﻿# yaml-language-server: $schema=https://json.schemastore.org/clang-format.json
+---
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: 4
+UseTab: Never
+---
+Language: Cpp
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations:
+  Enabled: false
+AlignConsecutiveMacros: Consecutive
+AlignConsecutiveShortCaseStatements:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseColons: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Never
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Attach # One True Brace Style
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+FixNamespaceComments: true
+NamespaceIndentation: None
+SeparateDefinitionBlocks: Always
+---

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,32 @@
+---
+Checks: |
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  mpi-*,
+  bugprone-*,
+  boost-*,
+  performance-*,
+  hicpp-*,
+  google-*,
+  readability-*,
+  misc-confusable-identifiers,
+  misc-const-correctness,
+  -modernize-use-trailing-return-type,
+  -cppcoreguidelines-special-member-functions
+AnalyzeTemporaryDtors: false
+FormatStyle: file
+CheckOptions:
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: "1"
+  - key: modernize-loop-convert.MaxCopySize
+    value: "16"
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: modernize-pass-by-value.IncludeStyle
+    value: google
+  - key: modernize-use-nullptr.NullMacros
+    value: "NULL"
+---
+

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ CMakeCache.txt
 /cmake_build
 /build
 /cmake_build*
+compile_commands.json
 
 # Prevent ignoring cmake modules
 !cmake/**/*.cmake


### PR DESCRIPTION
This PR resolves #614, by adding `.clang-format` and `.clang-tidy` files. Note, this PR does not apply any formatting and only adds the files. Most likely, the state they are in is not final and will most likely change as we utilize them to better fit our needs.

The current `.clang-format` options are based off the NGen programming standards guide in the documentation, and from skimming the codebase.

Additionally, this PR makes a small change to `.gitignore` to ignore the compilation database artifact from CMake -- this is not directly related to the PR, but is small enough that I figured it wouldn't be an issue including in this.

## Additions

- `.clang-format` file
- `.clang-tidy` file
- Adds `compile_commands.json` to `.gitignore`

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
