### PR TITLE
Modify CMakelists.txt so that test_bmi_fortran can find iso_c

### DIFF
--- a/extern/test_bmi_fortran/CMakeLists.txt
+++ b/extern/test_bmi_fortran/CMakeLists.txt
@@ -19,6 +19,8 @@ target_include_directories(testbmifortranmodel INTERFACE "${_TESTBMIFORTRAN_BINA
 
 if(NGEN_IS_MAIN_PROJECT)
 
+    # This ensures we can build testbmifortranmodel with NGen support, but
+    # separate from NGen.
     if(NOT TARGET iso_c_bmi)
         add_subdirectory(
             "${CMAKE_CURRENT_LIST_DIR}/../iso_c_fortran_bmi"
@@ -26,9 +28,7 @@ if(NGEN_IS_MAIN_PROJECT)
         )
     endif()
 
-    #target_link_libraries(surfacebmi PUBLIC iso_c_bmi)
     target_link_libraries(testbmifortranmodel PUBLIC iso_c_bmi)
-    #target_compile_definitions(surfacebmi PRIVATE NGEN_FORCING_ACTIVE NGEN_OUTPUT_ACTIVE NGEN_ACTIVE)
 endif()
 
 unset(_TESTBMIFORTRAN_BINARY_DIR)

--- a/extern/test_bmi_fortran/CMakeLists.txt
+++ b/extern/test_bmi_fortran/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(testbmifortranmodel INTERFACE "${_TESTBMIFORTRAN_BINA
 
 if(NGEN_IS_MAIN_PROJECT)
 
-    # This ensures we can build NOAH-OWP-Modular with NGen support, but
+    # This ensures we can build test_bmi_fortran with NGen support, but
     # separate from NGen.
     if(NOT TARGET iso_c_bmi)
         add_subdirectory(

--- a/extern/test_bmi_fortran/CMakeLists.txt
+++ b/extern/test_bmi_fortran/CMakeLists.txt
@@ -16,7 +16,22 @@ target_sources(testbmifortranmodel PRIVATE ${_TESTBMIFORTRAN_OBJECTS})
 target_compile_options(testbmifortranmodel PRIVATE -cpp -ffree-line-length-none)
 target_compile_definitions(testbmifortranmodel PRIVATE NGEN_ACTIVE)
 target_include_directories(testbmifortranmodel INTERFACE "${_TESTBMIFORTRAN_BINARY_DIR}/mod")
-target_link_libraries(testbmifortranmodel PUBLIC iso_c_bmi)
+
+if(NGEN_IS_MAIN_PROJECT)
+
+    # This ensures we can build NOAH-OWP-Modular with NGen support, but
+    # separate from NGen.
+    if(NOT TARGET iso_c_bmi)
+        add_subdirectory(
+            "${CMAKE_CURRENT_LIST_DIR}/../iso_c_fortran_bmi"
+            "${CMAKE_CURRENT_BINARY_DIR}/iso_c_fortran_bmi"
+        )
+    endif()
+
+    #target_link_libraries(surfacebmi PUBLIC iso_c_bmi)
+    target_link_libraries(testbmifortranmodel PUBLIC iso_c_bmi)
+    #target_compile_definitions(surfacebmi PRIVATE NGEN_FORCING_ACTIVE NGEN_OUTPUT_ACTIVE NGEN_ACTIVE)
+endif()
 
 unset(_TESTBMIFORTRAN_BINARY_DIR)
 unset(_TESTBMIFORTRAN_OBJECTS)

--- a/extern/test_bmi_fortran/CMakeLists.txt
+++ b/extern/test_bmi_fortran/CMakeLists.txt
@@ -19,8 +19,6 @@ target_include_directories(testbmifortranmodel INTERFACE "${_TESTBMIFORTRAN_BINA
 
 if(NGEN_IS_MAIN_PROJECT)
 
-    # This ensures we can build test_bmi_fortran with NGen support, but
-    # separate from NGen.
     if(NOT TARGET iso_c_bmi)
         add_subdirectory(
             "${CMAKE_CURRENT_LIST_DIR}/../iso_c_fortran_bmi"


### PR DESCRIPTION
This PR fix a compile error for extern/test_bmi_fortran where an error such as following occurs:
```
use bmif_2_0_iso
      1
Fatal Error: Can't open module file ‘bmif_2_0_iso.mod’ for reading at (1): No such file or directory
```

## Additions

-

## Removals

-

## Changes

extern/test_bmi_fortran/CMakeLists.txt

## Testing

1. Local Linux platform test

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [x ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
