### PR TITLE
Json property additions

### DIFF
--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -389,6 +389,16 @@ namespace geojson {
             }
 
             /**
+             * @brief Copy construct a JSONProperty, but use a new key value for the property
+             * 
+             * @param value_key 
+             * @param original 
+             */
+            JSONProperty(const std::string& value_key, const JSONProperty&original):JSONProperty(original){
+                key = value_key;
+            }
+
+            /**
              * A basic destructor
              */
             virtual ~JSONProperty(){};

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -5,7 +5,7 @@
 #include <map>
 #include <vector>
 #include <iostream>
-
+#include <iomanip>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/variant.hpp>
@@ -417,6 +417,65 @@ namespace geojson {
                     values(value)
             {   
                 data = Object( &values );
+            }
+
+            /**
+             * @brief Pretty print the property to standard out stream.
+             * 
+             * Recurses through the property to tab/print nested objects/lists.
+             * 
+             * @param p Property to print
+             * @param tab (optional) Additional starting tab to indent (default 0)
+             * @param newline (optional) Add a new line to the end of the print (default true)
+             */
+            static void print_property(const geojson::JSONProperty& p, int tab=0, bool newline = true){
+                char end = '\0';
+                if(newline)  end = '\n';
+                std::cout<<std::setw(tab);
+                switch( p.get_type() ){
+                    case geojson::PropertyType::String:
+                        std::cout<<p.as_string()<<end;
+                        break;
+                    case geojson::PropertyType::Real:
+                        std::cout<<p.as_real_number()<<end;
+                        break;
+                    case geojson::PropertyType::Natural:
+                        std::cout<<p.as_natural_number()<<end;
+                        break;
+                    case geojson::PropertyType::Boolean:
+                        if(p.as_boolean())
+                            std::cout<<"true"<<end;
+                        else
+                            std::cout<<"false"<<end;
+                        break;   
+                    case geojson::PropertyType::List:
+                        std::cout<<std::setw(tab)<<"[";
+                        tab += 5;
+                        for( const auto& lp : p.as_list() ){
+                            //This is a little harder to align nicely without knowing
+                            //the length of the property as a string first...so for now,
+                            //just try to get a little bit in to make it easier to read
+                            std::cout<<std::setw(tab);
+                            print_property(lp, tab, false);
+                            std::cout<<","<<end;
+                        }
+                        tab -= 5;
+                        std::cout<<std::setw(tab)<<" ]"<<end;
+                        
+                        break;
+                    case geojson::PropertyType::Object:
+                        //tab += 5;
+                        std::cout<<std::setw(tab)<<"{\n";
+                        tab += 5;
+                        for( auto pair : p.get_values() ){
+                            std::cout<<std::setw(tab + pair.first.length())<<pair.first<<" : ";
+                            print_property(pair.second, tab, false);
+                            std::cout<<",\n";
+                        }
+                        tab -= 5;
+                        std::cout<<std::setw(tab)<<"}"<<end;
+                        tab -= 5;
+                };
             }
 
             /**

--- a/test/geojson/JSONProperty_Test.cpp
+++ b/test/geojson/JSONProperty_Test.cpp
@@ -27,6 +27,40 @@ class JSONProperty_Test : public ::testing::Test {
 
 };
 
+TEST_F(JSONProperty_Test, print_property_test) {
+    geojson::JSONProperty string_property("string", "test_string");
+    geojson::JSONProperty::print_property(string_property);
+    geojson::JSONProperty natural_property("natural", 4);
+    geojson::JSONProperty::print_property(natural_property);
+    geojson::JSONProperty real_property("real", 3.0);
+    geojson::JSONProperty::print_property(real_property);
+    geojson::JSONProperty boolean_property("boolean", true);
+    geojson::JSONProperty::print_property(boolean_property);
+
+    geojson::PropertyMap object;
+    
+    object.emplace("natural", geojson::JSONProperty("natural", 4));
+    object.emplace("real", geojson::JSONProperty("real", 3.0));
+    object.emplace("string", geojson::JSONProperty("string", "test_string"));
+    object.emplace("boolean", geojson::JSONProperty("boolean", true));
+
+    geojson::JSONProperty object_property("object", object);
+    geojson::JSONProperty::print_property(object_property);
+
+        std::vector<geojson::JSONProperty> properties;
+
+    properties.push_back(geojson::JSONProperty("natural", 4));
+    properties.push_back(geojson::JSONProperty("real", 3.0));
+    properties.push_back(geojson::JSONProperty("string", "test_string"));
+    properties.push_back(geojson::JSONProperty("boolean", true));
+    properties.push_back(object_property);
+
+    geojson::JSONProperty list_property("list_property", properties);
+
+    geojson::JSONProperty::print_property(list_property);
+    
+}
+
 TEST_F(JSONProperty_Test, natural_property_test) {
     geojson::JSONProperty natural_property("natural", 4);
     ASSERT_EQ(natural_property.get_type(), geojson::PropertyType::Natural);

--- a/test/geojson/JSONProperty_Test.cpp
+++ b/test/geojson/JSONProperty_Test.cpp
@@ -61,6 +61,14 @@ TEST_F(JSONProperty_Test, print_property_test) {
     
 }
 
+TEST_F(JSONProperty_Test, copy_new_key_test) {
+    geojson::JSONProperty string_property("string", "test_string");
+    geojson::JSONProperty new_key_property("new_string", string_property);
+    ASSERT_EQ(new_key_property.get_type(), geojson::PropertyType::String);
+    ASSERT_EQ(new_key_property.as_string(), string_property.as_string());
+    ASSERT_EQ(new_key_property.get_key(), "new_string");
+}
+
 TEST_F(JSONProperty_Test, natural_property_test) {
     geojson::JSONProperty natural_property("natural", 4);
     ASSERT_EQ(natural_property.get_type(), geojson::PropertyType::Natural);


### PR DESCRIPTION
Supports future development and use of JSONProperties with a couple simple enhancements.

## Additions

- `print_property` function to pretty print a JSONProperty (recursively) with indentation.
- A copy constructor that takes a new key to assign to the copied property

## Testing

1. Added simple test of print_property function
2. Added unit test for new constructor

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS