### PR TITLE
Add errno reporting to bad file reads

### DIFF
--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -32,9 +32,10 @@ namespace models {
             {
                 // This replicates a lot of Initialize, but it's necessary to be able to do it separately to support
                 // "initializing" on construction, given using Initialize requires use of virtual functions
+                errno = 0;
                 if (!utils::FileChecker::file_is_readable(this->bmi_init_config)) {
                     init_exception_msg = "Cannot create and initialize " + this->model_name + " using unreadable file '"
-                            + this->bmi_init_config + "'";
+                            + this->bmi_init_config + "'. Error: "+std::strerror(errno);
                     throw std::runtime_error(init_exception_msg);
                 }
             }
@@ -125,6 +126,7 @@ namespace models {
             void Initialize() {
                 // If there was previous init attempt but w/ failure exception, throw runtime error and include previous
                 // message
+                errno = 0;
                 if (model_initialized && !init_exception_msg.empty()) {
                     throw std::runtime_error(
                             "Previous " + model_name + " init attempt had exception: \n\t" + init_exception_msg);
@@ -135,7 +137,7 @@ namespace models {
                 }
                 else if (!utils::FileChecker::file_is_readable(bmi_init_config)) {
                     init_exception_msg = "Cannot initialize " + model_name + " using unreadable file '"
-                            + bmi_init_config + "'";
+                            + bmi_init_config + "'. Error: "+std::strerror(errno);;
                     throw std::runtime_error(init_exception_msg);
                 }
                 else {


### PR DESCRIPTION
Additional error reporting when file reads fail to occur, this provides additional context as to why the failure happens.

## Changes

- Capture and report the `errno` when certain file reads fail

## Todos

- May need to check other possible locations of file read errors and extend their error messaging similarly

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
