### PR TITLE
Hydrofabric network cycle detection

### DIFF
--- a/include/core/network.hpp
+++ b/include/core/network.hpp
@@ -137,6 +137,86 @@ namespace network {
    */
   using IndexPair = std::pair< NetworkIndexT::const_iterator, NetworkIndexT::const_iterator>;
 
+  /**
+   * @brief Graph visitor which detects and stores cycles in the network
+   * 
+   */
+  struct detect_cycles : public boost::dfs_visitor<>
+  {
+    using colormap = std::map<Graph::vertex_descriptor, boost::default_color_type>;
+    colormap vertex_coloring;
+
+    using edgeColorMap = std::map<Graph::edge_descriptor, boost::default_color_type>;
+    edgeColorMap  edge_coloring;
+    using vertex_t = Graph::vertex_descriptor;
+
+    //Delete the default constructor so we don't get a nullptr for cycles
+    detect_cycles() = delete;
+    /**
+     * @brief Construct a new detect_cycle object holding a reference to a vector to store cycle pairs
+     * 
+     * @param out pointer to a vector to hold vertex pairs that complete cycles
+     */
+    detect_cycles(std::vector<std::pair<Graph::vertex_descriptor, Graph::vertex_descriptor>>* out):cycles(out){}
+    
+    /**
+     * @brief Mark target verticies of visited edge
+     * 
+     * @tparam Edge 
+     * @tparam Graph 
+     * @param e 
+     * @param g 
+     */
+    /*
+    template <class Edge, class Graph>
+    void tree_edge(Edge e, const Graph& g) {
+      //Start by pushing the first vertex (source)
+      if (vertexVisited.empty()) {
+          vertexVisited.push(boost::source(e, g));
+      }
+      //Push every assoicated target vertex of the edge
+      vertexVisited.push(boost::target(e, g));
+    }*/
+   
+    /**
+      * @brief When a back edge is encountered, we have a cycle
+      * 
+      * @tparam Edge 
+      * @tparam Graph 
+      * @param e 
+      * @param g 
+      */
+    template <class Edge, class Graph>
+    void back_edge(Edge e, const Graph& g) {
+      // std::cout << source(e, g)
+      //   << " -- "
+      //   << target(e, g) << "\n";
+      // std::cout<< get(boost::vertex_name, g)[ source(e, g) ] <<
+      //   " -- " << get(boost::vertex_name, g)[ target(e,g)  ]<<"\n";
+      vertex_t v2;
+      //At this point, vertexVisited is every vertice which has been visted
+      //up to the point of finding this back edge (so each is part of the total cycle)
+      /*while ( vertexVisited.top() != boost::target(e, g) )
+      {
+          //std::cout << " Cycle middle=" << vertexVisited.top() << std::endl;
+          v2 = vertexVisited.top();
+          vertexVisited.pop();
+      }*/
+      //Reset the verticies stack to the last
+      //vertexVisited.push(v2);
+      if(cycles != nullptr){
+        cycles->push_back(std::make_pair(source(e,g), target(e,g)));
+      }
+    }
+    //Currently not used, but could be used to report the reset of the 
+    //verticies involved in the cycle if needed
+    //(would need become a pointer similar to cycles if consumed/reported externally)
+    //std::stack<Graph::vertex_descriptor> vertexVisited;
+    //Since visitors are passed by value, we need an external reference
+    //to store the cycle in
+    std::vector<std::pair<Graph::vertex_descriptor, Graph::vertex_descriptor>>* cycles;
+  };
+
     /**
      * @brief A lightweight, graph based index of hydrologic features.
      * 


### PR DESCRIPTION
Cycles in the hydrofabric topology can cause a `boost::not_a_dag` exception to occur (when performing topological sort of the graph, for example.)

This exception, however, doesn't provide any useful context to determine what part of the hydrofabric creates/contributes to the cycle to be investigated.

This PR provides a custom cycle detection visitor which records the vertices of all back edges in the graph.  This visitor is then used in the `init_indicies` function of all network creation to run an undirected depth first search and record the cycles.  All cycles are identified and the verticies are mapped back to the hydrofabric ID and reported in a `std::domain_error` exception message that looks like
```
Cycle(s) detected in hydrofabric
The following features form a cycle:
        nex-1 --> cat-0
```

## Additions

- `detect_cycles` visitor

## Removals

- None

## Changes

- `std::domain_error` thrown in network creation when cycles are detected

## Testing

1. New test added which attempts to create a `Network` using a topology which has a cycle

## Notes

Some additional code is left in the visitor implementation commented out.  If additional information about hydrofabric features involved in the cycle are needed, it can be used to provide all vertices related to a reported cycle.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
