### PR TITLE
Layer and DomainLayer Formulation Management

### DIFF
--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -11,7 +11,22 @@ namespace ngen
         public:
         DomainLayer() = delete;
         /**
-         * @brief Construct a new Domain Layer object
+         * @brief Construct a new Domain Layer object.
+         * 
+         * Unlike HY_Features types, the feature relationship with a DomainLayer is
+         * indirect.  The @p features collection defines features assoicated
+         * (e.g. overlapping) with the Domain.  The domain must be further queried
+         * in order to provide specific information at a particular feature,
+         * e.g. a catchment which this domain overlaps with, or a nexus location
+         * the domain may contribute to directly/indirectly via the catchment.
+         * 
+         * A domain layer assoicated with a set of catchment features will need to have
+         * outputs of the domain reasmpled/aggregegated to the catchment.
+         * 
+         * Currently unsupported, but a future extension of the DomainLayer is interactions
+         * beetween two or more generic DomainLayers, perhaps each with its own internal grid,
+         * and resampling between the layers would be required similarly to resampling from
+         * a DomainLayer to the HY_Features catchment domain.
          * 
          * @param desc LayerDescription for the domain layer
          * @param s_t Simulation_Time object associated with the domain layer
@@ -32,6 +47,13 @@ namespace ngen
 
         /***
          * @brief Run one simulation timestep for this model associated with the domain
+         * 
+         * A domain layer update simply advances the attached domain formulation(s) in time and records
+         * the BMI accessible outputs of the domain formulation. Since this is NOT a HY_Features
+         * concept/class, it doesn't directly associate with HY_Features types (e.g. catchments, nexus, ect) 
+         * 
+         * Any required connection to other components, e.g. providing inputs to a catchment feature,
+         * is not yet implemented in this class.
         */
         void update_models() override{
             formulation->get_response(output_time_index, simulation_time.get_output_interval_seconds());

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -1,0 +1,55 @@
+#ifndef __NGEN_DOMAIN_LAYER__
+#define __NGEN_DOMAIN_LAYER__
+
+#include "Catchment_Formulation.hpp"
+#include "Layer.hpp"
+
+namespace ngen
+{
+    class DomainLayer : public Layer
+    {
+        public:
+        DomainLayer() = delete;
+        /**
+         * @brief Construct a new Domain Layer object
+         * 
+         * @param desc LayerDescription for the domain layer
+         * @param s_t Simulation_Time object associated with the domain layer
+         * @param features collection of HY_Features associated with the domain
+         * @param idx index of the layer
+         * @param formulation Formulation associated with the domain
+         */
+        DomainLayer(
+                const LayerDescription& desc,
+                const Simulation_Time& s_t,
+                feature_type& features,
+                long idx,
+                std::shared_ptr<realization::Catchment_Formulation> formulation):
+                    Layer(desc, s_t, features, idx), formulation(formulation)
+        {
+            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+        }
+
+        /***
+         * @brief Run one simulation timestep for this model associated with the domain
+        */
+        void update_models() override{
+            formulation->get_response(output_time_index, simulation_time.get_output_interval_seconds());
+            std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
+            std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
+            formulation->get_output_line_for_timestep(output_time_index)+"\n";
+            formulation->write_output(output);
+            ++output_time_index;
+            if ( output_time_index < simulation_time.get_total_output_times() )
+            {
+               simulation_time.advance_timestep();
+            }
+    
+        }
+
+        private:
+        std::shared_ptr<realization::Catchment_Formulation> formulation;
+    };
+}
+
+#endif

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -1,5 +1,5 @@
-#ifndef __NGEN_DOMAIN_LAYER__
-#define __NGEN_DOMAIN_LAYER__
+#ifndef NGEN_DOMAIN_LAYER
+#define NGEN_DOMAIN_LAYER
 
 #include "Catchment_Formulation.hpp"
 #include "Layer.hpp"
@@ -52,4 +52,4 @@ namespace ngen
     };
 }
 
