### PR TITLE
Add MPI_Finalize "detouring" mechanism

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[]) {
         } // if (mpi_rank == 0)
 
         #if NGEN_WITH_MPI
-        MPI_Finalize();
+        PMPI_Finalize();
         #endif
 
         exit(1);
@@ -587,7 +587,7 @@ int main(int argc, char *argv[]) {
     }
 
 #ifdef NGEN_MPI_ACTIVE
-    MPI_Finalize();
+    PMPI_Finalize();
 #endif
 
     return 0;

--- a/src/utilities/mpi/CMakeLists.txt
+++ b/src/utilities/mpi/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(MPIDetour SHARED "${CMAKE_CURRENT_LIST_DIR}/MPIDetour.c")

--- a/src/utilities/mpi/MPIDetour.c
+++ b/src/utilities/mpi/MPIDetour.c
@@ -1,0 +1,3 @@
+int MPI_Finalize() {
+    return 0;
+}


### PR DESCRIPTION
This PR resolves #748 by implementing a shim library that overrides `MPI_Finalize` calls to become no-op. Additionally, calls to `MPI_Finalize` from NGen code are modified to `PMPI_Finalize` to call the MPI library's actual implementation.

Adding everyone as reviewers for visibility on this change.

## Additions

- CMake target `MPIDetour` in `utilities/mpi/` with the source file `MPIDetour.c`.

## Changes

- Both calls to `MPI_Finalize` in `src/NGen.cpp` are converted to `PMPI_Finalize`.
- 
## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [X] Linux
- [ ] macOS