### PR TITLE
Updated realization configs in `data/`

### DIFF
--- a/data/example_bmi_multi_realization_config.json
+++ b/data/example_bmi_multi_realization_config.json
@@ -60,16 +60,10 @@
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
                                     "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface",
-				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
-				    "soil_moisture_profile" : "sloth_smp"
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/example_bmi_multi_realization_config__macos.json
+++ b/data/example_bmi_multi_realization_config__macos.json
@@ -43,14 +43,8 @@
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
-                                    "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface"
+                                    "water_potential_evaporation_flux": "EVAPOTRANS",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/example_bmi_multi_realization_config_w_netcdf.json
+++ b/data/example_bmi_multi_realization_config_w_netcdf.json
@@ -59,17 +59,11 @@
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
-                                    "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface",
-				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
-				    "soil_moisture_profile" : "sloth_smp"
+                                    "water_potential_evaporation_flux": "EVAPOTRANS",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/example_bmi_multi_realization_config_w_nfp.json
+++ b/data/example_bmi_multi_realization_config_w_nfp.json
@@ -68,13 +68,7 @@
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
                                     "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface"
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/example_bmi_multi_realization_config_w_noah_pet_cfe.json
+++ b/data/example_bmi_multi_realization_config_w_noah_pet_cfe.json
@@ -76,16 +76,10 @@
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
                                     "water_potential_evaporation_flux": "potential_evapotranspiration",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface",
-				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
-				    "soil_moisture_profile" : "sloth_smp"
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/example_bmi_multi_realization_config_w_routing.json
+++ b/data/example_bmi_multi_realization_config_w_routing.json
@@ -59,14 +59,8 @@
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
-                                    "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface"
+                                    "water_potential_evaporation_flux": "EVAPOTRANS",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/test_bmi_multi_realization_config.json
+++ b/data/test_bmi_multi_realization_config.json
@@ -59,17 +59,11 @@
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
-                                    "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface",
-				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
-				    "soil_moisture_profile" : "sloth_smp"
+                                    "water_potential_evaporation_flux": "EVAPOTRANS",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/test_bmi_multi_realization_config_w_netcdf.json
+++ b/data/test_bmi_multi_realization_config_w_netcdf.json
@@ -59,17 +59,11 @@
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
-                                    "water_potential_evaporation_flux": "ETRAN",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface",
-				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
-				    "soil_moisture_profile" : "sloth_smp"
+                                    "water_potential_evaporation_flux": "EVAPOTRANS",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
                             }

--- a/data/test_bmi_multi_realization_config_w_noah_pet_cfe.json
+++ b/data/test_bmi_multi_realization_config_w_noah_pet_cfe.json
@@ -76,16 +76,10 @@
                                 "registration_function": "register_bmi_cfe",
                                 "variables_names_map": {
                                     "water_potential_evaporation_flux": "potential_evapotranspiration",
-                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
-                                    "land_surface_air__temperature": "TMP_2maboveground",
-                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
-                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
-                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
-                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
-                                    "land_surface_air__pressure": "PRES_surface",
-				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
-				    "soil_moisture_profile" : "sloth_smp"
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
                             }


### PR DESCRIPTION
#787 indicates that the example realization configs in the `data` directory are out of date. Notably, none of the realizations mapped Noah-OWP-Modular `QINSUR` output to CFE, meaning the latter was taking precipitation directly from forcing.

## Additions

-

## Removals

-

## Changes

Updated the `variables_names_map` in:

- `example_bmi_multi_realization_config.json`
- `example_bmi_multi_realization_config__macos.json`
- `example_bmi_multi_realization_config_w_netcdf.json`
- `example_bmi_multi_realization_config_w_nfp.json`
- `example_bmi_multi_realization_config_w_noah_pet_cfe.json`
- `example_bmi_multi_realization_config_w_routing.json`
- `test_bmi_multi_realization_config.json`
- `test_bmi_multi_realization_config_w_netcdf.json`
- `test_bmi_multi_realization_config_w_noah_pet_cfe.json`

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
