### PR TITLE
Add missing override specifiers to quiet warnings

### DIFF
--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -373,7 +373,7 @@ namespace models {
              *
              * @return Whether the backing model has been initialized yet.
              */
-            bool is_model_initialized();
+            bool is_model_initialized() override;
 
             void SetValue(std::string name, void *src) override;
 

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -293,7 +293,7 @@ namespace models {
              *
              * @return Whether the backing model has been initialized yet.
              */
-            bool is_model_initialized();
+            bool is_model_initialized() override;
 
             void SetValue(std::string name, void *src) override;
 

--- a/include/bmi/Bmi_Fortran_Adapter.hpp
+++ b/include/bmi/Bmi_Fortran_Adapter.hpp
@@ -340,7 +340,7 @@ namespace models {
              *
              * @return Whether the backing model has been initialized yet.
              */
-            bool is_model_initialized();
+            bool is_model_initialized() override;
 
             void SetValue(std::string name, void *src) override;
 

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -513,7 +513,7 @@ namespace models {
              *
              * @return Whether the backing model has been initialized yet.
              */
-            inline bool is_model_initialized() {
+            inline bool is_model_initialized() override {
                 return model_initialized;
             }
 


### PR DESCRIPTION
CI builds using Clang produce warnings like 
```
[ 44%] Building CXX object src/bmi/CMakeFiles/ngen_bmi.dir/Bmi_Cpp_Adapter.cpp.o
In file included from /Users/runner/work/ngen/ngen/src/bmi/Bmi_Cpp_Adapter.cpp:1:
/Users/runner/work/ngen/ngen/include/bmi/Bmi_Cpp_Adapter.hpp:296:18: warning: 'is_model_initialized' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
            bool is_model_initialized();
                 ^
/Users/runner/work/ngen/ngen/include/bmi/Bmi_Adapter.hpp:35:26: note: overridden virtual function is here
            virtual bool is_model_initialized() = 0;
                         ^
1 warning generated.
```
They're not wrong.

## Changes

- Add the missing specifiers

## Testing

1. Compilation with AppleClang no longer emits warnings

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux/gcc
- [x] macOS/AppleClang
- [x] Linux/clang
