### PR TITLE
Refactor: BMI adapters' virtual destructor hierarchy and general cleanup

### DIFF
--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -36,7 +36,7 @@ namespace models {
              * Note that this performs the logic in the `Finalize()` function for cleaning up this object and its
              * backing BMI model.
              */
-            ~AbstractCLibBmiAdapter() override;
+            ~AbstractCLibBmiAdapter() noexcept override;
 
             /**
              * Perform tear-down task for this object and its backing model.

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -5,8 +5,6 @@
 
 #include "Bmi_Adapter.hpp"
 
-#include "utilities/ExternalIntegrationException.hpp"
-
 namespace models {
     namespace bmi {
 
@@ -28,21 +26,9 @@ namespace models {
              */
             AbstractCLibBmiAdapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                                    std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
-                                   std::string registration_func, utils::StreamHandler output)
-                    : Bmi_Adapter(type_name, std::move(bmi_init_config), std::move(forcing_file_path),
-                                     allow_exceed_end, has_fixed_time_step, output),
-                      bmi_lib_file(std::move(library_file_path)),
-                      bmi_registration_function(std::move(registration_func)) { }
+                                   std::string registration_func, utils::StreamHandler output);
 
-            AbstractCLibBmiAdapter(AbstractCLibBmiAdapter &&adapter) noexcept :
-                    Bmi_Adapter(std::move(adapter)),
-                    bmi_lib_file(std::move(adapter.bmi_lib_file)),
-                    bmi_registration_function(adapter.bmi_registration_function),
-                    dyn_lib_handle(adapter.dyn_lib_handle)
-            {
-                // Have to make sure to do this after "moving" so the original does not close the dynamically loaded library handle
-                adapter.dyn_lib_handle = nullptr;
-            }
+            AbstractCLibBmiAdapter(AbstractCLibBmiAdapter &&adapter) noexcept;
 
             /**
              * Class destructor.
@@ -50,9 +36,7 @@ namespace models {
              * Note that this performs the logic in the `Finalize()` function for cleaning up this object and its
              * backing BMI model.
              */
-            ~AbstractCLibBmiAdapter() override {
-                finalizeForLibAbstraction();
-            }
+            ~AbstractCLibBmiAdapter() override;
 
             /**
              * Perform tear-down task for this object and its backing model.
@@ -68,77 +52,14 @@ namespace models {
              *
              * @throws models::external::State_Exception Thrown if nested model `finalize()` call is not successful.
              */
-            void Finalize() override {
-                finalizeForLibAbstraction();
-            }
+            void Finalize() override;
 
         protected:
 
             /**
              * Dynamically load and obtain this instance's handle to the shared library.
              */
-            inline void dynamic_library_load() {
-                if (bmi_registration_function.empty()) {
-                    this->init_exception_msg =
-                            "Can't init " + this->model_name + "; empty name given for library's registration function.";
-                    throw std::runtime_error(this->init_exception_msg);
-                }
-                if (dyn_lib_handle != nullptr) {
-                    this->output.put("WARNING: ignoring attempt to reload dynamic shared library '" + bmi_lib_file +
-                    "' for " + this->model_name);
-                    return;
-                }
-                if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {
-                    //Try alternative extension...
-                    size_t idx = bmi_lib_file.rfind(".");
-                    if(idx == std::string::npos){
-                        idx = bmi_lib_file.length()-1;
-                    }
-                    std::string alt_bmi_lib_file;  
-                    if(bmi_lib_file.length() == 0){
-                        this->init_exception_msg =
-                                "Can't init " + this->model_name + "; library file path is empty";
-                        throw std::runtime_error(this->init_exception_msg);
-                    }
-                    if(bmi_lib_file.substr(idx) == ".so"){
-                        alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".dylib";
-                    } else if(bmi_lib_file.substr(idx) == ".dylib"){
-                        alt_bmi_lib_file = bmi_lib_file.substr(0,idx) + ".so";
-                    } else {
-                        // Try appending instead of replacing...
-                        #ifdef __APPLE__
-                        alt_bmi_lib_file = bmi_lib_file + ".dylib";
-                        #else
-                        #ifdef __GNUC__
-                        alt_bmi_lib_file = bmi_lib_file + ".so";
-                        #endif // __GNUC__
-                        #endif // __APPLE__
-                    }
-                    //TODO: Try looking in e.g. /usr/lib, /usr/local/lib, $LD_LIBRARY_PATH... try pre-pending "lib"...
-                    if (utils::FileChecker::file_is_readable(alt_bmi_lib_file)) {
-                        bmi_lib_file = alt_bmi_lib_file;
-                    } else {
-                        this->init_exception_msg =
-                                "Can't init " + this->model_name + "; unreadable shared library file '" + bmi_lib_file + "'";
-                        throw std::runtime_error(this->init_exception_msg);
-                    }
-
-                }
-
-                // Call first to ensure any previous error is cleared before trying to load the symbol
-                dlerror();
-                // Load up the necessary library dynamically
-                dyn_lib_handle = dlopen(bmi_lib_file.c_str(), RTLD_NOW | RTLD_LOCAL);
-                // Now call again to see if there was an error (if there was, this will not be null)
-                char *err_message = dlerror();
-                if (dyn_lib_handle == nullptr && err_message != nullptr) {
-                    this->init_exception_msg = "Cannot load shared lib '" + bmi_lib_file + "' for model " + this->model_name;
-                    if (err_message != nullptr) {
-                        this->init_exception_msg += " (" + std::string(err_message) + ")";
-                    }
-                    throw ::external::ExternalIntegrationException(this->init_exception_msg);
-                }
-            }
+            void dynamic_library_load();
 
             /**
              * Load and return the address of the given symbol from the loaded dynamic model shared library.
@@ -162,24 +83,7 @@ namespace models {
              * @throws ``std::runtime_error`` If there is not a valid handle already to the shared library.
              * @throws ``::external::ExternalIntegrationException`` If symbol could not be found for the shared library.
              */
-            inline void *dynamic_load_symbol(const std::string &symbol_name, bool is_null_valid) {
-                if (dyn_lib_handle == nullptr) {
-                    throw std::runtime_error("Cannot load symbol '" + symbol_name + "' without handle to shared library (bmi_lib_file = '" + bmi_lib_file + "')");
-                }
-                // Call first to ensure any previous error is cleared before trying to load the symbol
-                dlerror();
-                void *symbol = dlsym(dyn_lib_handle, symbol_name.c_str());
-                // Now call again to see if there was an error (if there was, this will not be null)
-                char *err_message = dlerror();
-                if (symbol == nullptr && (err_message != nullptr || !is_null_valid)) {
-                    this->init_exception_msg = "Cannot load shared lib symbol '" + symbol_name + "' for model " + this->model_name;
-                    if (err_message != nullptr) {
-                        this->init_exception_msg += " (" + std::string(err_message) + ")";
-                    }
-                    throw ::external::ExternalIntegrationException(this->init_exception_msg);
-                }
-                return symbol;
-            }
+            void *dynamic_load_symbol(const std::string &symbol_name, bool is_null_valid);
 
             /**
              * Convenience for @see dynamic_load_symbol(std::string, bool) where the symbol address must be found.
@@ -193,24 +97,18 @@ namespace models {
              * @throws ``::external::ExternalIntegrationException`` If symbol could not be found for the shared library.
              * @see dynamic_load_symbol(std::string, bool)
              */
-            inline void *dynamic_load_symbol(const std::string &symbol_name) {
-                return dynamic_load_symbol(symbol_name, false);
-            }
+            void *dynamic_load_symbol(const std::string &symbol_name);
 
-            inline const std::string &get_bmi_registration_function() {
-                return bmi_registration_function;
-            }
+            const std::string &get_bmi_registration_function();
 
-            inline const void *get_dyn_lib_handle() {
-                return dyn_lib_handle;
-            }
+            const void *get_dyn_lib_handle();
 
         private:
 
             /** Path to the BMI shared library file, for dynamic linking. */
             std::string bmi_lib_file;
             /** Name of the function that registers BMI struct's function pointers to the right module functions. */
-            const std::string bmi_registration_function;
+            std::string bmi_registration_function;
             /** Handle for dynamically loaded library file. */
             void *dyn_lib_handle = nullptr;
 
@@ -223,12 +121,7 @@ namespace models {
              * Primarily, this exists to contain the functionality appropriate for @see Finalize in a function that is
              * non-virtual, and can therefore be called by a destructor.
              */
-            void finalizeForLibAbstraction() {
-                //  close the dynamically loaded library
-                if (dyn_lib_handle != nullptr) {
-                    dlclose(dyn_lib_handle);
-                }
-            }
+            void finalizeForLibAbstraction();
         };
 
     }

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -2,9 +2,10 @@
 #define NGEN_ABSTRACTCLIBBMIADAPTER_HPP
 
 #include <dlfcn.h>
+
 #include "Bmi_Adapter.hpp"
