### PR TITLE
Bundle netcdf-cxx4 and build it as needed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 	path = extern/sloth
 	url = https://github.com/noaa-owp/SLoTH
 	branch = latest
+[submodule "extern/netcdf-cxx4"]
+	path = extern/netcdf-cxx4
+	url = https://github.com/Unidata/netcdf-cxx4/

--- a/.gitmodules
+++ b/.gitmodules
@@ -41,5 +41,5 @@
 	url = https://github.com/noaa-owp/SLoTH
 	branch = latest
 [submodule "extern/netcdf-cxx4"]
-	path = extern/netcdf-cxx4
+	path = extern/netcdf-cxx4/netcdf-cxx4
 	url = https://github.com/Unidata/netcdf-cxx4/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,22 @@ endif()
 
 # -----------------------------------------------------------------------------
 if(NGEN_WITH_NETCDF)
-    find_package(NetCDF REQUIRED COMPONENTS CXX)
+    find_package(NetCDF COMPONENTS CXX)
+
+    if(NOT NetCDF_CXX_FOUND)
+        find_package(NetCDF REQUIRED)
+        message(INFO " Using internal copy of netcdf-cxx4")
+        add_external_subdirectory(
+            SOURCE "${NGEN_EXT_DIR}/netcdf-cxx4"
+            OUTPUT "${PROJECT_BINARY_DIR}/extern-libs/netcdf-cxx4"
+            GIT_UPDATE "${NGEN_EXT_DIR}/netcdf-cxx4/netcdf-cxx4"
+	    IMPORTS netcdf-cxx4
+        )
+        set(NetCDF_CXX_INCLUDE_DIR "${NGEN_EXT_DIR}/netcdf-cxx4/netcdf-cxx4/cxx4")
+        set(NetCDF_CXX_LIBRARY "${PROJECT_BINARY_DIR}/extern-libs/netcdf-cxx4/libnetcdf-cxx4.a")
+        target_link_libraries(NetCDF INTERFACE netcdf-cxx4)
+    endif()
+
     add_compile_definitions(NETCDF_ACTIVE)
 endif()
 

--- a/extern/netcdf-cxx4/CMakeLists.txt
+++ b/extern/netcdf-cxx4/CMakeLists.txt
@@ -1,0 +1,10 @@
+###
+# Set up headers and sources
+###
+
+file(GLOB CXX_HEADERS netcdf-cxx4/cxx4/*.h)
+file(GLOB CXX_SOURCES netcdf-cxx4/cxx4/nc*.cpp)
+
+ADD_LIBRARY(netcdf-cxx4 ${CXX_SOURCES})
+TARGET_INCLUDE_DIRECTORIES(netcdf-cxx4 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/netcdf-cxx4/cxx4")
+TARGET_LINK_LIBRARIES(netcdf-cxx4 NetCDF::C)


### PR DESCRIPTION
It's apparently common to find installations of netcdf that don't have netcdf-cxx4 installed in the same place, or at all. We want to just build and use our own copy of the C++ bindings when this is the case.

Fixes #729

## Additions

- Submodule netcdf-cxx4
- CMakeLists.txt to wrap up a simple source build, not trying to do a full stand-alone configuration

## Changes

- Top-level CMakeLists.txt now tries to find NetCDF with and without the C++ bindings from netcdf-cxx4, and builds netcdf-cxx4 privately if they're not found

## Testing

- Built on Hera where netcdf-cxx4 is absent
- The BMI module integration tests run in an environment with netcdf-cxx4 coinstalled from the Ubuntu distro package or from Homebrew on macOS

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
