### PR TITLE
GH Actions Submod NOM Flag

### DIFF
--- a/.github/actions/ngen-submod-build/action.yaml
+++ b/.github/actions/ngen-submod-build/action.yaml
@@ -17,6 +17,10 @@ inputs:
     mod-dir:
       required: true
       description: 'Path to the submodule with CMakeLists.txt to build'
+    is_main_project:
+      required: false
+      description: 'A required Noah-OWP-Modular build flag'
+      default: 'OFF'
 outputs:
   build-dir:
     description: "Directory build was performed in"
@@ -39,7 +43,9 @@ runs:
         - name: Cmake Initialization
           id: cmake_init
           run: |
-            cmake -B ${{ inputs.mod-dir}}/${{ inputs.build-dir }} -S ${{ inputs.mod-dir }}
+            cmake -B ${{ inputs.mod-dir}}/${{ inputs.build-dir }} \
+            -DNGEN_IS_MAIN_PROJECT:BOOL=${{ inputs.is_main_project }} \
+            -S ${{ inputs.mod-dir }}
             echo "build-dir=$(echo ${{ inputs.mod-dir}}/${{ inputs.build-dir }})" >> $GITHUB_OUTPUT
           shell: bash
 


### PR DESCRIPTION
Update submodule actions for NOM to include build flag `-NGEN_IS_MAIN_PROJECT`

## Changes

- added input `is_main_project` to submod lib build [actions.yml](https://github.com/NOAA-OWP/ngen/tree/master/.github/actions/ngen-submod-build) - specific to Noah-OWP-Modular

## Formulation Notes

- There are (3) "formulation" repos (PET, Topmodel & NOM) which currently use/build NOM as apart of testing. Therefore (ngen_integration.yaml) workflows will be defined as follows, 
```
      - name: Build Surfacebmi
        id: submod_build_1
        uses: ./.github/actions/ngen-submod-build
        with:
          mod-dir: " extern/noah-owp-modular/"
          targets: "surfacebmi"
          is_main_project: 'ON'
```

## Notes
Speaks to Issue #761 - but hesitant to close as there maybe more flags that I am missing outside of NOM (e.g `extern/cfe/cfe/ -DNGEN=ON`)?


