### PR TITLE
provide option to skip initializing and add general build flags to sub-module build

### DIFF
--- a/.github/actions/ngen-submod-build/action.yaml
+++ b/.github/actions/ngen-submod-build/action.yaml
@@ -17,6 +17,14 @@ inputs:
     mod-dir:
       required: true
       description: 'Path to the submodule with CMakeLists.txt to build'
+    initialize:
+      description: 'Initialize the ngen submodule, default'
+      required: false
+      default: 'true'
+    cmake-flags:
+      desciption: 'Options to pass to the cmake build configuration, e.g. -D<var> defines'
+      required: false
+      default: ''
 outputs:
   build-dir:
     description: "Directory build was performed in"
@@ -26,6 +34,7 @@ runs:
     steps:
         #This may be redundant
         - name: Init Submodules
+          if: ${{ inputs.initialize == 'true' }} #not true is false, don't init
           run: git submodule update --init --recursive -- ${{ inputs.mod-dir }}
           shell: bash
 
@@ -39,7 +48,7 @@ runs:
         - name: Cmake Initialization
           id: cmake_init
           run: |
-            cmake -B ${{ inputs.mod-dir}}/${{ inputs.build-dir }} -S ${{ inputs.mod-dir }}
+            cmake -B ${{ inputs.mod-dir}}/${{ inputs.build-dir }} -S ${{ inputs.mod-dir }} ${{ inputs.cmake-flags }}
             echo "build-dir=$(echo ${{ inputs.mod-dir}}/${{ inputs.build-dir }})" >> $GITHUB_OUTPUT
           shell: bash
 


### PR DESCRIPTION
Provide some flexibility in the submodule build action, so a caller can avoid initializing the module in case they want to replace the submodule code with custom code before the compile steps.

Also take a generic build flag input allowing custom cmake flags such as macro defines to be passed to to the cmake configure step.

This would replace #768, which would address noaa-owp/noaa-owp-modular#104 by allowing custom workflows to change to replace the code being built by the action.

Should also strongly consider adding a `workdir` input to allow a `cd ${{ inputs.workdir }}` before the configure/build steps.  This would allow some customization with the actions/checkout which allows checking out different repositories to new directories, but the build action would need to know which path to initiate the build steps under.