### PR TITLE
Update workflows to Ubuntu 22.04

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -186,14 +186,14 @@ runs:
             . .venv/bin/activate
             [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} \
-              -DBMI_C_LIB_ACTIVE:BOOL=${{ inputs.bmi_c }} \
-              -DNGEN_ACTIVATE_PYTHON:BOOL=${{ inputs.use_python }} \
-              -DUDUNITS_ACTIVE:BOOL=${{ inputs.use_udunits }} \
-              -DBMI_FORTRAN_ACTIVE:BOOL=${{ inputs.bmi_fortran }} \
-              -DNGEN_ACTIVATE_ROUTING:BOOL=${{ inputs.use_troute }} \
-              -DNETCDF_ACTIVE:BOOL=${{ inputs.use_netcdf }} \
+              -DNGEN_WITH_BMI_C:BOOL=${{ inputs.bmi_c }} \
+              -DNGEN_WITH_PYTHON:BOOL=${{ inputs.use_python }} \
+              -DNGEN_WITH_UDUNITS:BOOL=${{ inputs.use_udunits }} \
+              -DNGEN_WITH_BMI_FORTRAN:BOOL=${{ inputs.bmi_fortran }} \
+              -DNGEN_WITH_ROUTING:BOOL=${{ inputs.use_troute }} \
+              -DNGEN_WITH_NETCDF:BOOL=${{ inputs.use_netcdf }} \
               -DNGEN_WITH_SQLITE:BOOL=${{ inputs.use_sqlite }} \
-              -DMPI_ACTIVE:BOOL=${{ inputs.use_mpi }} -S .
+              -DNGEN_WITH_MPI:BOOL=${{ inputs.use_mpi }} -S .
             echo "build-dir=$(echo ${{ inputs.build-dir }})" >> $GITHUB_OUTPUT
           shell: bash
 

--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -22,7 +22,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -55,7 +55,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04] # [ubuntu-latest, macos-12] #TODO: Fix #505
+        os: [ubuntu-22.04] # [ubuntu-latest, macos-12] #TODO: Fix #505
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -24,7 +24,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -59,7 +59,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -87,7 +87,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -116,7 +116,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -151,7 +151,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -184,7 +184,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -217,7 +217,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -252,7 +252,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -166,8 +166,6 @@ jobs:
           targets: "test_bmi_c"
           build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
           bmi_c: 'ON'
-          #Is this required for this test???
-          use_python: 'ON'
 
       - name: run_bmi_c_tests
         run: |


### PR DESCRIPTION
The current supported release of Ubuntu is 22.04, and the later 24.04 is just entering beta. We don't want to fall too far behind.

## Changes

- Update Linux OS image to Ubuntu 22.04
- Update CMake options to quiet distracting warnings during configuration
- Turn off Python for BMI C tests
- (not reflected in code) Regenerate cached `.venv` for new OS and Python versions

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. CI is the sole focus of this change

### Target Environment support

- [x] Linux
