### PR TITLE
Resolve several minor bugs

### DIFF
--- a/src/core/network.cpp
+++ b/src/core/network.cpp
@@ -100,7 +100,7 @@ void Network::init_indicies(){
                    boost::vertex_index_map(get(boost::vertex_index, this->graph)));
 }
 
-Network::Network( geojson::GeoJSON features, std::string* link_key = nullptr ){
+Network::Network( geojson::GeoJSON features, std::string* link_key ){
 
   std::string feature_id, downstream_id;
   Graph::vertex_descriptor v1, v2;

--- a/src/geopackage/geometry.cpp
+++ b/src/geopackage/geometry.cpp
@@ -31,7 +31,7 @@ geojson::geometry ngen::geopackage::build_geometry(
     const bg::srs::transformation<> prj{epsg, ngen::srs::epsg::get(ngen::srs::epsg::wgs84)};
     wkb::wgs84 pvisitor{srs_id, prj};
     
-    if (indicator > 0 & indicator < 5) {
+    if (indicator > 0 && indicator < 5) {
         // not an empty envelope
 
         double min_x = 0, max_x = 0, min_y = 0, max_y = 0;


### PR DESCRIPTION
- Resolves #782.
- Resolves #783.
- Resolves #784.

## Changes

- Removes default `link_key` value for network class constructor.
- Replaces a bitwise AND with logical AND in the geopackage read function.
- Replaces usage of VLAs with `std::vector` in parallel_utils.h.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
