### PR TITLE
Fix the few most pressing warnings reported by -Wall

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -182,7 +182,7 @@ runs:
           run: |
             export BOOST_ROOT="$(pwd)/boost_1_79_0"
             export CFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -Werror"
-            export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -pedantic-errors -Werror"
+            export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -pedantic-errors -Werror -Wpessimizing-move -Wparentheses -Wrange-loop-construct"
             . .venv/bin/activate
             [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} \

--- a/include/geojson/FeatureBuilder.hpp
+++ b/include/geojson/FeatureBuilder.hpp
@@ -283,11 +283,11 @@ namespace geojson {
             }
             else if (child.first == "properties") {
                 for (auto& property : child.second) {
-                    properties.emplace(property.first, std::move(JSONProperty(property.first, property.second)));
+                    properties.emplace(property.first, JSONProperty(property.first, property.second));
                 }
             }
             else {
-                foreign_members.emplace(child.first, std::move(JSONProperty(child.first, child.second)));
+                foreign_members.emplace(child.first, JSONProperty(child.first, child.second));
             }
         }
 
@@ -425,7 +425,7 @@ namespace geojson {
                 }
             }
             else {
-                foreign_members.emplace(child.first, std::move(JSONProperty(child.first, child.second)));
+                foreign_members.emplace(child.first, JSONProperty(child.first, child.second));
                 
             }
             

