### PR TITLE
Fix minor issues in tests

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -292,8 +292,8 @@ namespace realization {
                 utils::StreamHandler output_stream
             ) {
                 if(!formulation_exists(catchment_formulation.formulation.type)){
-                    throw std::runtime_error("Catchment " + identifier + " failed initialization: " + 
-                            catchment_formulation.formulation.type + " is not a valid formulation. Options are: "+valid_formulation_keys());
+                    throw std::runtime_error("Catchment " + identifier + " failed initialization: '" +
+                            catchment_formulation.formulation.type + "' is not a valid formulation. Options are: "+valid_formulation_keys());
                 }
 
                 if(catchment_formulation.forcing.parameters.empty()){

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -293,7 +293,7 @@ namespace realization {
             ) {
                 if(!formulation_exists(catchment_formulation.formulation.type)){
                     throw std::runtime_error("Catchment " + identifier + " failed initialization: " + 
-                            catchment_formulation.formulation.type + "is not a valid formulation. Options are: "+valid_formulation_keys());
+                            catchment_formulation.formulation.type + " is not a valid formulation. Options are: "+valid_formulation_keys());
                 }
 
                 if(catchment_formulation.forcing.parameters.empty()){

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -256,6 +256,7 @@ ngen_add_test(
         NGen::forcing
     REQUIRES
         NGEN_WITH_NETCDF
+        NGEN_WITH_BMI_FORTRAN
 )
 
 


### PR DESCRIPTION
In a build with Fortran disabled, I noticed the `MultiLayerParserTest` failing, and that the error message had a small typo.

## Changes

- Add a space and quote the named module in the error message
- Disable the test when BMI Fortran is unavailable

## Testing

1. With just the source changes, the error message looks better
2. With the CMake change, the test isn't built or run

## Notes

Wait until my earlier PR is merged, since this branch builds on it

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
