### PR TITLE
Ensure NOAH-OWP-Modular can be built manually

### DIFF
--- a/extern/noah-owp-modular/CMakeLists.txt
+++ b/extern/noah-owp-modular/CMakeLists.txt
@@ -28,6 +28,16 @@ target_include_directories(surfacebmi INTERFACE "${_SURFACEBMI_BINARY_DIR}/mod")
 target_compile_definitions(surfacebmi PRIVATE BMI_ACTIVE)
 
 if(NGEN_IS_MAIN_PROJECT)
+
+    # This ensures we can build NOAH-OWP-Modular with NGen support, but
+    # separate from NGen.
+    if(NOT TARGET iso_c_bmi)
+        add_subdirectory(
+            "${CMAKE_CURRENT_LIST_DIR}/../iso_c_fortran_bmi"
+            "${CMAKE_CURRENT_BINARY_DIR}/iso_c_fortran_bmi"
+        )
+    endif()
+
     target_link_libraries(surfacebmi PUBLIC iso_c_bmi)
     target_compile_definitions(surfacebmi PRIVATE NGEN_FORCING_ACTIVE NGEN_OUTPUT_ACTIVE NGEN_ACTIVE)
 else()


### PR DESCRIPTION
This PR resolves #730 by ensuring `iso_c_fortran_bmi` is part of the NOAH-OWP-Modular build when it is built manually. To ensure NOAH-OWP-Modular is built with NGen support, when configuring, the CMake option `-DNGEN_IS_MAIN_PROJECT` must be set to `ON`.

## Changes

- Add `iso_c_fortran_bmi` as a dependent CMake subdirectory to the NOAH-OWP-Modular build.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
- [x] macOS
