### PR TITLE
Loosen dependency on netcdf-cxx4 to 4.3.0 from 4.3.1

### DIFF
--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -120,7 +120,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     });
 
     // correct string release
-    ids.freeString(num_ids,&string_buffers[0]);
+    nc_free_string(num_ids,&string_buffers[0]);
 
     // now get the size of the time dimension
     auto num_times = nc_file->getDim("time").getSize();


### PR DESCRIPTION
There was an API change that's not backwards compatible from 4.3.0 to 4.3.1, in adding a member function. Avoid using that member function to gain compatibility with the older release.

## Changes

- Use C API free function `nc_free_string` from base netcdf instead of member function `freeString` from separate C++ bindings in netcdf-cxx4

## Testing

Modified version used in benchmark/scaling runs on Hera.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
