### PR TITLE
Formulation configuration refactoring

### DIFF
--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -45,6 +45,14 @@ namespace realization {
 #endif // ACTIVATE_PYTHON
     };
 
+    static std::string valid_formulation_keys(){
+        std::string keys = "";
+        for(const auto& kv : formulations){
+            keys.append(kv.first+" ");
+        }
+        return keys;
+    }
+
     static bool formulation_exists(std::string formulation_type) {
         return formulations.count(formulation_type) > 0;
     }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -19,6 +19,7 @@
 #include "LayerData.hpp"
 #include "realizations/config/time.hpp"
 #include "realizations/config/routing.hpp"
+#include "realizations/config/config.hpp"
 
 namespace realization {
 
@@ -58,31 +59,9 @@ namespace realization {
                 auto possible_global_config = tree.get_child_optional("global");
 
                 if (possible_global_config) {
-                    this->global_formulation_tree = *possible_global_config;
-
-                    //get forcing info
-                    for (auto &forcing_parameter : (*possible_global_config).get_child("forcing")) {
-                        this->global_forcing.emplace(
-                            forcing_parameter.first,
-                            geojson::JSONProperty(forcing_parameter.first, forcing_parameter.second)
-                        );
-                      }
-
-                    //get first empty key under formulations (corresponds to first json array element)
-                    auto formulation = (*possible_global_config).get_child("formulations..");
-
-                    for (std::pair<std::string, boost::property_tree::ptree> global_setting : formulation.get_child("params")) {
-                        this->global_formulation_parameters.emplace(
-                            global_setting.first,
-                            geojson::JSONProperty(global_setting.first, global_setting.second)
-                        );
-                    }
+                    global_config = realization::config::Config(*possible_global_config);
                 }
 
-                /**
-                 * Read simulation time from configuration file
-                 * /// \todo TODO: Separate input_interval from output_interval
-                 */            
                 auto possible_simulation_time = tree.get_child_optional("time");
 
                 if (!possible_simulation_time) {
@@ -703,11 +682,7 @@ namespace realization {
 
             boost::property_tree::ptree tree;
 
-            boost::property_tree::ptree global_formulation_tree;
-
-            geojson::PropertyMap global_formulation_parameters;
-
-            geojson::PropertyMap global_forcing;
+            realization::config::Config global_config;
 
             std::map<std::string, std::shared_ptr<Catchment_Formulation>> formulations;
 

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -165,46 +165,25 @@ namespace realization {
                           #endif
                           continue;
                       }
+                      realization::config::Config catchment_formulation(catchment_config.second);
 
-                      decltype(auto) formulations = catchment_config.second.get_child_optional("formulations");
-                      if( !formulations ) {
+                      if(!catchment_formulation.has_formulation()){
                         throw std::runtime_error("ERROR: No formulations defined for "+catchment_config.first+".");
                       }
-
                       // Parse catchment-specific model_params
                       auto catchment_feature = fabric->get_feature(catchment_index);
-
-                      for (auto &formulation: *formulations) {
-                          // Handle single-bmi
-                          decltype(auto) model_params = formulation.second.get_child_optional("params.model_params");
-                          if (model_params) {
-                              parse_external_model_params(*model_params, catchment_feature);
-                          }
-
-                          // Handle multi-bmi
-                          // FIXME: this will not handle doubly nested multi-BMI configs,
-                          //        might need a recursive helper here?
-                          decltype(auto) nested_modules = formulation.second.get_child_optional("params.modules");
-                          if (nested_modules) {
-                            for (decltype(auto) nested_formulation : *nested_modules) {
-                                decltype(auto) nested_model_params = nested_formulation.second.get_child_optional("params.model_params");
-                                if (nested_model_params) {
-                                    parse_external_model_params(*nested_model_params, catchment_feature);
-                                }
-                            }
-                          }
-                        
-                          this->add_formulation(
-                              this->construct_formulation_from_tree(
-                                  simulation_time_config,
-                                  catchment_config.first,
-                                  catchment_config.second,
-                                  formulation.second,
-                                  output_stream
-                              )
-                          );
-                          break; //only construct one for now FIXME
-                        } //end for formulaitons
+                      catchment_formulation.formulation.link_external(catchment_feature);
+                      this->add_formulation(
+                        this->construct_formulation_from_tree(
+                            simulation_time_config,
+                            catchment_config.first,
+                            catchment_config.second,
+                            catchment_formulation,
+                            output_stream
+                        )
+                      );
+                        //  break; //only construct one for now FIXME
+                       // } //end for formulaitons
                       }//end for catchments
 
 

--- a/include/realizations/config/config.hpp
+++ b/include/realizations/config/config.hpp
@@ -1,0 +1,63 @@
+#ifndef NGEN_REALIZATION_CONFIG_H
+#define NGEN_REALIZATION_CONFIG_H
+
+#include <boost/property_tree/ptree.hpp>
+
+#include "formulation.hpp"
+#include "forcing.hpp"
+
+#include<iostream>
+
+namespace realization{
+  namespace config{
+
+    /**
+     * @brief Structure representing the configuration for a general Formulation.
+     * 
+     */
+    struct Config{
+        
+        /**
+         * @brief Construct a new Config object
+         *
+         */
+        Config() = default;
+
+        /**
+         * @brief Construct a new Config object from a property tree
+         * 
+         * @param tree 
+         */
+        Config(const boost::property_tree::ptree& tree):formulation_tree(tree){
+        
+            auto possible_forcing = tree.get_child_optional("forcing");
+
+            if (possible_forcing) {
+                forcing = Forcing(*possible_forcing);
+            }
+            //get first empty key under formulations (corresponds to first json array element)
+            auto possible_formulation_tree = tree.get_child_optional("formulations..");
+            if(possible_formulation_tree){
+                formulation = Formulation(*possible_formulation_tree);
+            }
+        }
+
+        /**
+         * @brief Determine if the config has a formulation
+         * 
+         * @return true if the formulation name/type is set or if model parameters are present
+         * @return false if either the type or parameters are empty
+         */
+        bool has_formulation(){
+            return !(formulation.type.empty() || formulation.parameters.empty());
+        }
+
+        Formulation formulation;
+        boost::property_tree::ptree formulation_tree;
+        Forcing forcing;
+    };
+
+    
+  };//end namespace config
+}//end namespace realization
+#endif //NGEN_REALIZATION_CONFIG_H

--- a/include/realizations/config/config.hpp
+++ b/include/realizations/config/config.hpp
@@ -6,8 +6,6 @@
 #include "formulation.hpp"
 #include "forcing.hpp"
 
-#include<iostream>
-
 namespace realization{
   namespace config{
 
@@ -28,7 +26,7 @@ namespace realization{
          * 
          * @param tree 
          */
-        Config(const boost::property_tree::ptree& tree):formulation_tree(tree){
+        Config(const boost::property_tree::ptree& tree){
         
             auto possible_forcing = tree.get_child_optional("forcing");
 
@@ -53,7 +51,6 @@ namespace realization{
         }
 
         Formulation formulation;
-        boost::property_tree::ptree formulation_tree;
         Forcing forcing;
     };
 

--- a/include/realizations/config/forcing.hpp
+++ b/include/realizations/config/forcing.hpp
@@ -1,0 +1,58 @@
+#ifndef NGEN_REALIZATION_CONFIG_FORCING_H
+#define NGEN_REALIZATION_CONFIG_FORCING_H
+
+#include <boost/property_tree/ptree.hpp>
+
+#include "JSONProperty.hpp"
+
+namespace realization{
+  namespace config{
+
+  /**
+   * @brief Structure for holding forcing configuration information
+   * 
+   */
+  struct Forcing{
+    /**
+     * @brief key -> Property mapping for forcing parameters
+     * 
+     */
+    geojson::PropertyMap parameters;
+
+    /**
+     * @brief Construct a new, empty Forcing object
+     * 
+     */
+    Forcing():parameters(geojson::PropertyMap()){};
+
+    /**
+     * @brief Construct a new Forcing object from a property_tree
+     * 
+     * @param tree 
+     */
+    Forcing(const boost::property_tree::ptree& tree){
+        //get forcing info
+        for (auto &forcing_parameter : tree) {
+            this->parameters.emplace(
+                forcing_parameter.first,
+                geojson::JSONProperty(forcing_parameter.first, forcing_parameter.second)
+            );  
+        }
+    }
+
+    /**
+     * @brief Test if a particualr forcing parameter exists
+     * 
+     * @param key parameter name to test
+     * @return true if the forcing properties contain key
+     * @return false if the key is not in the forcing properties
+     */
+    bool has_key(const std::string& key) const{
+        return parameters.count(key) > 0;
+    }
+  };
+
+
+  };//end namespace config
+}//end namespace realization
+#endif //NGEN_REALIZATION_CONFIG_FORCING_H

--- a/include/realizations/config/formulation.hpp
+++ b/include/realizations/config/formulation.hpp
@@ -1,0 +1,135 @@
+#ifndef NGEN_REALIZATION_CONFIG_FORMULATION_H
+#define NGEN_REALIZATION_CONFIG_FORMULATION_H
+
+#include <boost/property_tree/ptree.hpp>
+#include <string>
+
+#include "JSONProperty.hpp"
+
+namespace realization{
+  namespace config{
+
+  struct Formulation{
+    std::string type;
+    //Formulation parameters, object as a PropertyMap
+    geojson::PropertyMap parameters;
+    //List of nested formulations (used for multi bmi representations)
+    std::vector<Formulation> nested;
+
+    /**
+     * @brief Construct a new default Formulation object
+     * 
+     * Default objects have an "" type and and empty property map.
+     */
+    Formulation():type(std::string()), parameters(geojson::PropertyMap()){}
+
+    /**
+     * @brief Construct a new Formulation object
+     * 
+     * @param type formulation type represented
+     * @param params formulation parameter mapping
+     */
+    Formulation(std::string& type, geojson::PropertyMap params):type(std::move(type)), parameters(params){}
+
+    /**
+     * @brief Construct a new Formulation object from a boost property tree
+     * 
+     * The tree should have a "name" key corresponding to the formulation type
+     * as well as a "params" key to build the property map from
+     * 
+     * @param tree property tree to build Formulation from
+     */
+    Formulation(const boost::property_tree::ptree& tree){
+        type = tree.get<std::string>("name");
+        for (std::pair<std::string, boost::property_tree::ptree> setting : tree.get_child("params")) {
+            //Construct the geoJSON PropertyMap from each key, value pair in  "params"
+            parameters.emplace(
+                setting.first,
+                geojson::JSONProperty(setting.first, setting.second)
+            );
+        }
+        if(type=="bmi_multi"){
+            for(auto& module : tree.get_child("params.modules")){
+                //Create the nested formulations in order of definition
+                nested.push_back(Formulation(module.second));
+            }
+            geojson::JSONProperty::print_property(parameters.at("modules"));
+        }
+        
+    }
+
+    /**
+     * @brief Link formulation parameters to hydrofabric data held in feature
+     * 
+     * @param feature Hydrofabric feature with properties to assign to formulation
+     *                model params
+     */
+    void link_external(geojson::Feature feature){
+
+        if(type == "bmi_multi"){
+            std::vector<geojson::JSONProperty> tmp;
+            for(auto& n : nested){
+                //Iterate and link any nested modules with this feature
+                if(n.parameters.count("model_params")){
+                    n.link_external(feature);
+                }
+                //Need a temporary map to hold the updated formulation properties in
+                geojson::PropertyMap map = {};
+                map.emplace("name", geojson::JSONProperty("name", n.type));
+                map.emplace("params", geojson::JSONProperty("", n.parameters));
+                tmp.push_back(geojson::JSONProperty("", map));
+            }
+            //Reset the bmi_multi modules with the now linked module definitions
+            parameters.at("modules") = geojson::JSONProperty("modules", tmp);
+            return;
+        }
+        //Short circut
+        if(parameters.count("model_params") < 1 ) return;
+        //Have some model params, check to see if any should be linked to the hyrdofabric feature
+        geojson::PropertyMap attr = parameters.at("model_params").get_values();
+        for (decltype(auto) param : attr) {
+            // Check for type to short-circuit. If param.second is not an object, `.has_key()` will throw
+            if (param.second.get_type() != geojson::PropertyType::Object || !param.second.has_key("source")) {
+                attr.emplace(param.first, param.second);
+                continue;
+            }
+        
+            decltype(auto) param_source = param.second.at("source");
+            decltype(auto) param_source_name = param_source.as_string();
+            if (param_source_name != "hydrofabric") {
+                // TODO: temporary until the logic for alternative sources is designed
+                throw std::logic_error("ERROR: 'model_params' source `" + param_source_name + "` not currently supported. Only `hydrofabric` is supported.");
+            }
+
+            // Property name in the feature properties is either
+            // the value of key "from", or has the same name as
+            // the expected model parameter key
+            decltype(auto) param_name = param.second.has_key("from")
+                ? param.second.at("from").as_string()
+                : param.first;
+
+            if (feature->has_property(param_name)) {
+                auto catchment_attribute = feature->get_property(param_name);
+
+                // Use param.first in the `.emplace` calls instead of param_name since
+                // the expected name is given by the key of the model_params values.
+                switch (catchment_attribute.get_type()) {
+                    case geojson::PropertyType::List:
+                    case geojson::PropertyType::Object:
+                        // TODO: Should list/object values be passed to model parameters?
+                        //       Typically, feature properties *should* be scalars.
+                        std::cerr << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
+                                    << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
+                        break;
+                    default:
+                        attr.at(param.first) = geojson::JSONProperty(param.first, catchment_attribute);
+                }
+            }
+        }
+        parameters.at("model_params") = geojson::JSONProperty("model_params", attr);
+    }
+  };
+
+  };//end namespace config
+}//end namespace realization
+#endif //NGEN_REALIZATION_CONFIG_FORMULATION_H

--- a/include/realizations/config/formulation.hpp
+++ b/include/realizations/config/formulation.hpp
@@ -21,7 +21,7 @@ namespace realization{
      * 
      * Default objects have an "" type and and empty property map.
      */
-    Formulation():type(std::string()), parameters(geojson::PropertyMap()){}
+    Formulation() = default;
 
     /**
      * @brief Construct a new Formulation object
@@ -29,7 +29,7 @@ namespace realization{
      * @param type formulation type represented
      * @param params formulation parameter mapping
      */
-    Formulation(std::string& type, geojson::PropertyMap params):type(std::move(type)), parameters(params){}
+    Formulation(std::string type, geojson::PropertyMap params):type(std::move(type)), parameters(params){}
 
     /**
      * @brief Construct a new Formulation object from a boost property tree

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -602,6 +602,7 @@ const std::string EXAMPLE_5_a =
 "                        \"init_config\": \"\","
 "                        \"allow_exceed_end_time\": true,"
 "                        \"main_output_variable\": \"OUTPUT_VAR_4\","
+"                        \"uses_forcing_file\": false,"
 "                        \"modules\": ["
 "                            {"
 "                                \"name\": \"bmi_c++\","


### PR DESCRIPTION
Builds on #743.  This will nearly decouple Formulation_Manager from boost ptrees.  There are still a couple places which are dependent on the ptree, but it is now only the highest level of extracting the main components and building configuration strcutures which are used throughout the rest of the formulation manager code.

## Additions

- Forcing configuration structure
- Formulation configuration structure
- Config structure which pairs Formulations with potential Forcing

## Removals

-

## Changes

- Most configuration parsing logic, such as linking external parameters, is now isolated and managed in the config structures and methods.
- `construct_formulation_from_tree` renamed to `construct_formulation_from_config` and no longer requires any ptree inputs, but instead uses the constructed configuration objects.

## Testing

1. All existing tests pass with the refactored code
2. Fixed one test realization to include a required key that was previously missing

## Todos

- A subsequent PR will address Layer configuration and mechanics

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
