### PR TITLE
Fix for embedded Python interpreter issues on macOS

### DIFF
--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -146,7 +146,11 @@ namespace utils {
                 py::object requestedDirPath = Path(directoryPath);
                 if (py::bool_(requestedDirPath.attr("is_dir")())) {
                     if (std::find(sys_path_vector.begin(), sys_path_vector.end(), directoryPath) == sys_path_vector.end()) {
+#ifdef __APPLE__
+                        sys_path.attr("insert")(1, py::str(directoryPath));
+#else
                         sys_path.attr("insert")(sys_path_vector.size(), py::str(directoryPath));
+#endif
                     }
                 }
                 else {


### PR DESCRIPTION
Fixes issues described in #628.

Moving to a newer version of pybind11 that has [this issue](https://github.com/pybind/pybind11/issues/4471) fixed.  Also modifying the order in which items (e.g., virtual environment directories) are added to the interpreter  system path, but only on macOS.

These changes allow for successful and correct loading of numpy 1.26.3 from the virtual environment (as was used during build system generation), where previously 1.26.2 was being loaded from the system-level installed packages. 