--- a/include/geojson/FeatureBuilder.hpp
+++ b/include/geojson/FeatureBuilder.hpp
@@ -195,7 +195,7 @@ namespace geojson {
     }
 
     static geometry build_geometry(boost::property_tree::ptree &tree) {
-        std::string type = std::move(tree.get<std::string>("type"));
+        std::string type = tree.get<std::string>("type");
 
         if (type == "Point") {
             

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -215,12 +215,12 @@ namespace geojson {
                     for (auto &property : property_tree) {
                         if (property.first.empty()) {
                             type = PropertyType::List;
-                            value_list.push_back(std::move(JSONProperty(value_key, property.second)));
+                            value_list.push_back(JSONProperty(value_key, property.second));
                             data = List(& value_list );
                         }
                         else {
                             type = PropertyType::Object;
-                            values.emplace(property.first, std::move(JSONProperty(property.first, property.second)));
+                            values.emplace(property.first, JSONProperty(property.first, property.second));
                             data = Object( & values );
                         }
                     }

--- a/include/geojson/features/CollectionFeature.hpp
+++ b/include/geojson/features/CollectionFeature.hpp
@@ -37,7 +37,7 @@ namespace geojson {
                 try {
                     return boost::get<coordinate_t>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = "Point";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -53,7 +53,7 @@ namespace geojson {
                         try {
                             point_geometries.push_back(&boost::get<coordinate_t>(geometry));
                         }
-                        catch (boost::bad_get exception) {
+                        catch (boost::bad_get &exception) {
                             std::string template_name = "Point";
                             std::string expected_name = get_geometry_type(geometry);
                             std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -69,7 +69,7 @@ namespace geojson {
                 try {
                     return boost::get<linestring_t>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = "LineString";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -85,7 +85,7 @@ namespace geojson {
                         try {
                             linestring_geometries.push_back(&boost::get<linestring_t>(geometry));
                         }
-                        catch (boost::bad_get exception) {
+                        catch (boost::bad_get &exception) {
                             std::string template_name = "LineString";
                             std::string expected_name = get_geometry_type(geometry);
                             std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -101,7 +101,7 @@ namespace geojson {
                 try {
                     return boost::get<polygon_t>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = "Polygon";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -117,7 +117,7 @@ namespace geojson {
                         try {
                             polygon_geometries.push_back(&boost::get<polygon_t>(geometry));
                         }
-                        catch (boost::bad_get exception) {
+                        catch (boost::bad_get &exception) {
                             std::string template_name = "Polygon";
                             std::string expected_name = get_geometry_type(geometry);
                             std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -133,7 +133,7 @@ namespace geojson {
                 try {
                     return boost::get<multipoint_t>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = "MultiPoint";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -157,7 +157,7 @@ namespace geojson {
                 try {
                     return boost::get<multilinestring_t>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = "MultiLineString";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -181,7 +181,7 @@ namespace geojson {
                 try {
                     return boost::get<multipolygon_t>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = "MultiPolygon";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;

--- a/include/geojson/features/FeatureBase.hpp
+++ b/include/geojson/features/FeatureBase.hpp
@@ -527,7 +527,7 @@ namespace geojson {
                 try {
                     return boost::get<T>(this->geom);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = boost::typeindex::type_id<T>().pretty_name();
                     std::string expected_name = get_geometry_type(this->geom);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
@@ -544,7 +544,7 @@ namespace geojson {
                 try {
                     return boost::get<T>(this->geometry_collection[index]);
                 }
-                catch (boost::bad_get exception) {
+                catch (boost::bad_get &exception) {
                     std::string template_name = boost::typeindex::type_id<T>().pretty_name();
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
                     std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -429,14 +429,14 @@ int main(int argc, char* argv[])
     if (boost::algorithm::ends_with(catchmentDataFile, "gpkg"))
     {
         #ifdef NGEN_WITH_SQLITE3
-        catchment_collection = std::move( ngen::geopackage::read(catchmentDataFile, "divides", catchment_subset_ids) );
+        catchment_collection = ngen::geopackage::read(catchmentDataFile, "divides", catchment_subset_ids);
         #else
         throw std::runtime_error("SQLite3 support required to read GeoPackage files.");
         #endif
     }
     else
     {
-        catchment_collection = std::move( geojson::read(catchmentDataFile, catchment_subset_ids) );
+        catchment_collection = geojson::read(catchmentDataFile, catchment_subset_ids);
     }
     int num_catchments = catchment_collection->get_size();
     std::cout<<"Partitioning "<<num_catchments<<" catchments into "<<num_partitions<<" partitions."<<std::endl;
@@ -461,14 +461,14 @@ int main(int argc, char* argv[])
     if (boost::algorithm::ends_with(nexusDataFile, "gpkg")) 
     {
       #ifdef NGEN_WITH_SQLITE3
-      global_nexus_collection = std::move( ngen::geopackage::read(nexusDataFile, "nexus", nexus_subset_ids) );
+      global_nexus_collection = ngen::geopackage::read(nexusDataFile, "nexus", nexus_subset_ids);
       #else
       throw std::runtime_error("SQLite3 support required to read GeoPackage files.");
       #endif
     } 
     else 
     {
-      global_nexus_collection = std::move( geojson::read(nexusDataFile, nexus_subset_ids) );
+      global_nexus_collection = geojson::read(nexusDataFile, nexus_subset_ids);
     }
 
     //Now read the collection of catchments, iterate it and add them to the nexus collection

--- a/test/bmi/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Fortran_Adapter_Test.cpp
@@ -874,7 +874,7 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridNodesPerFace_0_a) {
 
     std::string variable_name = adapter->GetOutputVarNames()[out_var_index];
     int grd = adapter->GetVarGrid(variable_name);
-    int* nodes_per_face;
+    int* nodes_per_face = nullptr;
     EXPECT_THROW(adapter->GetGridNodesPerFace(grd, nodes_per_face), std::runtime_error);
     // int size = adapter->GetGridFaceCount(grd);
     // nodes_per_face = new int [size];
@@ -894,7 +894,7 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridEdgeNodes_0_a) {
 
     std::string variable_name = adapter->GetOutputVarNames()[out_var_index];
     int grd = adapter->GetVarGrid(variable_name);
-    int* edge_nodes;
+    int* edge_nodes = nullptr;
     EXPECT_THROW(adapter->GetGridEdgeNodes(grd, edge_nodes), std::runtime_error);
     // int size = 2*adapter->GetGridEdgeCount(grd);
     // edge_nodes = new int [size];
@@ -914,7 +914,7 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridFaceEdges_0_a) {
 
     std::string variable_name = adapter->GetOutputVarNames()[out_var_index];
     int grd = adapter->GetVarGrid(variable_name);
-    int* face_edges;
+    int* face_edges = nullptr;
     EXPECT_THROW(adapter->GetGridFaceEdges(grd, face_edges), std::runtime_error);
     // int num_faces = adapter->GetGridFaceCount(grd);
     // int * nodes_per_face = new int [num_faces];
@@ -942,7 +942,7 @@ TEST_F(Bmi_Fortran_Adapter_Test, GetGridFaceNodes_0_a) {
 
     std::string variable_name = adapter->GetOutputVarNames()[out_var_index];
     int grd = adapter->GetVarGrid(variable_name);
-    int* face_nodes;
+    int* face_nodes = nullptr;
     EXPECT_THROW(adapter->GetGridFaceNodes(grd, face_nodes), std::runtime_error);
     // int num_faces = adapter->GetGridFaceCount(grd);
     // int * nodes_per_face = new int [num_faces];

--- a/test/core/NetworkTests.cpp
+++ b/test/core/NetworkTests.cpp
@@ -167,7 +167,7 @@ TEST_P(Network_Test1, TestNetworkHeadwaterIndex)
   for(auto it = begin; it != end; ++it)
   {
     std::string id =  n.get_id(*it);
-    ASSERT_TRUE( id  ==  "cat-0" | id ==  "cat-1");
+    ASSERT_TRUE( id  ==  "cat-0" || id ==  "cat-1");
   }
 }
 

--- a/test/geojson/JSONProperty_Test.cpp
+++ b/test/geojson/JSONProperty_Test.cpp
@@ -367,7 +367,7 @@ TEST_F(JSONProperty_Test, test_as_vector_mixed_list_0a){
     for(auto const num : test_list_natural){
         properties.push_back(geojson::JSONProperty("", num));
     }
-    for(auto const str : test_list_str){
+    for(auto const& str : test_list_str){
         properties.push_back(geojson::JSONProperty("", str));
     }
     geojson::JSONProperty mixed_property("mixed_list", properties);


### PR DESCRIPTION
## Changes

- Fix occurrences of `-Wpessimizing-move` reported by either GCC or AppleClang
- Fix a mis-use of bitwise `|` instead of logical `||`
- Fix range-for loop over `vector<string>` working on values rather than references
- Quiet some `-Wmaybe-uninitialized` by setting output-argument pointer variables to `nullptr`
- Fix catching polymorphic `boost::bad_get` by value

## Testing

1. Local testing with GCC 13
2. Local testing with AppleClang 15
3. CI with GCC 11
4. CI with AppleClang 14

## Notes

This gets us a large portion of the way to being able to build with `-Wall` for C++

- There are a lot of un/signed comparison warnings that I think we can reasonably suppress
- There are some constructor initializer list warnings about orders not matching declarations, that we should probably just fix, but aren't a big deal
- There are a bunch of unused variables and functions that should eventually be investigated and likely deleted
- The BMI C++ spec misses a virtual destructor, so we get warnings about that until https://github.com/csdms/bmi-cxx/issues/11 gets addressed, and we incorporate the fix in our modules

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: