### PR TITLE
Remove global include from FindUDUNITS2.cmake

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -86,7 +86,6 @@ runs:
               echo "LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH" >> $GITHUB_ENV
               echo "LDFLAGS=-L/usr/local/lib" >> $GITHUB_ENV
               echo "LIB=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-              echo "INCLUDE=/usr/local/include" >> $GITHUB_ENV
               echo "NETCDF=/usr/local" >> $GITHUB_ENV
             fi
           shell: bash
@@ -169,6 +168,13 @@ runs:
         - name: Setup Fortran Compiler
           if: ${{ inputs.bmi_fortran == 'ON' && runner.os == 'macOS' }}
           run: echo "FC=gfortran-13" >> $GITHUB_ENV
+          shell: bash
+
+        - name: Setup macOS Default Compiler Includes
+          if: runner.os == 'macOS'
+          run: |
+            echo "C_INCLUDE_PATH=/usr/local/include" >> $GITHUB_ENV
+            echo "CPLUS_INCLUDE_PATH=/usr/local/include" >> $GITHUB_ENV
           shell: bash
 
         - name: Cmake Initialization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,6 @@ endif()
 if(NGEN_WITH_UDUNITS)
     find_package(UDUNITS2 REQUIRED)
     add_compile_definitions(NGEN_WITH_UDUNITS)
-    get_target_property(_SUMMARY_UDUNITS_INCLUDE libudunits2 INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 
 # -----------------------------------------------------------------------------
@@ -459,7 +458,7 @@ ngen_dependent_multiline_message(NGEN_WITH_SQLITE
 ngen_dependent_multiline_message(NGEN_WITH_UDUNITS
 "  UDUNITS2:"
 "    Library: ${UDUNITS2_LIBRARY}"
-"    Include: ${_SUMMARY_UDUNITS_INCLUDE}")
+"    Include: ${UDUNITS2_INCLUDE_DIR}")
 ngen_dependent_multiline_message(NGEN_WITH_BMI_FORTRAN
 "  Fortran:"
 "    BMI_FORTRAN_ISO_C_LIB_PATH: ${BMI_FORTRAN_ISO_C_LIB_PATH}"

--- a/cmake/FindUDUNITS2.cmake
+++ b/cmake/FindUDUNITS2.cmake
@@ -1,34 +1,32 @@
-find_path(UDUNITS2_INCLUDE 
-    NAMES udunits2.h
-    PATH_SUFFIXES udunits2
-    DOC "UDUNITS-2 include directories"
-)
-mark_as_advanced(UDUNITS2_INCLUDE)
-
-find_library(UDUNITS2_LIBRARY
-    NAMES
-        libudunits2.so
-        libudunits2.dylib
-)
-mark_as_advanced(UDUNITS2_LIBRARY)
-
-if(DEFINED UDUNITS2_INCLUDE AND DEFINED UDUNITS2_LIBRARY)
-    set(UDUNITS2_FOUND ON)
-else()
-    set(UDUNITS2_FOUND OFF)
+if (UDUNITS2_INCLUDE_DIR AND UDUNITS2_LIBRARY)
+    set(UDUNITS2_FIND_QUIETLY TRUE)
 endif()
 
+find_library(UDUNITS2_LIBRARY udunits2
+    PATHS "${UDUNITS2_ROOT}/lib")
+mark_as_advanced(UDUNITS2_LIBRARY)
+
+get_filename_component(UDUNITS2_LIBRARY_DIR "${UDUNITS2_LIBRARY}" PATH)
+
+find_path(UDUNITS2_INCLUDE_DIR udunits2.h
+    PATHS "${UDUNITS2_ROOT}/include"
+    HINTS "${UDUNITS2_LIBRARY_DIR}/../include"
+    PATH_SUFFIXES "udunits2")
+mark_as_advanced(UDUNITS2_INCLUDE_DIR)
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(UDUNITS2 DEFAULT_MSG UDUNITS2_LIBRARY UDUNITS2_INCLUDE)
+find_package_handle_standard_args(UDUNITS2
+    DEFAULT_MSG UDUNITS2_LIBRARY UDUNITS2_INCLUDE_DIR)
 
 if(UDUNITS2_FOUND)
     # Create UDUNITS2 target
     # Note: GLOBAL is required here in order to extend the scope of the target.
     #       see: https://stackoverflow.com/a/46491758/6891484
     add_library(libudunits2 SHARED IMPORTED GLOBAL)
-    set_target_properties(libudunits2 PROPERTIES IMPORTED_LOCATION "${UDUNITS2_LIBRARY}")
-    target_include_directories(libudunits2 INTERFACE "${UDUNITS2_INCLUDE}")
-
-    # Based on: https://stackoverflow.com/questions/26834553/osx-10-10-cmake-3-0-2-and-clang-wont-find-local-headers
-    include_directories(${UDUNITS2_INCLUDE})
+    target_link_libraries(libudunits2 INTERFACE "${UDUNITS2_LIBRARY}")
+    target_include_directories(libudunits2 INTERFACE "${UDUNITS2_INCLUDE_DIR}")
+    set_target_properties(libudunits2
+        PROPERTIES
+            IMPORTED_LOCATION "${UDUNITS2_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${UDUNITS2_INCLUDE_DIR}")
 endif()

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -1,7 +1,22 @@
 #ifndef NGEN_UNITSHELPER_H
 #define NGEN_UNITSHELPER_H
 
-#include <udunits2.h>
+// FIXME: Workaround to handle UDUNITS2 includes with differing paths.
+//        Not exactly sure why CMake can't handle this, but even with
+//        verifying the search paths, the correct header can't be found.
+//
+//        See PR #725 for context on this issue.
+
+#if defined(__has_include)
+#  if __has_include(<udunits2.h>)
+#    include <udunits2.h>
+#  elif __has_include(<udunits2/udunits2.h>)
+#    include <udunits2/udunits2.h>
+#  endif
+#else
+#  include <udunits2.h>
+#endif
+
 #include <map>
 #include <memory>
 #include <mutex>

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -1,12 +1,12 @@
+#ifndef NGEN_UNITSHELPER_H
+#define NGEN_UNITSHELPER_H
+
 #include <udunits2.h>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include "all.h"
-
-#ifndef NGEN_UNITSHELPER_H
-#define NGEN_UNITSHELPER_H
 
 class UnitsHelper {
 

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -8,10 +8,10 @@
 //        See PR #725 for context on this issue.
 
 #if defined(__has_include)
-#  if __has_include(<udunits2.h>)
-#    include <udunits2.h>
-#  elif __has_include(<udunits2/udunits2.h>)
+#  if __has_include(<udunits2/udunits2.h>)
 #    include <udunits2/udunits2.h>
+#  else
+#    include <udunits2.h>
 #  endif
 #else
 #  include <udunits2.h>


### PR DESCRIPTION
This PR fixes an issue where non-default UDUNITS2 installations are propagating its include path to all targets. This becomes an issue if the non-default path has a conflicting header (i.e. `bmi.h`), as files will prefer that over other search paths.

For example, if `bmi-c` is installed in the same non-default path, this can cause an issue in compiling CFE because there's a non-BMI define in its header:

```
<ngen_dir>/extern/cfe/cfe/src/bmi_cfe.c:1588:56: error: use of undeclared identifier 'BMI_MAX_LOCATION_NAME'
            strncpy(location, output_var_locations[i], BMI_MAX_LOCATION_NAME);
                                                       ^
<ngen_dir>/extern/cfe/cfe/src/bmi_cfe.c:1595:55: error: use of undeclared identifier 'BMI_MAX_LOCATION_NAME'
            strncpy(location, input_var_locations[i], BMI_MAX_LOCATION_NAME);
```

For reference, this issue was discovered by checking the exported compilation database of a macOS host attempting to build `ngen`, and noticing that `-I/usr/local/include` was added to every translation unit.

## Removals

- Removes global include statement. ~The comment shouldn't be relevant anymore, since the transition to a more targets-based build process.~ The comment is still relevant, but our approach should change so that the include issue requires user-intervention instead of forcing onto the user, i.e. see [comment below](https://github.com/NOAA-OWP/ngen/pull/725#issuecomment-1936375955).

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
- [x] macOS