-#endif
+#endif // NGEN_DOMAIN_LAYER

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -3,6 +3,7 @@
 
 #include "Catchment_Formulation.hpp"
 #include "Layer.hpp"
+#include "State_Exception.hpp"
 
 namespace ngen
 {
@@ -56,8 +57,18 @@ namespace ngen
          * is not yet implemented in this class.
         */
         void update_models() override{
-            formulation->get_response(output_time_index, simulation_time.get_output_interval_seconds());
             std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
+            try{
+                formulation->get_response(output_time_index, simulation_time.get_output_interval_seconds());
+            }
+            catch(models::external::State_Exception& e){
+                std::string msg = e.what();
+                msg = msg+" at timestep "+std::to_string(output_time_index)
+                            +" ("+current_timestamp+")"
+                            +" at domain layer "+description.name
+                            +" (layer id: "+std::to_string(description.id)+")";
+                throw models::external::State_Exception(msg);
+            } 
             std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
             formulation->get_output_line_for_timestep(output_time_index)+"\n";
             formulation->write_output(output);

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -15,14 +15,14 @@ namespace ngen
          * @brief Construct a new Domain Layer object.
          * 
          * Unlike HY_Features types, the feature relationship with a DomainLayer is
-         * indirect.  The @p features collection defines features assoicated
+         * indirect.  The @p features collection defines features associated
          * (e.g. overlapping) with the Domain.  The domain must be further queried
          * in order to provide specific information at a particular feature,
          * e.g. a catchment which this domain overlaps with, or a nexus location
          * the domain may contribute to directly/indirectly via the catchment.
          * 
-         * A domain layer assoicated with a set of catchment features will need to have
-         * outputs of the domain reasmpled/aggregegated to the catchment.
+         * A domain layer associated with a set of catchment features will need to have
+         * outputs of the domain resampled/aggregated to the catchment.
          * 
          * Currently unsupported, but a future extension of the DomainLayer is interactions
          * beetween two or more generic DomainLayers, perhaps each with its own internal grid,

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -40,6 +40,27 @@ namespace ngen
 
         }
 
+        /**
+         * @brief Construct a minimum layer object
+         * 
+         * @param desc 
+         * @param s_t 
+         * @param f 
+         * @param idx 
+         */
+        Layer(
+                const LayerDescription& desc, 
+                const Simulation_Time& s_t, 
+                feature_type& f,
+                long idx) :
+            description(desc),
+            simulation_time(s_t),
+            features(f),
+            output_time_index(idx)
+        {
+
+        }
+
         virtual ~Layer() {}
 
         /***
@@ -138,9 +159,12 @@ namespace ngen
         protected:
 
         const LayerDescription description;
+        //TODO is this really required at the top level?
+        //See "mimimum" constuctor above used for DomainLayer impl...
         const std::vector<std::string> processing_units;
         Simulation_Time simulation_time;
         feature_type& features;
+        //TODO is this really required at the top level? or can this be moved to SurfaceLayer?
         const geojson::GeoJSON catchment_data;
         long output_time_index;       
 

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -160,7 +160,7 @@ namespace ngen
 
         const LayerDescription description;
         //TODO is this really required at the top level?
-        //See "mimimum" constuctor above used for DomainLayer impl...
+        //See "minimum" constructor above used for DomainLayer impl...
         const std::vector<std::string> processing_units;
         Simulation_Time simulation_time;
         feature_type& features;

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -96,18 +96,10 @@ namespace realization {
 
                         // add the layer to storage
                         layer_storage.put_layer(layer_desc, layer_desc.id);
-                        // debuggin print to see parsed data
-                        //std::cout << layer_desc.name << ", " << layer_desc.id << ", " << layer_desc.time_step << ", " << layer_desc.time_step_units << "\n";
                         if(layer.has_formulation() && layer.get_domain()=="catchments"){
-                            auto formulation = construct_formulation_from_config(simulation_time_config,
-                            "layer-"+std::to_string(layer_desc.id),
-                            layer.formulation,
-                            output_stream
-                            );
                             double c_value = UnitsHelper::get_converted_value(layer_desc.time_step_units,layer_desc.time_step,"s");
                             // make a new simulation time object with a different output interval
                             Simulation_Time sim_time(*Simulation_Time_Object, c_value);
-                            //formulation->set_output_stream(get_output_root() + layer_desc.name + "_layer_"+std::to_string(layer_desc.id) + ".csv");
                             domain_formulations.emplace(
                                 layer_desc.id,
                                 construct_formulation_from_config(simulation_time_config,

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -12,9 +12,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <FeatureBuilder.hpp>
-#include "JSONProperty.hpp"
 #include "features/Features.hpp"
-#include <FeatureCollection.hpp>
 #include "Formulation_Constructors.hpp"
 #include "LayerData.hpp"
 #include "realizations/config/time.hpp"
@@ -120,11 +118,12 @@ namespace realization {
                             );
                             domain_formulations.at(layer_desc.id)->set_output_stream(get_output_root() + layer_desc.name + "_layer_"+std::to_string(layer_desc.id) + ".csv");
                         }
-
-                        // debuggin print to see parsed data
-                        std::cout << layer_desc.name << ", " << layer_desc.id << ", " << layer_desc.time_step << ", " << layer_desc.time_step_units << "\n";
+                        //TODO for each layer, create deferred providers for use by other layers
+                        //VERY SIMILAR TO NESTED MODULE INIT
                     }
                 }
+
+                //TODO use the set of layer providers as input for catchments to lookup from
 
                 /**
                  * Read routing configurations from configuration file

--- a/include/realizations/config/layer.hpp
+++ b/include/realizations/config/layer.hpp
@@ -28,6 +28,7 @@ namespace realization{
      * @param tree 
      */
     Layer(const boost::property_tree::ptree& tree):formulation(tree){
+        std::vector<std::string> missing_keys;
         auto name = tree.get_optional<std::string>("name");
         if(!name) missing_keys.push_back("name");
         auto unit = tree.get<std::string>("time_step_units", "s");
@@ -43,7 +44,16 @@ namespace realization{
             descriptor = {*name, unit, *id, *ts};// ngen::LayerDescription(  );
         }
         else{
-            //FIXME then what?
+            std::string message = "ERROR: Layer cannot be created; the following parameters are missing or invalid: ";
+
+            for (const auto& missing : missing_keys) {
+                message += missing;
+                message += ", ";
+            }
+            //pop off the extra ", "
+            message.pop_back();
+            message.pop_back();
+            throw std::runtime_error(message);
         }
     }
 
@@ -53,24 +63,11 @@ namespace realization{
      * @return const ngen::LayerDescription& 
      */
     const ngen::LayerDescription& get_descriptor(){
-        if(!missing_keys.empty()){
-            std::string message = "ERROR: Layer cannot be created; the following parameters are missing or invalid: ";
-
-            for (int missing_parameter_index = 0; missing_parameter_index < missing_keys.size(); missing_parameter_index++) {
-                message += missing_keys[missing_parameter_index];
-
-                if (missing_parameter_index < missing_keys.size() - 1) {
-                    message += ", ";
-                }
-            }
-            
-            throw std::runtime_error(message);
-        }
         return descriptor;
     }
 
     /**
-     * @brief Determins if the layer has a valid configured formulation
+     * @brief Determines if the layer has a valid configured formulation
      * 
      * @return true 
      * @return false 
@@ -94,7 +91,6 @@ namespace realization{
     private:
     std::string domain;
     ngen::LayerDescription descriptor;
-    std::vector<std::string> missing_keys;
 
   };
 

--- a/include/realizations/config/layer.hpp
+++ b/include/realizations/config/layer.hpp
@@ -94,6 +94,6 @@ namespace realization{
 
   };
 
-  };//end namespace config
+  }//end namespace config
 }//end namespace realization
 #endif //NGEN_REALIZATION_CONFIG_LAYER_H

--- a/include/realizations/config/layer.hpp
+++ b/include/realizations/config/layer.hpp
@@ -1,0 +1,103 @@
+#ifndef NGEN_REALIZATION_CONFIG_LAYER_H
+#define NGEN_REALIZATION_CONFIG_LAYER_H
+
+#include <boost/property_tree/ptree.hpp>
+
+#include "LayerData.hpp"
+#include "config.hpp"
+
+namespace realization{
+  namespace config{
+
+  /**
+   * @brief Layer configuration information
+   * 
+   */
+  struct Layer{
+    /**
+     * @brief Construct a new default surface layer
+     * 
+     * Default layers are surface layers (0) with 3600 second time steps
+     * 
+     */
+    Layer():descriptor( {"surface layer", "s", 0, 3600 } ){};
+
+    /**
+     * @brief Construct a new Layer from a property tree
+     * 
+     * @param tree 
+     */
+    Layer(const boost::property_tree::ptree& tree):formulation(tree){
+        auto name = tree.get_optional<std::string>("name");
+        if(!name) missing_keys.push_back("name");
+        auto unit = tree.get<std::string>("time_step_units", "s");
+
+        auto id = tree.get_optional<int>("id");
+        if(!id) missing_keys.push_back("id");
+
+        auto ts = tree.get_optional<double>("time_step");
+        //TODO is time_step required? e.g. need to add to missing_keys?
+        auto tmp = tree.get_optional<std::string>("domain");
+        if(tmp) domain = *tmp;
+        if(missing_keys.empty()){
+            descriptor = {*name, unit, *id, *ts};// ngen::LayerDescription(  );
+        }
+        else{
+            //FIXME then what?
+        }
+    }
+
+    /**
+     * @brief Get the descriptor associated with this layer configuration
+     * 
+     * @return const ngen::LayerDescription& 
+     */
+    const ngen::LayerDescription& get_descriptor(){
+        if(!missing_keys.empty()){
+            std::string message = "ERROR: Layer cannot be created; the following parameters are missing or invalid: ";
+
+            for (int missing_parameter_index = 0; missing_parameter_index < missing_keys.size(); missing_parameter_index++) {
+                message += missing_keys[missing_parameter_index];
+
+                if (missing_parameter_index < missing_keys.size() - 1) {
+                    message += ", ";
+                }
+            }
+            
+            throw std::runtime_error(message);
+        }
+        return descriptor;
+    }
+
+    /**
+     * @brief Determins if the layer has a valid configured formulation
+     * 
+     * @return true 
+     * @return false 
+     */
+    bool has_formulation(){
+        return formulation.has_formulation();
+    }
+
+    /**
+     * @brief Get the domain description
+     * 
+     * @return const std::string& 
+     */
+    const std::string& get_domain(){ return domain; }
+
+    /**
+     * @brief The formulation configuration associated with the layer
+     * 
+     */
+    Config formulation;
+    private:
+    std::string domain;
+    ngen::LayerDescription descriptor;
+    std::vector<std::string> missing_keys;
+
+  };
+
+  };//end namespace config
+}//end namespace realization
+#endif //NGEN_REALIZATION_CONFIG_LAYER_H

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -60,6 +60,7 @@ int mpi_num_procs;
 
 #include <Layer.hpp>
 #include <SurfaceLayer.hpp>
