### PR TITLE
CI: pin ubuntu runner to 20.04 to avoid sanitizer failures

### DIFF
--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -24,7 +24,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Recently tests are failing with `AddressSanitizer:DEADLYSIGNAL`.  A ctest timeout occurs and causes the test suite to fail.  This does NOT occur when actually running the tests, but instead during the build/linking step.  In the test CMakeLists, there is a call to
```
gtest_discover_tests
```
which defers test discovery until runtime instead of scanning source files.  In effect, the causes the test executable to run with the flag `--gtest_list_tests`.  
The cmake error points to this call as failing:
```
CMake Error at /usr/local/share/cmake-3.28/Modules/GoogleTestAddTests.cmake:112 (message):
2024-03-15T22:38:17.3140582Z   Error running test executable.
2024-03-15T22:38:17.3140590Z 
2024-03-15T22:38:17.3140878Z     Path: '/home/runner/work/ngen/ngen/cmake_build/test/test_bmi_c'
2024-03-15T22:38:17.3141033Z     Result: Process terminated due to timeout
2024-03-15T22:38:17.3141126Z     Output:
2024-03-15T22:38:17.3141215Z       
2024-03-15T22:38:17.3141230Z 
2024-03-15T22:38:17.3141350Z Call Stack (most recent call first):
2024-03-15T22:38:17.3141791Z   /usr/local/share/cmake-3.28/Modules/GoogleTestAddTests.cmake:225 (gtest_discover_tests_impl)
```

It appears that some combination of google test, ubuntu, and VM/Containers is causes the address sanitizer to trigger an infinite loop which causes the timeout.

See quantumlib/Stim#717 and google/googletest#4491

## Changes

- Change from `ubuntu-latest` to `ubuntu-20.04` in github CI runners

### Target Environment support

- [x] GitHub CI ubuntu runner
