### PR TITLE
CMake: add option to perform unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(NGEN_WITH_BMI_C       "Build with C BMI support"           ON)
 option(NGEN_WITH_PYTHON      "Build with embedded Python support" ON)
 option(NGEN_WITH_TESTS       "Build with unit tests"              ON)
 option(NGEN_QUIET            "Silence output"                     OFF)
+option(NGEN_WITH_UNITY_BUILD "Perform a unity build"              ON)
 
 # These options require dependency on some of the above options
 # Syntax: cmake_dependent_option(<option> "<help_text>" <value> <depends> <force>)
@@ -118,6 +119,9 @@ project(ngen VERSION 0.1.0)
 add_executable(ngen "${NGEN_SRC_DIR}/NGen.cpp")
 
 # Dependencies ================================================================
+if(NGEN_WITH_UNITY_BUILD)
+    set(CMAKE_UNITY_BUILD ON)
+endif()
 
 # -----------------------------------------------------------------------------
 # Check if NGen is the main project (e.g. development environment)
@@ -418,6 +422,7 @@ ngen_multiline_message(
 "  C Flags: ${CMAKE_C_FLAGS}"
 "  CXX Compiler: ${CMAKE_CXX_COMPILER}"
 "  CXX Flags: ${CMAKE_CXX_FLAGS}"
+"  Linker: ${CMAKE_LINKER}"
 "  Flags:"
 "    NGEN_WITH_MPI: ${NGEN_WITH_MPI}"
 "    NGEN_WITH_NETCDF: ${NGEN_WITH_NETCDF}"

--- a/src/geopackage/CMakeLists.txt
+++ b/src/geopackage/CMakeLists.txt
@@ -1,10 +1,10 @@
-add_library(geopackage proj.cpp
+add_library(geopackage ngen_sqlite.cpp
+                       proj.cpp
                        geometry.cpp
                        properties.cpp
                        feature.cpp
                        read.cpp
                        wkb.cpp
-                       ngen_sqlite.cpp
 )
 add_library(NGen::geopackage ALIAS geopackage)
 target_include_directories(geopackage PUBLIC ${PROJECT_SOURCE_DIR}/include/geopackage)


### PR DESCRIPTION
This PR adds the option `NGEN_WITH_UNITY_BUILD`, which is a convenience option to build NGen targets as [unity builds](https://en.wikipedia.org/wiki/Unity_build). This speeds up compilation by roughly ~20%, and may introduce some more optimizations similar to LTO/IPO.

## Additions

- Adds `NGEN_WITH_UNITY_BUILD` CMake option.
- Small utility: adds what Linker is used to configure output.

## Changes

- Sorts `NGen::geopackage` source files to enable unity builds

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [ ] Linux
- [ ] macOS