+#include <DomainLayer.hpp>
 
 std::unordered_map<std::string, std::ofstream> nexus_outfiles;
 
@@ -457,9 +458,7 @@ int main(int argc, char *argv[]) {
     // get the keys for the existing layers
     std::vector<int>& keys = layer_meta_data.get_keys();
 
-    // get the converted time steps for layers
-    double min_time_step;
-    double max_time_step;
+    //FIXME refactor the layer building to avoid this mess
     std::vector<double> time_steps;
     for(int i = 0; i < keys.size(); ++i)
     {
@@ -467,10 +466,6 @@ int main(int argc, char *argv[]) {
         double c_value = UnitsHelper::get_converted_value(m_data.time_step_units,m_data.time_step,"s");
         time_steps.push_back(c_value);
     }
-
-    std::vector<int> output_time_index;
-    output_time_index.resize(keys.size());
-    std::fill(output_time_index.begin(), output_time_index.end(),0);
 
     // now create the layer objects
 
@@ -487,15 +482,21 @@ int main(int argc, char *argv[]) {
 
       // make a new simulation time object with a different output interval
       Simulation_Time sim_time(*manager->Simulation_Time_Object, time_steps[i]);
-  
-      for ( std::string id : features.catchments(keys[i]) ) { cat_ids.push_back(id); }
-      if (keys[i] != 0 )
-      {
-        layers[i] = std::make_shared<ngen::Layer>(desc, cat_ids, sim_time, features, catchment_collection, 0);
+      if( manager->has_domain_formulation(keys[i])){
+        //create a domain wide layer
+        auto formulation = manager->get_domain_formulation(keys[i]);
+        layers[i] = std::make_shared<ngen::DomainLayer>(desc, sim_time, features, 0, formulation);
       }
-      else
-      {
-        layers[i] = std::make_shared<ngen::SurfaceLayer>(desc, cat_ids, sim_time, features, catchment_collection, 0, nexus_subset_ids, nexus_outfiles);
+      else{
+        for ( std::string id : features.catchments(keys[i]) ) { cat_ids.push_back(id); }
+        if (keys[i] != 0 )
+        {
+          layers[i] = std::make_shared<ngen::Layer>(desc, cat_ids, sim_time, features, catchment_collection, 0);
+        }
+        else
+        {
+          layers[i] = std::make_shared<ngen::SurfaceLayer>(desc, cat_ids, sim_time, features, catchment_collection, 0, nexus_subset_ids, nexus_outfiles);
+        }
       }
 
     }
@@ -533,7 +534,8 @@ int main(int argc, char *argv[]) {
           // only advance if you would not pass the master next time and the previous layer next time
           if ( layer_next_time <= next_time && layer_next_time <=  prev_layer_time)
           {
-            layer->update_models();
+            if(count%100==0) std::cout<<"Updating layer: "<<layer->get_name()<<"\n";
+            layer->update_models(); //assume update_models() calls time->advance_timestep()
             prev_layer_time = layer_next_time;
           }
           else


### PR DESCRIPTION
Supporting model layers which don't have a 1-1 `model -> catchment` association requires additional configuration and management.  This PR addresses 3 key components for supporting model layers.

1. Refactoring of layer configuration parsing
2. Creation of layer formulation attaching a model formulation to the layer
3. A DomainLayer abstraction which associates a single formulation with the entire simulation domain (hydrofabric) instead of a subset of catchment features.

## Additions

- `DomainLayer` subclass of the `Layer` abstraction
- `ngen::config::Layer` for parsing layer configurations
- `Formulation_Manager` attribute and functions for managing "Domain Layer" formulations.

## Removals

-

## Changes

- Refactored parsing in `Formulation_Manager` using the `ngen::config::Layer` structure
- Refactored `main` in `Ngen.cpp` to support creation of `DomainLayer`s and

## Testing

1. This work was used in testing the initial NOM gridded model runs via ngen.  Additional unit/integration testing should be added.

## Todos

-  ~~A couple of TODO's and FIXME's are noted in the code.  The FIXME particularly in the case of parsing Layer configurations with invalid configurations should likely be addressed before merging. This should likely throw a `std::runtime` error as used in some other config parsing when required missing keys are not found.  I'll try to get this added ASAP while the other components are being reviewed.~~ FIXME addressed in 88f3d23de09130996bcb602acb0a0aca27b0e88b

- Need to add some unit test code as well.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS