### PR TITLE
Parallel run with one proc w/o partition file

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,8 +40,8 @@ jobs:
         ref: gh-pages
         clean: false
         
-    - name: Move generated files where git can see them
-      run: cp -rp docs/html/* .
+    - name: Prevent generated docs dir from being committed and overwriting on the next run.
+      run: rm -Rf docs/html
 
     - name: Prevent generated docs dir from being committed and overwriting on the next run.
       run: rm -Rf docs/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,9 +46,6 @@ jobs:
     - name: Prevent generated docs dir from being committed and overwriting on the next run.
       run: rm -Rf docs/html
 
-    - name: Prevent generated docs dir from being committed and overwriting on the next run.
-      run: rm -Rf docs/html
-
     - name: Update branch information
       run: git fetch --all; git branch --list -r;
       

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,6 +39,9 @@ jobs:
       with:
         ref: gh-pages
         clean: false
+
+    - name: Move generated files where git can see them
+      run: cp -rp docs/html/* .
         
     - name: Prevent generated docs dir from being committed and overwriting on the next run.
       run: rm -Rf docs/html

--- a/include/core/Partition_Data.hpp
+++ b/include/core/Partition_Data.hpp
@@ -1,10 +1,11 @@
 #ifndef PARTITION_DATA_H
 #define PARTITION_DATA_H
 
-using Tuple = std::tuple<int, std::string, std::string, std::string>;
+//using Tuple = std::tuple<int, std::string, std::string, std::string>;
 
 struct PartitionData
 {
+using Tuple = std::tuple<int, std::string, std::string, std::string>;
     int mpi_world_rank;
     std::unordered_set<std::string> catchment_ids;
     std::unordered_set<std::string> nexus_ids;

--- a/include/core/Partition_Data.hpp
+++ b/include/core/Partition_Data.hpp
@@ -1,11 +1,9 @@
 #ifndef PARTITION_DATA_H
 #define PARTITION_DATA_H
 
-//using Tuple = std::tuple<int, std::string, std::string, std::string>;
-
 struct PartitionData
 {
-using Tuple = std::tuple<int, std::string, std::string, std::string>;
+    using Tuple = std::tuple<int, std::string, std::string, std::string>;
     int mpi_world_rank;
     std::unordered_set<std::string> catchment_ids;
     std::unordered_set<std::string> nexus_ids;

--- a/include/core/Partition_Data.hpp
+++ b/include/core/Partition_Data.hpp
@@ -1,0 +1,14 @@
+#ifndef PARTITION_DATA_H
+#define PARTITION_DATA_H
+
+using Tuple = std::tuple<int, std::string, std::string, std::string>;
+
+struct PartitionData
+{
+    int mpi_world_rank;
+    std::unordered_set<std::string> catchment_ids;
+    std::unordered_set<std::string> nexus_ids;
+    std::vector<Tuple> remote_connections;
+};
+
+#endif  //PARTITION_DATA_H

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -25,7 +25,6 @@ class Partition_One {
          */
         void generate_partition(geojson::GeoJSON& catchment_collection)
         {
-            //PartitionData partition_data;
             for(auto& feature: *catchment_collection)
             {
                 std::string cat_id = feature->get_id();
@@ -38,7 +37,6 @@ class Partition_One {
 
     	virtual ~Partition_One(){};
 
-        //PartitionData is a struct
         PartitionData partition_data;       
 };
 

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -1,0 +1,47 @@
+#ifndef PARTITION_ONE_H
+#define PARTITION_ONE_H
+
+#ifdef NGEN_MPI_ACTIVE
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_set>
+#include <FeatureBuilder.hpp>
+#include "features/Features.hpp"
+#include <FeatureCollection.hpp>
+#include "Partition_Data.hpp"
+
+class Partition_One {
+
+    public:
+        Partition_One() {};
+
+        void generate_partition(geojson::GeoJSON& catchment_collection)
+        {
+            int counter = 0;
+            for(auto& feature: *catchment_collection)
+            {
+                std::string cat_id = feature->get_id();
+                catchment_ids.emplace(cat_id);
+                std::string nex_id = feature->get_property("toid").as_string();
+                nexus_ids.emplace(nex_id);
+                counter++;
+            }
+            std::cout << "counter = " << counter << std::endl;
+        }
+
+    	virtual ~Partition_One(){};
+
+        PartitionData partition_data;       
+
+    private:
+        int mpi_world_rank;
+        std::unordered_set<std::string> catchment_ids;
+        std::unordered_set<std::string> nexus_ids;
+        std::vector<Tuple> remote_connections;
+};
+
+#endif // NGEN_MPI_ACTIVE
+#endif // PARTITION_ONE_H

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -25,28 +25,21 @@ class Partition_One {
          */
         void generate_partition(geojson::GeoJSON& catchment_collection)
         {
+            //PartitionData partition_data;
             for(auto& feature: *catchment_collection)
             {
                 std::string cat_id = feature->get_id();
-                catchment_ids.emplace(cat_id);
+                partition_data.catchment_ids.emplace(cat_id);
                 std::string nex_id = feature->get_property("toid").as_string();
-                nexus_ids.emplace(nex_id);
+                partition_data.nexus_ids.emplace(nex_id);
             }
             partition_data.mpi_world_rank = 0;
-            partition_data.catchment_ids = catchment_ids;
-            partition_data.nexus_ids = nexus_ids;
         }
 
     	virtual ~Partition_One(){};
 
         //PartitionData is a struct
         PartitionData partition_data;       
-
-    private:
-        int mpi_world_rank;
-        std::unordered_set<std::string> catchment_ids;
-        std::unordered_set<std::string> nexus_ids;
-        std::vector<Tuple> remote_connections;
 };
 
 #endif // NGEN_MPI_ACTIVE

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -18,22 +18,25 @@ class Partition_One {
     public:
         Partition_One() {};
 
+        /**
+         * The function that parses geojson::GeoJSON data and build unordered sets of catchment_ids and nexus_ids
+
+         * @param catchment_collection the geojson::GeoJSON data containing all the necessary hydrofabric info
+         */
         void generate_partition(geojson::GeoJSON& catchment_collection)
         {
-            int counter = 0;
             for(auto& feature: *catchment_collection)
             {
                 std::string cat_id = feature->get_id();
                 catchment_ids.emplace(cat_id);
                 std::string nex_id = feature->get_property("toid").as_string();
                 nexus_ids.emplace(nex_id);
-                counter++;
             }
-            std::cout << "counter = " << counter << std::endl;
         }
 
     	virtual ~Partition_One(){};
 
+        //PartitionData is a struct
         PartitionData partition_data;       
 
     private:

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -32,6 +32,9 @@ class Partition_One {
                 std::string nex_id = feature->get_property("toid").as_string();
                 nexus_ids.emplace(nex_id);
             }
+            partition_data.mpi_world_rank = 0;
+            partition_data.catchment_ids = catchment_ids;
+            partition_data.nexus_ids = nexus_ids;
         }
 
     	virtual ~Partition_One(){};

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -1,8 +1,6 @@
 #ifndef PARTITION_ONE_H
 #define PARTITION_ONE_H
 
-#ifdef NGEN_MPI_ACTIVE
-
 #include <iostream>
 #include <memory>
 #include <string>
@@ -36,5 +34,4 @@ class Partition_One {
         PartitionData partition_data;       
 };
 
-#endif // NGEN_MPI_ACTIVE
 #endif // PARTITION_ONE_H

--- a/include/core/Partition_One.hpp
+++ b/include/core/Partition_One.hpp
@@ -16,8 +16,6 @@
 class Partition_One {
 
     public:
-        Partition_One() {};
-
         /**
          * The function that parses geojson::GeoJSON data and build unordered sets of catchment_ids and nexus_ids
 
@@ -34,8 +32,6 @@ class Partition_One {
             }
             partition_data.mpi_world_rank = 0;
         }
-
-    	virtual ~Partition_One(){};
 
         PartitionData partition_data;       
 };

--- a/include/core/Partition_Parser.hpp
+++ b/include/core/Partition_Parser.hpp
@@ -20,18 +20,7 @@
 #include "features/Features.hpp"
 #include <FeatureCollection.hpp>
 #include "JSONProperty.hpp"
-
-using Tuple = std::tuple<int, std::string, std::string, std::string>;
-
-//This struct is moved from private section to here so that the unit test function can access it
-struct PartitionData
-{
-    int mpi_world_rank;
-    std::unordered_set<std::string> catchment_ids;
-    std::unordered_set<std::string> nexus_ids;
-    std::vector<Tuple> remote_connections;
-};
-
+#include "Partition_Data.hpp"
 
 class Partitions_Parser {
 

--- a/include/core/Partition_Parser.hpp
+++ b/include/core/Partition_Parser.hpp
@@ -52,7 +52,6 @@ class Partitions_Parser {
             std::string remote_nex_id;
             std::string remote_cat_id;
             std::string direction;
-            //Tuple tmp_tuple;
             PartitionData::Tuple tmp_tuple;
             std::vector<PartitionData::Tuple> remote_conn_vec;
             int part_counter = 0;

--- a/include/core/Partition_Parser.hpp
+++ b/include/core/Partition_Parser.hpp
@@ -52,8 +52,9 @@ class Partitions_Parser {
             std::string remote_nex_id;
             std::string remote_cat_id;
             std::string direction;
-            Tuple tmp_tuple;
-            std::vector<Tuple> remote_conn_vec;
+            //Tuple tmp_tuple;
+            PartitionData::Tuple tmp_tuple;
+            std::vector<PartitionData::Tuple> remote_conn_vec;
             int part_counter = 0;
             for(auto &partition: tree.get_child("partitions"))  {
                 //Get partition id

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -382,19 +382,16 @@ int main(int argc, char *argv[]) {
     } else {
       catchment_collection = geojson::read(catchmentDataFile, catchment_subset_ids);
     }
-    std::cout << "Building Nexus collection" << std::endl;
     
     for(auto& feature: *catchment_collection)
     {
-        std::cout << "cat feature: " << feature << std::endl;
         //feature->set_id(feature->get_property("id").as_string());
         nexus_collection->add_feature(feature);
-        std::cout<<"Catchment "<<feature->get_id()<<" -> Nexus "<<feature->get_property("toid").as_string()<<std::endl;
+        //std::cout<<"Catchment "<<feature->get_id()<<" -> Nexus "<<feature->get_property("toid").as_string()<<std::endl;
     }
     //Update the feature ids for the combined collection, using the alternative property 'id'
     //to map features to their primary id as well as the alternative property
     nexus_collection->update_ids("id");
-    //std::cout<<"Initializing formulations\n";
     std::cout<<"Initializing formulations" << std::endl;
     std::shared_ptr<realization::Formulation_Manager> manager = std::make_shared<realization::Formulation_Manager>(REALIZATION_CONFIG_PATH);
     manager->read(catchment_collection, utils::getStdOut());
@@ -492,13 +489,6 @@ int main(int argc, char *argv[]) {
       // make a new simulation time object with a different output interval
       Simulation_Time sim_time(*manager->Simulation_Time_Object, time_steps[i]);
   
-      /*
-      for ( std::string id : features.catchments(keys[i]) ) { cat_ids.push_back(id); }
-      if (keys[i] != 0 )
-      {
-        layers[i] = std::make_shared<ngen::Layer>(desc, cat_ids, sim_time, features, catchment_collection, 0);
-      }
-      */
       for ( std::string id : features.catchments(keys[i]) ) { cat_ids.push_back(id); }
       if (keys[i] != 0 )
       {
@@ -506,7 +496,6 @@ int main(int argc, char *argv[]) {
       }
       else
       {
-        //layers[i] = std::make_shared<ngen::SurfaceLayer>(desc, cat_ids, sim_time, features, catchment_collection, 0, nexus_subset_ids, nexus_outfiles);
         layers[i] = std::make_shared<ngen::SurfaceLayer>(desc, cat_ids, sim_time, features, catchment_collection, 0, nexus_subset_ids, nexus_outfiles);
       }
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -345,7 +345,7 @@ int main(int argc, char *argv[]) {
         partition_parser.parse_partition_file();
 
         std::vector<PartitionData> &partitions = partition_parser.partition_ranks;
-        PartitionData local_data_tmp = partitions[mpi_rank];
+        local_data_tmp = partitions[mpi_rank];
         if (!nexus_subset_ids.empty()) {
             std::cerr << "Warning: CLI provided nexus subset will be ignored when using partition config";
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -238,6 +238,9 @@ ngen_add_test(
         gmock
         NGen::core
         NGen::geojson
+        NGen::geopackage
+    #REQUIRES
+    #    NGEN_WITH_SQLITE
 )
 
 ########################## MultiLayer Tests
@@ -458,6 +461,7 @@ ngen_add_test(
         NGen::core_mediator
         NGen::forcing
         NGen::geojson
+        NGen::geopackage
         NGen::realizations_catchment
         NGen::mdarray
         NGen::mdframe

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -468,6 +468,8 @@ ngen_add_test(
         NGen::logging
         NGen::ngen_bmi
         testbmicppmodel
+    REQUIRES
+        NGEN_WITH_SQLITE
         
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -448,7 +448,6 @@ ngen_add_test(
         utils/include/StreamOutputTest.cpp
         realizations/Formulation_Manager_Test.cpp
         utils/Partition_Test.cpp
-        utils/Partition_One_Test.cpp
         utils/mdarray_Test.cpp
         utils/mdframe_Test.cpp
         utils/mdframe_netcdf_Test.cpp
@@ -461,16 +460,12 @@ ngen_add_test(
         NGen::core_mediator
         NGen::forcing
         NGen::geojson
-        NGen::geopackage
         NGen::realizations_catchment
         NGen::mdarray
         NGen::mdframe
         NGen::logging
         NGen::ngen_bmi
         testbmicppmodel
-    REQUIRES
-        NGEN_WITH_SQLITE
-        
 )
 
 # Discover for test_all

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -229,6 +229,17 @@ ngen_add_test(
     #   NGEN_WITH_MPI
 )
 
+########################## Partition_One Tests
+ngen_add_test(
+    test_partition_one
+    OBJECTS
+        utils/Partition_One_Test.cpp
+    LIBRARIES
+        gmock
+        NGen::core
+        NGen::geojson
+)
+
 ########################## MultiLayer Tests
 ngen_add_test(
     test_multilayer
@@ -434,6 +445,7 @@ ngen_add_test(
         utils/include/StreamOutputTest.cpp
         realizations/Formulation_Manager_Test.cpp
         utils/Partition_Test.cpp
+        utils/Partition_One_Test.cpp
         utils/mdarray_Test.cpp
         utils/mdframe_Test.cpp
         utils/mdframe_netcdf_Test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -239,8 +239,8 @@ ngen_add_test(
         NGen::core
         NGen::geojson
         NGen::geopackage
-    #REQUIRES
-    #    NGEN_WITH_SQLITE
+    REQUIRES
+        NGEN_WITH_SQLITE
 )
 
 ########################## MultiLayer Tests

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -6,6 +6,10 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
+#ifdef NGEN_WITH_SQLITE3
+#include <geopackage.hpp>
+#endif
+
 //This way we can test the partition, since this doesn't have an explicit MPI dependency
 #define NGEN_MPI_ACTIVE
 #include "core/Partition_One.hpp"

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -6,7 +6,9 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
-#include "geopackage.hpp"
+#ifdef NGEN_WITH_SQLITE3
+#include <geopackage.hpp>
+#endif
 
 //This way we can test the partition, since this doesn't have an explicit MPI dependency
 #define NGEN_MPI_ACTIVE

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -1,0 +1,172 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include <stdio.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <vector>
+
+//This way we can test the partition, since this doesn't have an explicit MPI dependency
+#define NGEN_MPI_ACTIVE
+#include "core/Partition_One.hpp"
+#include "FileChecker.h"
+
+
+class PartitionOneTest: public ::testing::Test {
+
+    protected:
+
+    std::vector<std::string> hydro_fabric_paths;
+
+    std::string catchmentDataFile;
+    geojson::GeoJSON catchment_collection;
+
+    std::vector<std::string> catchment_subset_ids;
+    std::vector<std::string> nexus_subset_ids;
+
+    std::unordered_set<std::string> catchment_ids;
+    std::unordered_set<std::string> nexus_ids;
+
+    PartitionOneTest() {} 
+
+    ~PartitionOneTest() override {}
+
+    std::string file_search(const std::vector<std::string> &parent_dir_options, const std::string& file_basename)
+    {
+        // Build vector of names by building combinations of the path and basename options
+        std::vector<std::string> name_combinations;
+
+        // Build so that all path names are tried for given basename before trying a different basename option
+        for (auto & path_option : parent_dir_options)
+            name_combinations.push_back(path_option + file_basename);
+
+        return utils::FileChecker::find_first_readable(name_combinations);
+    }
+
+    void read_file_generate_partition_data()
+    {
+        const std::string file_path = file_search(hydro_fabric_paths, "catchment_data.geojson");
+        if (boost::algorithm::ends_with(catchmentDataFile, "gpkg")) {
+          #ifdef NGEN_WITH_SQLITE3
+          catchment_collection = ngen::geopackage::read(catchmentDataFile, "divides", catchment_subset_ids);
+          #else
+          throw std::runtime_error("SQLite3 support required to read GeoPackage files.");
+          #endif
+        } else {
+          catchment_collection = geojson::read(file_path, catchment_subset_ids);
+        }
+
+        for(auto& feature: *catchment_collection)
+        {
+            std::string cat_id = feature->get_id();
+            catchment_ids.emplace(cat_id);
+            std::string nex_id = feature->get_property("toid").as_string();
+            nexus_ids.emplace(nex_id);
+        }
+    }
+
+    void SetUp() override;
+
+    void TearDown() override;
+
+    void setupArbitraryExampleCase();
+
+};
+
+void PartitionOneTest::SetUp() {
+    setupArbitraryExampleCase();
+}
+
+void PartitionOneTest::TearDown() {
+
+}
+
+void PartitionOneTest::setupArbitraryExampleCase() {
+    hydro_fabric_paths = {
+        "data/",
+        "./data/",
+        "../data/",
+        "../../data/",
+
+    };
+}
+
+TEST_F(PartitionOneTest, TestPartitionOne) 
+{
+    read_file_generate_partition_data();
+
+    // Using the PartitionData struct for validating the Partition_One class result
+    Partition_One partition_one;
+    partition_one.generate_partition(catchment_collection);
+    PartitionData data_struct = partition_one.partition_data;
+
+    ASSERT_TRUE(catchment_ids.size() == data_struct.catchment_ids.size());
+    ASSERT_TRUE(nexus_ids.size() == data_struct.nexus_ids.size());
+}
+
+TEST_F(PartitionOneTest, TestPartitionData_1a)
+{
+    read_file_generate_partition_data();
+
+    Partition_One partition_one;
+    partition_one.generate_partition(catchment_collection);
+    PartitionData data_struct = partition_one.partition_data;
+    catchment_ids = data_struct.catchment_ids;
+
+    //check catchment partition
+    std::vector<std::string> cat_id_vec;
+    // convert unordered_set to vector
+    for (const auto& id: catchment_ids) {
+        cat_id_vec.push_back(id);
+    }
+
+    //sort ids
+    std::sort(cat_id_vec.begin(), cat_id_vec.end());
+    //create set of unique ids
+    std::set<std::string> unique(cat_id_vec.begin(), cat_id_vec.end());
+    std::set<std::string> duplicates;
+    //use set difference to identify all duplicates
+    std::set_difference(cat_id_vec.begin(), cat_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
+    if( duplicates.size() > 0 ){
+        for( auto& id: duplicates){
+            std::cout << "catchment "<<id<<" is duplicated!"<<std::endl;
+        }
+        exit(1);
+    }
+
+    ASSERT_TRUE(true);
+}
+
+TEST_F(PartitionOneTest, TestPartitionData_1b)
+{
+    read_file_generate_partition_data();
+
+    Partition_One partition_one;
+    partition_one.generate_partition(catchment_collection);
+    PartitionData data_struct = partition_one.partition_data;
+    nexus_ids = data_struct.nexus_ids;
+
+    //check nexus partition
+    std::vector<std::string> nex_id_vec;
+    //convert unordered_set to vector
+    for (const auto& id: nexus_ids) {
+        nex_id_vec.push_back(id);
+    }
+
+    //sort ids
+    std::sort(nex_id_vec.begin(), nex_id_vec.end());
+    //create set of unique ids
+    std::set<std::string> unique(nex_id_vec.begin(), nex_id_vec.end());
+    std::set<std::string> duplicates;
+    //use set difference to identify all duplicates
+    std::set_difference(nex_id_vec.begin(), nex_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
+    if( duplicates.size() > 0 ){
+        for( auto& id: duplicates){
+            std::cout << "nexus "<<id<<" is duplicated!"<<std::endl;
+        }
+        exit(1);
+    }
+    ASSERT_TRUE(true);
+}
+
+#undef NGEN_MPI_ACTIVE

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -6,8 +6,6 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
-//This way we can test the partition_one, since this doesn't have an explicit MPI dependency
-#define NGEN_MPI_ACTIVE
 #include "core/Partition_One.hpp"
 #include "FileChecker.h"
 
@@ -190,5 +188,3 @@ TEST_F(PartitionOneTest, TestPartitionData_1b)
     ASSERT_EQ(nexus_ids.size(), num_nexus);
     ASSERT_EQ(duplicates.size(), 0);
 }
-
-#undef NGEN_MPI_ACTIVE

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -6,11 +6,7 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
-#ifdef NGEN_WITH_SQLITE3
-#include <geopackage.hpp>
-#endif
-
-//This way we can test the partition, since this doesn't have an explicit MPI dependency
+//This way we can test the partition_one, since this doesn't have an explicit MPI dependency
 #define NGEN_MPI_ACTIVE
 #include "core/Partition_One.hpp"
 #include "FileChecker.h"
@@ -53,15 +49,7 @@ class PartitionOneTest: public ::testing::Test {
     void read_file_generate_partition_data()
     {
         const std::string file_path = file_search(hydro_fabric_paths, "catchment_data.geojson");
-        if (boost::algorithm::ends_with(catchmentDataFile, "gpkg")) {
-          #ifdef NGEN_WITH_SQLITE3
-          catchment_collection = ngen::geopackage::read(catchmentDataFile, "divides", catchment_subset_ids);
-          #else
-          throw std::runtime_error("SQLite3 support required to read GeoPackage files.");
-          #endif
-        } else {
-          catchment_collection = geojson::read(file_path, catchment_subset_ids);
-        }
+        catchment_collection = geojson::read(file_path, catchment_subset_ids);
 
         for(auto& feature: *catchment_collection)
         {

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -110,10 +110,7 @@ TEST_F(PartitionOneTest, TestPartitionData_1a)
     std::set_difference(cat_id_vec.begin(), cat_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
 
     for( auto& id: duplicates){
-        if (!id.empty()) {
-            std::cout << "duplicates string set is not empty" << std::endl;
-            break;
-        }
+        std::cout << "duplicates string set contains " << id << std::endl;
     }
     ASSERT_EQ(duplicates.size(), 0);
 }
@@ -142,10 +139,7 @@ TEST_F(PartitionOneTest, TestPartitionData_1b)
     std::set_difference(nex_id_vec.begin(), nex_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
 
     for( auto& id: duplicates){
-        if (!id.empty()) {
-            std::cout << "duplicates string set is not empty" << std::endl;
-            break;
-        }
+        std::cout << "duplicates string set contains " << id << std::endl;
     }
     ASSERT_EQ(duplicates.size(), 0);
 }

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -31,6 +31,9 @@ class PartitionOneTest: public ::testing::Test {
     std::unordered_set<std::string> catchment_ids;
     std::unordered_set<std::string> nexus_ids;
 
+    Partition_One partition_one;
+    PartitionData partition_data;
+
     PartitionOneTest() {} 
 
     ~PartitionOneTest() override {}
@@ -63,9 +66,9 @@ class PartitionOneTest: public ::testing::Test {
         for(auto& feature: *catchment_collection)
         {
             std::string cat_id = feature->get_id();
-            catchment_ids.emplace(cat_id);
+            partition_data.catchment_ids.emplace(cat_id);
             std::string nex_id = feature->get_property("toid").as_string();
-            nexus_ids.emplace(nex_id);
+            partition_data.nexus_ids.emplace(nex_id);
         }
     }
 
@@ -95,24 +98,10 @@ void PartitionOneTest::setupArbitraryExampleCase() {
     };
 }
 
-TEST_F(PartitionOneTest, TestPartitionOne) 
-{
-    read_file_generate_partition_data();
-
-    // Using the PartitionData struct for validating the Partition_One class result
-    Partition_One partition_one;
-    partition_one.generate_partition(catchment_collection);
-    PartitionData data_struct = partition_one.partition_data;
-
-    ASSERT_TRUE(catchment_ids.size() == data_struct.catchment_ids.size());
-    ASSERT_TRUE(nexus_ids.size() == data_struct.nexus_ids.size());
-}
-
 TEST_F(PartitionOneTest, TestPartitionData_1a)
 {
     read_file_generate_partition_data();
 
-    Partition_One partition_one;
     partition_one.generate_partition(catchment_collection);
     PartitionData data_struct = partition_one.partition_data;
     catchment_ids = data_struct.catchment_ids;
@@ -133,7 +122,6 @@ TEST_F(PartitionOneTest, TestPartitionData_1a)
     std::set_difference(cat_id_vec.begin(), cat_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
     if( duplicates.size() > 0 ){
         for( auto& id: duplicates){
-            std::cout << "catchment "<<id<<" is duplicated!"<<std::endl;
         }
         exit(1);
     }
@@ -145,7 +133,6 @@ TEST_F(PartitionOneTest, TestPartitionData_1b)
 {
     read_file_generate_partition_data();
 
-    Partition_One partition_one;
     partition_one.generate_partition(catchment_collection);
     PartitionData data_struct = partition_one.partition_data;
     nexus_ids = data_struct.nexus_ids;
@@ -166,7 +153,6 @@ TEST_F(PartitionOneTest, TestPartitionData_1b)
     std::set_difference(nex_id_vec.begin(), nex_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
     if( duplicates.size() > 0 ){
         for( auto& id: duplicates){
-            std::cout << "nexus "<<id<<" is duplicated!"<<std::endl;
         }
         exit(1);
     }

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -6,9 +6,7 @@
 #include <boost/lexical_cast.hpp>
 #include <vector>
 
-#ifdef NGEN_WITH_SQLITE3
-#include <geopackage.hpp>
-#endif
+#include "geopackage.hpp"
 
 //This way we can test the partition, since this doesn't have an explicit MPI dependency
 #define NGEN_MPI_ACTIVE

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -19,7 +19,7 @@ class PartitionOneTest: public ::testing::Test {
     std::vector<std::string> hydro_fabric_paths;
 
     std::string catchmentDataFile;
-    geojson::GeoJSON catchment_collection;
+    geojson::GeoJSON catchment_collection, nexus_collection;
 
     std::vector<std::string> catchment_subset_ids;
     std::vector<std::string> nexus_subset_ids;
@@ -58,6 +58,12 @@ class PartitionOneTest: public ::testing::Test {
             std::string nex_id = feature->get_property("toid").as_string();
             partition_data.nexus_ids.emplace(nex_id);
         }
+    }
+
+    void read_file_nexus_data()
+    {
+        const std::string file_path = file_search(hydro_fabric_paths, "nexus_data.geojson");
+        nexus_collection = geojson::read(file_path, nexus_subset_ids);
     }
 
     void SetUp() override;
@@ -112,12 +118,33 @@ TEST_F(PartitionOneTest, TestPartitionData_1a)
     for( auto& id: duplicates){
         std::cout << "duplicates string set contains " << id << std::endl;
     }
+
+    //process the original read in data
+    std::vector<std::string> input_cat_ids;
+    for(auto& feature: *catchment_collection)
+    {
+        std::string cat_id = feature->get_id();
+        input_cat_ids.push_back(cat_id);
+    }
+    std::sort(input_cat_ids.begin(), input_cat_ids.end());
+    
+    for (int i = 0; i < input_cat_ids.size(); ++i) {
+        if (input_cat_ids[i] != cat_id_vec[i]) {
+            std::cout << "Input cat_id: " << input_cat_ids[i] << " differs from patition cat_id: " << cat_id_vec[i] << std::endl;
+        }
+    }
+
+    //get input number of catchments
+    int num_catchments = catchment_collection->get_size();
+
+    ASSERT_EQ(catchment_ids.size(), num_catchments);
     ASSERT_EQ(duplicates.size(), 0);
 }
 
 TEST_F(PartitionOneTest, TestPartitionData_1b)
 {
     read_file_generate_partition_data();
+    read_file_nexus_data();
 
     partition_one.generate_partition(catchment_collection);
     PartitionData data_struct = partition_one.partition_data;
@@ -141,6 +168,26 @@ TEST_F(PartitionOneTest, TestPartitionData_1b)
     for( auto& id: duplicates){
         std::cout << "duplicates string set contains " << id << std::endl;
     }
+
+    //process the original read in data
+    std::vector<std::string> input_nex_ids;
+    for(auto& feature: *nexus_collection)
+    {
+        std::string nex_id = feature->get_id();
+        input_nex_ids.push_back(nex_id);
+    }
+    std::sort(input_nex_ids.begin(), input_nex_ids.end());
+
+    for (int i = 0; i < input_nex_ids.size(); ++i) {
+        if (input_nex_ids[i] != nex_id_vec[i]) {
+            std::cout << "Input nex_id: " << input_nex_ids[i] << " differs from patition nex_id: " << nex_id_vec[i] << std::endl;
+        }
+    }
+
+    //get input number of nexus
+    int num_nexus = nexus_collection->get_size();
+
+    ASSERT_EQ(nexus_ids.size(), num_nexus);
     ASSERT_EQ(duplicates.size(), 0);
 }
 

--- a/test/utils/Partition_One_Test.cpp
+++ b/test/utils/Partition_One_Test.cpp
@@ -120,13 +120,14 @@ TEST_F(PartitionOneTest, TestPartitionData_1a)
     std::set<std::string> duplicates;
     //use set difference to identify all duplicates
     std::set_difference(cat_id_vec.begin(), cat_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
-    if( duplicates.size() > 0 ){
-        for( auto& id: duplicates){
-        }
-        exit(1);
-    }
 
-    ASSERT_TRUE(true);
+    for( auto& id: duplicates){
+        if (!id.empty()) {
+            std::cout << "duplicates string set is not empty" << std::endl;
+            break;
+        }
+    }
+    ASSERT_EQ(duplicates.size(), 0);
 }
 
 TEST_F(PartitionOneTest, TestPartitionData_1b)
@@ -151,12 +152,14 @@ TEST_F(PartitionOneTest, TestPartitionData_1b)
     std::set<std::string> duplicates;
     //use set difference to identify all duplicates
     std::set_difference(nex_id_vec.begin(), nex_id_vec.end(), unique.begin(), unique.end(), std::inserter(duplicates, duplicates.end()));
-    if( duplicates.size() > 0 ){
-        for( auto& id: duplicates){
+
+    for( auto& id: duplicates){
+        if (!id.empty()) {
+            std::cout << "duplicates string set is not empty" << std::endl;
+            break;
         }
-        exit(1);
     }
-    ASSERT_TRUE(true);
+    ASSERT_EQ(duplicates.size(), 0);
 }
 
 #undef NGEN_MPI_ACTIVE


### PR DESCRIPTION
This PR address issue #703 in ngen framework, i.e., to run a MPI job using one processor without providing a partition file. For more than one processor, you must provide a partition file. If you insist on providing the partition file in the case of one processor, you are still ok.

## Additions

- Define a dummy class `PartitionOne` for to present a whole-hydrofabric partition for a single process, and associated test

## Removals

None

## Changes

- Use `PartitionOne` when running on a single MPI process, rather than expecting a partition file argument on the command line

## Testing

Passed all local test except RoutingPyBindTest.TestRoutingPyBind
Passing all automated testing

## Screenshots


## Notes

Command line example to run a job without/with partition file:

    mpirun -n 1 ./cmake_build_mpi/ngen data/catchment_data.geojson '' data/nexus_data.geojson '' data/example_bmi_multi_realization_config.json
 
    mpirun -n 3 ./cmake_build_mpi/ngen data/catchment_data.geojson '' data/nexus_data.geojson '' data/example_bmi_multi_realization_config.json ./test_partition_3.json


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