-#include "ExternalIntegrationException.hpp"
-#include "State_Exception.hpp"
+
+#include "utilities/ExternalIntegrationException.hpp"
 
 namespace models {
     namespace bmi {

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -97,11 +97,17 @@ namespace models {
              * @throws ``::external::ExternalIntegrationException`` If symbol could not be found for the shared library.
              * @see dynamic_load_symbol(std::string, bool)
              */
-            void *dynamic_load_symbol(const std::string &symbol_name);
+            inline void *dynamic_load_symbol(const std::string& symbol_name) {
+                return dynamic_load_symbol(symbol_name, false);
+            }
 
-            const std::string &get_bmi_registration_function();
+            inline const std::string& get_bmi_registration_function() {
+                return bmi_registration_function;
+            }
 
-            const void *get_dyn_lib_handle();
+            inline const void *get_dyn_lib_handle() {
+                return dyn_lib_handle;
+            }
 
         private:
 

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -28,7 +28,7 @@ namespace models {
                                    std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                                    std::string registration_func, utils::StreamHandler output);
 
-            AbstractCLibBmiAdapter(AbstractCLibBmiAdapter &&adapter) noexcept;
+            AbstractCLibBmiAdapter(AbstractCLibBmiAdapter &&adapter) noexcept = default;
 
             /**
              * Class destructor.
@@ -36,7 +36,7 @@ namespace models {
              * Note that this performs the logic in the `Finalize()` function for cleaning up this object and its
              * backing BMI model.
              */
-            ~AbstractCLibBmiAdapter() noexcept override;
+            ~AbstractCLibBmiAdapter() override;
 
             /**
              * Perform tear-down task for this object and its backing model.

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -49,7 +49,7 @@ namespace models {
              * Note that this performs the logic in the `Finalize()` function for cleaning up this object and its
              * backing BMI model.
              */
-            virtual ~AbstractCLibBmiAdapter() {
+            ~AbstractCLibBmiAdapter() override {
                 finalizeForLibAbstraction();
             }
 

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -28,8 +28,6 @@ namespace models {
                                    std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
                                    std::string registration_func, utils::StreamHandler output);
 
-            AbstractCLibBmiAdapter(AbstractCLibBmiAdapter &&adapter) noexcept = default;
-
             /**
              * Class destructor.
              *

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -1,8 +1,6 @@
 #ifndef NGEN_ABSTRACTCLIBBMIADAPTER_HPP
 #define NGEN_ABSTRACTCLIBBMIADAPTER_HPP
 
-#include <dlfcn.h>
-
 #include "Bmi_Adapter.hpp"
 
 namespace models {

--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -114,7 +114,7 @@ namespace models {
             /** Path to the BMI shared library file, for dynamic linking. */
             std::string bmi_lib_file;
             /** Name of the function that registers BMI struct's function pointers to the right module functions. */
-            std::string bmi_registration_function;
+            const std::string bmi_registration_function;
             /** Handle for dynamically loaded library file. */
             void *dyn_lib_handle = nullptr;
 

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -25,7 +25,7 @@ namespace models {
             Bmi_Adapter(Bmi_Adapter const&) = delete;
             Bmi_Adapter(Bmi_Adapter &&) = default;
 
-            virtual ~Bmi_Adapter() = default;
+            virtual ~Bmi_Adapter() = 0;
 
             /**
              * Whether the backing model has been initialized yet.

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -3,12 +3,14 @@
 
 #include <string>
 #include <vector>
+
 #include "bmi.hpp"
-#include "FileChecker.h"
-#include "JSONProperty.hpp"
+
 #include "State_Exception.hpp"
-#include "StreamHandler.hpp"
-#include <UnitsHelper.hpp>
+
+#include "core/mediator/UnitsHelper.hpp"
+#include "utilities/StreamHandler.hpp"
+#include "utilities/FileChecker.h"
 
 namespace models {
     namespace bmi {

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -23,7 +23,7 @@ namespace models {
                         bool has_fixed_time_step, utils::StreamHandler output);
 
             Bmi_Adapter(Bmi_Adapter const&) = delete;
-            Bmi_Adapter(Bmi_Adapter &&) = default;
+            Bmi_Adapter(Bmi_Adapter &&) = delete;
 
             virtual ~Bmi_Adapter() = 0;
 

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -43,6 +43,8 @@ namespace models {
             Bmi_Adapter(Bmi_Adapter const&) = delete;
             Bmi_Adapter(Bmi_Adapter &&) = default;
 
+            virtual ~Bmi_Adapter() = 0;
+
             /**
              * Whether the backing model has been initialized yet.
              *

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -3,10 +3,10 @@
 
 #include <memory>
 #include <string>
-#include "AbstractCLibBmiAdapter.hpp"
+
 #include "bmi.h"
-#include "JSONProperty.hpp"
-#include "StreamHandler.hpp"
+#include "AbstractCLibBmiAdapter.hpp"
+#include "utilities/StreamHandler.hpp"
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_C_Adapter_Test;

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -6,7 +6,10 @@
 
 #include "bmi.h"
 #include "AbstractCLibBmiAdapter.hpp"
+#include "State_Exception.hpp"
 #include "utilities/StreamHandler.hpp"
+#include "utilities/ExternalIntegrationException.hpp"
+
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_C_Adapter_Test;

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -23,7 +23,7 @@ namespace models {
          * An adapter class to serve as a C++ interface to the essential aspects of external models written in the C
          * language that implement the BMI.
          */
-        class Bmi_C_Adapter : public AbstractCLibBmiAdapter {
+        class Bmi_C_Adapter final : public AbstractCLibBmiAdapter {
 
         public:
 

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -101,7 +101,7 @@ namespace models {
              *
              * Note that this calls the `Finalize()` function for cleaning up this object and its backing BMI model.
              */
-            virtual ~Bmi_C_Adapter() {
+            ~Bmi_C_Adapter() override {
                 finalizeForCAdapter();
             }
 

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -112,7 +112,7 @@ namespace models {
              *
              * Note that this calls the `Finalize()` function for cleaning up this object and its backing BMI model.
              */
-            virtual ~Bmi_Cpp_Adapter() {
+            ~Bmi_Cpp_Adapter() override {
                 finalizeForCppAdapter();
             }
 

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -3,10 +3,10 @@
 
 #include <memory>
 #include <string>
-#include "AbstractCLibBmiAdapter.hpp"
+
 #include "bmi.hpp"
-#include "JSONProperty.hpp"
-#include "StreamHandler.hpp"
+#include "AbstractCLibBmiAdapter.hpp"
+#include "utilities/StreamHandler.hpp"
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_Cpp_Adapter_Test;

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -7,6 +7,8 @@
 #include "bmi.hpp"
 #include "AbstractCLibBmiAdapter.hpp"
 #include "utilities/StreamHandler.hpp"
+#include "utilities/ExternalIntegrationException.hpp"
+
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_Cpp_Adapter_Test;

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -26,7 +26,7 @@ namespace models {
          * loaded dynamically from libraries. This is less important than e.g. @see Bmi_C_Adapter but still provides
          * some useful generalized functionality.
          */
-        class Bmi_Cpp_Adapter : public AbstractCLibBmiAdapter  {
+        class Bmi_Cpp_Adapter final : public AbstractCLibBmiAdapter  {
 
         public:
 

--- a/include/bmi/Bmi_Fortran_Adapter.hpp
+++ b/include/bmi/Bmi_Fortran_Adapter.hpp
@@ -23,7 +23,7 @@ namespace models {
          * An adapter class to serve as a C++ interface to the essential aspects of external models written in the
          * Fortran language that implement the BMI.
          */
-        class Bmi_Fortran_Adapter : public AbstractCLibBmiAdapter {
+        class Bmi_Fortran_Adapter final : public AbstractCLibBmiAdapter {
 
         public:
 

--- a/include/bmi/Bmi_Fortran_Adapter.hpp
+++ b/include/bmi/Bmi_Fortran_Adapter.hpp
@@ -6,6 +6,8 @@
 #include "AbstractCLibBmiAdapter.hpp"
 #include "Bmi_Fortran_Common.h"
 #include "bmi.h"
+#include "State_Exception.hpp"
+#include "utilities/ExternalIntegrationException.hpp"
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_Fortran_Adapter_Test;

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -7,14 +7,15 @@
 #include <exception>
 #include <memory>
 #include <string>
+
 #include "pybind11/pybind11.h"
 #include "pybind11/pytypes.h"
 #include "pybind11/numpy.h"
-#include "JSONProperty.hpp"
-#include "StreamHandler.hpp"
-#include "boost/algorithm/string.hpp"
+
 #include "Bmi_Adapter.hpp"
-#include "python/InterpreterUtil.hpp"
+
+#include "utilities/StreamHandler.hpp"
+#include "utilities/python/InterpreterUtil.hpp"
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_Py_Adapter_Test;

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -12,6 +12,8 @@
 #include "pybind11/pytypes.h"
 #include "pybind11/numpy.h"
 
+#include "boost/algorithm/string/join.hpp"
+
 #include "Bmi_Adapter.hpp"
 
 #include "utilities/StreamHandler.hpp"

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -44,6 +44,10 @@ namespace models {
             Bmi_Py_Adapter(Bmi_Py_Adapter const&) = delete;
             Bmi_Py_Adapter(Bmi_Py_Adapter&&) = delete;
 
+            ~Bmi_Py_Adapter() override {
+                Finalize();
+            }
+
             /**
              * Copy the given BMI variable's values from the backing numpy array to a C++ array.
              *

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -33,7 +33,7 @@ namespace models {
          * An adapter class to serve as a C++ interface to the aspects of external models written in the Python
          * language that implement the BMI.
          */
-        class Bmi_Py_Adapter : public Bmi_Adapter {
+        class Bmi_Py_Adapter final : public Bmi_Adapter {
 
         public:
 

--- a/include/bmi/State_Exception.hpp
+++ b/include/bmi/State_Exception.hpp
@@ -3,6 +3,7 @@
 
 #include <exception>
 #include <utility>
+#include <string>
 
 namespace models {
     namespace external {

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -3,6 +3,8 @@
 #include "utilities/FileChecker.h"
 #include "utilities/ExternalIntegrationException.hpp"
 
+#include <dlfcn.h>
+
 namespace models {
 namespace bmi {
 

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -127,18 +127,6 @@ void* AbstractCLibBmiAdapter::dynamic_load_symbol(
     return symbol;
 }
 
-void* AbstractCLibBmiAdapter::dynamic_load_symbol(const std::string& symbol_name) {
-    return dynamic_load_symbol(symbol_name, false);
-}
-
-const std::string& AbstractCLibBmiAdapter::get_bmi_registration_function() {
-    return bmi_registration_function;
-}
-
-const void* AbstractCLibBmiAdapter::get_dyn_lib_handle() {
-    return dyn_lib_handle;
-}
-
 void AbstractCLibBmiAdapter::finalizeForLibAbstraction() {
     //  close the dynamically loaded library
     if (dyn_lib_handle != nullptr) {

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -27,8 +27,6 @@ AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
     , bmi_lib_file(std::move(library_file_path))
     , bmi_registration_function(std::move(registration_func)){};
 
-AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(AbstractCLibBmiAdapter&& adapter) noexcept = default;
-
 AbstractCLibBmiAdapter::~AbstractCLibBmiAdapter() {
     finalizeForLibAbstraction();
 }

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -27,7 +27,7 @@ AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
           output
       )
     , bmi_lib_file(std::move(library_file_path))
-    , bmi_registration_function(std::move(registration_func)){};
+    , bmi_registration_function(std::move(registration_func)){}
 
 AbstractCLibBmiAdapter::~AbstractCLibBmiAdapter() {
     finalizeForLibAbstraction();

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -1,0 +1,152 @@
+#include "bmi/AbstractCLibBmiAdapter.hpp"
+
+#include "utilities/FileChecker.h"
+#include "utilities/ExternalIntegrationException.hpp"
+
+namespace models {
+namespace bmi {
+
+AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
+    const std::string& type_name,
+    std::string library_file_path,
+    std::string bmi_init_config,
+    std::string forcing_file_path,
+    bool allow_exceed_end,
+    bool has_fixed_time_step,
+    std::string registration_func,
+    utils::StreamHandler output
+)
+    : Bmi_Adapter(
+          type_name,
+          std::move(bmi_init_config),
+          std::move(forcing_file_path),
+          allow_exceed_end,
+          has_fixed_time_step,
+          output
+      )
+    , bmi_lib_file(std::move(library_file_path))
+    , bmi_registration_function(std::move(registration_func)){};
+
+AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(AbstractCLibBmiAdapter&& adapter) noexcept = default;
+
+AbstractCLibBmiAdapter::~AbstractCLibBmiAdapter() {
+    finalizeForLibAbstraction();
+}
+
+void AbstractCLibBmiAdapter::Finalize() {
+    finalizeForLibAbstraction();
+}
+
+void AbstractCLibBmiAdapter::dynamic_library_load() {
+    if (bmi_registration_function.empty()) {
+        this->init_exception_msg = "Can't init " + this->model_name +
+                                   "; empty name given for library's registration function.";
+        throw std::runtime_error(this->init_exception_msg);
+    }
+    if (dyn_lib_handle != nullptr) {
+        this->output.put(
+            "WARNING: ignoring attempt to reload dynamic shared library '" + bmi_lib_file +
+            "' for " + this->model_name
+        );
+        return;
+    }
+    if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {
+        // Try alternative extension...
+        size_t idx = bmi_lib_file.rfind(".");
+        if (idx == std::string::npos) {
+            idx = bmi_lib_file.length() - 1;
+        }
+        std::string alt_bmi_lib_file;
+        if (bmi_lib_file.length() == 0) {
+            this->init_exception_msg =
+                "Can't init " + this->model_name + "; library file path is empty";
+            throw std::runtime_error(this->init_exception_msg);
+        }
+        if (bmi_lib_file.substr(idx) == ".so") {
+            alt_bmi_lib_file = bmi_lib_file.substr(0, idx) + ".dylib";
+        } else if (bmi_lib_file.substr(idx) == ".dylib") {
+            alt_bmi_lib_file = bmi_lib_file.substr(0, idx) + ".so";
+        } else {
+// Try appending instead of replacing...
+#ifdef __APPLE__
+            alt_bmi_lib_file = bmi_lib_file + ".dylib";
+#else
+#ifdef __GNUC__
+            alt_bmi_lib_file = bmi_lib_file + ".so";
+#endif // __GNUC__
+#endif // __APPLE__
+        }
+        // TODO: Try looking in e.g. /usr/lib, /usr/local/lib, $LD_LIBRARY_PATH... try pre-pending
+        // "lib"...
+        if (utils::FileChecker::file_is_readable(alt_bmi_lib_file)) {
+            bmi_lib_file = alt_bmi_lib_file;
+        } else {
+            this->init_exception_msg = "Can't init " + this->model_name +
+                                       "; unreadable shared library file '" + bmi_lib_file + "'";
+            throw std::runtime_error(this->init_exception_msg);
+        }
+    }
+
+    // Call first to ensure any previous error is cleared before trying to load the symbol
+    dlerror();
+    // Load up the necessary library dynamically
+    dyn_lib_handle = dlopen(bmi_lib_file.c_str(), RTLD_NOW | RTLD_LOCAL);
+    // Now call again to see if there was an error (if there was, this will not be null)
+    char* err_message = dlerror();
+    if (dyn_lib_handle == nullptr && err_message != nullptr) {
+        this->init_exception_msg =
+            "Cannot load shared lib '" + bmi_lib_file + "' for model " + this->model_name;
+        if (err_message != nullptr) {
+            this->init_exception_msg += " (" + std::string(err_message) + ")";
+        }
+        throw ::external::ExternalIntegrationException(this->init_exception_msg);
+    }
+}
+
+void* AbstractCLibBmiAdapter::dynamic_load_symbol(
+    const std::string& symbol_name,
+    bool is_null_valid
+) {
+    if (dyn_lib_handle == nullptr) {
+        throw std::runtime_error(
+            "Cannot load symbol '" + symbol_name +
+            "' without handle to shared library (bmi_lib_file = '" + bmi_lib_file + "')"
+        );
+    }
+    // Call first to ensure any previous error is cleared before trying to load the symbol
+    dlerror();
+    void* symbol = dlsym(dyn_lib_handle, symbol_name.c_str());
+    // Now call again to see if there was an error (if there was, this will not be null)
+    char* err_message = dlerror();
+    if (symbol == nullptr && (err_message != nullptr || !is_null_valid)) {
+        this->init_exception_msg =
+            "Cannot load shared lib symbol '" + symbol_name + "' for model " + this->model_name;
+        if (err_message != nullptr) {
+            this->init_exception_msg += " (" + std::string(err_message) + ")";
+        }
+        throw ::external::ExternalIntegrationException(this->init_exception_msg);
+    }
+    return symbol;
+}
+
+void* AbstractCLibBmiAdapter::dynamic_load_symbol(const std::string& symbol_name) {
+    return dynamic_load_symbol(symbol_name, false);
+}
+
+const std::string& AbstractCLibBmiAdapter::get_bmi_registration_function() {
+    return bmi_registration_function;
+}
+
+const void* AbstractCLibBmiAdapter::get_dyn_lib_handle() {
+    return dyn_lib_handle;
+}
+
+void AbstractCLibBmiAdapter::finalizeForLibAbstraction() {
+    //  close the dynamically loaded library
+    if (dyn_lib_handle != nullptr) {
+        dlclose(dyn_lib_handle);
+    }
+}
+
+} // namespace bmi
+} // namespace models

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -33,6 +33,8 @@ Bmi_Adapter::Bmi_Adapter(
     }
 }
 
+Bmi_Adapter::~Bmi_Adapter() = default;
+
 double Bmi_Adapter::get_time_convert_factor() {
     double value             = 1.0;
     std::string input_units  = GetTimeUnits();

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -1,0 +1,121 @@
+#include "bmi/Bmi_Adapter.hpp"
+#include "bmi/State_Exception.hpp"
+#include "utilities/FileChecker.h"
+
+namespace models {
+namespace bmi {
+
+Bmi_Adapter::Bmi_Adapter(
+    std::string model_name,
+    std::string bmi_init_config,
+    std::string forcing_file_path,
+    bool allow_exceed_end,
+    bool has_fixed_time_step,
+    utils::StreamHandler output
+)
+    : model_name(std::move(model_name))
+    , bmi_init_config(std::move(bmi_init_config))
+    , bmi_model_uses_forcing_file(!forcing_file_path.empty())
+    , forcing_file_path(std::move(forcing_file_path))
+    , bmi_model_has_fixed_time_step(has_fixed_time_step)
+    , allow_model_exceed_end_time(allow_exceed_end)
+    , output(std::move(output))
+    , bmi_model_time_convert_factor(1.0) {
+    // This replicates a lot of Initialize, but it's necessary to be able to do it separately to
+    // support "initializing" on construction, given using Initialize requires use of virtual
+    // functions
+    errno = 0;
+    if (!utils::FileChecker::file_is_readable(this->bmi_init_config)) {
+        init_exception_msg = "Cannot create and initialize " + this->model_name +
+                             " using unreadable file '" + this->bmi_init_config +
+                             "'. Error: " + std::strerror(errno);
+        throw std::runtime_error(init_exception_msg);
+    }
+}
+
+double Bmi_Adapter::get_time_convert_factor() {
+    double value             = 1.0;
+    std::string input_units  = GetTimeUnits();
+    std::string output_units = "s";
+    return UnitsHelper::get_converted_value(input_units, value, output_units);
+}
+
+double Bmi_Adapter::convert_model_time_to_seconds(const double& model_time_val) {
+    return model_time_val * bmi_model_time_convert_factor;
+}
+
+double Bmi_Adapter::convert_seconds_to_model_time(const double& seconds_val) {
+    return seconds_val / bmi_model_time_convert_factor;
+}
+
+void Bmi_Adapter::Initialize() {
+    // If there was previous init attempt but w/ failure exception, throw runtime error and include
+    // previous message
+    errno = 0;
+    if (model_initialized && !init_exception_msg.empty()) {
+        throw std::runtime_error(
+            "Previous " + model_name + " init attempt had exception: \n\t" + init_exception_msg
+        );
+    }
+    // If there was previous init attempt w/ (implicitly) no exception on previous attempt, just
+    // return
+    else if (model_initialized) {
+        return;
+    } else if (!utils::FileChecker::file_is_readable(bmi_init_config)) {
+        init_exception_msg = "Cannot initialize " + model_name + " using unreadable file '" +
+                             bmi_init_config + "'. Error: " + std::strerror(errno);
+        ;
+        throw std::runtime_error(init_exception_msg);
+    } else {
+        try {
+            // TODO: make this same name as used with other testing (adjust name in docstring above
+            // also)
+            construct_and_init_backing_model();
+            // Make sure this is set to 'true' after this function call finishes
+            model_initialized             = true;
+            bmi_model_time_convert_factor = get_time_convert_factor();
+        }
+        // Record the exception message before re-throwing to handle subsequent function calls
+        // properly
+        catch (std::exception& e) {
+            // Make sure this is set to 'true' after this function call finishes
+            model_initialized = true;
+            throw e;
+        }
+    }
+}
+
+void Bmi_Adapter::Initialize(std::string config_file) {
+    if (config_file != bmi_init_config && model_initialized) {
+        throw std::runtime_error(
+            "Model init previously attempted; cannot change config from " + bmi_init_config +
+            " to " + config_file
+        );
+    }
+
+    if (config_file != bmi_init_config && !model_initialized) {
+        output.put(
+            "Warning: initialization call changes model config from " + bmi_init_config + " to " +
+            config_file
+        );
+        bmi_init_config = config_file;
+    }
+    try {
+        Initialize();
+    } catch (models::external::State_Exception& e) {
+        throw e;
+    } catch (std::exception& e) {
+        throw std::runtime_error(e.what());
+    }
+}
+
+bool Bmi_Adapter::isInitialized() {
+    return model_initialized;
+}
+
+std::string Bmi_Adapter::get_model_name() {
+    return model_name;
+}
+
+} // namespace bmi
+} // namespace models

--- a/src/bmi/Bmi_C_Adapter.cpp
+++ b/src/bmi/Bmi_C_Adapter.cpp
@@ -1,8 +1,7 @@
+#include "bmi/Bmi_C_Adapter.hpp"
+
 #include <exception>
 #include <utility>
-
-#include "FileChecker.h"
-#include "Bmi_C_Adapter.hpp"
 
 using namespace models::bmi;
 

--- a/src/bmi/Bmi_Cpp_Adapter.cpp
+++ b/src/bmi/Bmi_Cpp_Adapter.cpp
@@ -3,6 +3,7 @@
 #include <exception>
 #include <utility>
 
+
 using namespace models::bmi;
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string forcing_file_path,

--- a/src/bmi/Bmi_Cpp_Adapter.cpp
+++ b/src/bmi/Bmi_Cpp_Adapter.cpp
@@ -1,8 +1,7 @@
+#include "bmi/Bmi_Cpp_Adapter.hpp"
+
 #include <exception>
 #include <utility>
-
-#include "FileChecker.h"
-#include "Bmi_Cpp_Adapter.hpp"
 
 using namespace models::bmi;
 

--- a/src/bmi/Bmi_Fortran_Adapter.cpp
+++ b/src/bmi/Bmi_Fortran_Adapter.cpp
@@ -1,5 +1,5 @@
 #ifdef NGEN_BMI_FORTRAN_ACTIVE
-#include "Bmi_Fortran_Adapter.hpp"
+#include "bmi/Bmi_Fortran_Adapter.hpp"
 
 using namespace models::bmi;
 

--- a/src/bmi/Bmi_Py_Adapter.cpp
+++ b/src/bmi/Bmi_Py_Adapter.cpp
@@ -2,8 +2,8 @@
 
 #include <exception>
 #include <utility>
-#include "pybind11/numpy.h"
-#include "Bmi_Py_Adapter.hpp"
+
+#include "bmi/Bmi_Py_Adapter.hpp"
 
 using namespace models::bmi;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality

--- a/src/bmi/CMakeLists.txt
+++ b/src/bmi/CMakeLists.txt
@@ -1,25 +1,35 @@
-include(${PROJECT_SOURCE_DIR}/cmake/dynamic_sourced_library.cmake)
-dynamic_sourced_cxx_library(ngen_bmi "${CMAKE_CURRENT_SOURCE_DIR}")
-
+add_library(ngen_bmi)
 add_library(NGen::ngen_bmi ALIAS ngen_bmi)
 
-target_include_directories(ngen_bmi PUBLIC
-        ${PROJECT_SOURCE_DIR}/include/
-        ${PROJECT_SOURCE_DIR}/include/bmi
-        )
-        
-target_link_libraries(ngen_bmi PUBLIC
-        ${CMAKE_DL_LIBS}
-        Boost::boost                # Headers-only Boost
-        NGen::logging
-        NGen::geojson
-        NGen::core_mediator
-        )
+target_include_directories(ngen_bmi
+  PUBLIC
+    ${NGEN_INC_DIR}
+)
+
+target_link_libraries(ngen_bmi
+  PUBLIC
+    ${CMAKE_DL_LIBS}
+    Boost::boost # Headers-only Boost
+    NGen::logging
+    NGen::geojson
+    NGen::core_mediator
+)
+
+target_sources(ngen_bmi
+  PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/Bmi_Cpp_Adapter.cpp"
+)
+
+if(NGEN_WITH_BMI_C)
+    target_sources(ngen_bmi PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Bmi_C_Adapter.cpp")
+endif()
 
 if(NGEN_WITH_PYTHON)
-   target_link_libraries(ngen_bmi PUBLIC pybind11::embed)
+    target_sources(ngen_bmi PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Bmi_Py_Adapter.cpp")
+    target_link_libraries(ngen_bmi PUBLIC pybind11::embed)
 endif()
 
 if(NGEN_WITH_BMI_FORTRAN)
+    target_sources(ngen_bmi PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Bmi_Fortran_Adapter.cpp")
     target_link_libraries(ngen_bmi PUBLIC iso_c_bmi)
 endif()

--- a/src/bmi/CMakeLists.txt
+++ b/src/bmi/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(NGen::ngen_bmi ALIAS ngen_bmi)
 target_include_directories(ngen_bmi
   PUBLIC
     ${NGEN_INC_DIR}
-    ${NGEN_INC_DIR}/bmi
 )
 
 target_link_libraries(ngen_bmi
@@ -18,6 +17,8 @@ target_link_libraries(ngen_bmi
 
 target_sources(ngen_bmi
   PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/Bmi_Adapter.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/AbstractCLibBmiAdapter.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/Bmi_Cpp_Adapter.cpp"
 )
 

--- a/src/bmi/CMakeLists.txt
+++ b/src/bmi/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(NGen::ngen_bmi ALIAS ngen_bmi)
 target_include_directories(ngen_bmi
   PUBLIC
     ${NGEN_INC_DIR}
+    ${NGEN_INC_DIR}/bmi
 )
 
 target_link_libraries(ngen_bmi

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -12,6 +12,8 @@ namespace py = pybind11;
 
 #include "Bmi_Py_Adapter.hpp"
 
+#include "utilities/FileChecker.h"
+
 using namespace models::bmi;
 using namespace utils::ngenPy;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -13,6 +13,7 @@
 #include "Bmi_Py_Formulation.hpp"
 #include "python/InterpreterUtil.hpp"
 #include <CsvPerFeatureForcingProvider.hpp>
+#include "utilities/FileChecker.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality


### PR DESCRIPTION
This PR resolves #747 by pulling the virtual destructor hierarchy one level above `AbstractCLibBmiAdapter`, so that `Bmi_Adapter` defines a virtual destructor.

Moreover, this PR includes some additional cleanup of the BMI adapter classes and supporting files.

## Additions

- Adds a default virtual destructor to `Bmi_Adapter`.
- Adds an overridden destructor to `Bmi_Py_Adapter`.
- Adds source files for `AbstractCLibBmiAdapter` and `Bmi_Adapter`.

## Changes

- Reworks Bmi listfile to remove call to dynamically sourced library, and instead manually creates the CMake target to handle conditional compilation properly.
- Replaces `virtual` destructor attribute with `override` in subclasses of `Bmi_Adapter` and `AbstractCLibBmiAdapter`.
- Updates and sorts include directives in header and source files.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] macOS
