### PR TITLE
Support numpy/python 32 bit float type names

### DIFF
--- a/doc/BMIconventions.md
+++ b/doc/BMIconventions.md
@@ -81,7 +81,19 @@ Since the [BMI Documentation] simply states that, "Use of native language type n
     * `get_var_itemsize` result **must** match the size of the data type in the compiler used to build ngen
 * Python
     * `int`, `long`, `long long`, `int64`, `longlong`, `float`, `float64`, `long double`
-    * also accepts `numpy.float64` and `np.float64` but this usage is discouraged! Please use the non-namespaced names above.
+    * also accepts the following numpy types
+        - `numpy.float64` and `np.float64` for double precision floats
+        - `numpy.float32`, `np.float32`, `numpy.single`, and `np.single` for single precision floats
+    
+    Use of these namespaced types should be limited to variables that are implemented as numpy arrays in the model, as the data type is part of the of the array metadata.  E.g.
+    ```python
+        import numpy as np
+        variable = np.ndarray((1,1), dtype=np.single)
+        print(variable.dtype)
+    ```
+    will produce `dtype('float32')`.
+
+    For variables where the dtype is not directly accessed from the numpy meta data, this usage is discouraged! Please use the non-namespaced names above.
 
 # Input and output published variables
 

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -248,7 +248,8 @@ namespace models {
                     return "long long";
                 } else if (py_type_name == "longlong" && item_size == sizeof(long long)) {
                     return "long long"; //numpy type
-                } else if (py_type_name == "float" && item_size == sizeof(float)) {
+                } else if ( (py_type_name == "float" || py_type_name == "float32" || py_type_name == "np.float32" ||
+                           py_type_name == "numpy.float32") && item_size == sizeof(float)) {
                     return "float";
                 } else if ((py_type_name == "float" || py_type_name == "float64" || py_type_name == "np.float64" ||
                             py_type_name == "numpy.float64") && item_size == sizeof(double)) {

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -249,7 +249,7 @@ namespace models {
                 } else if (py_type_name == "longlong" && item_size == sizeof(long long)) {
                     return "long long"; //numpy type
                 } else if ( (py_type_name == "float" || py_type_name == "float32" || py_type_name == "np.float32" ||
-                           py_type_name == "numpy.float32") && item_size == sizeof(float)) {
+                           py_type_name == "numpy.float32" || py_type_name == "np.single" ||  py_type_name == "numpy.single") && item_size == sizeof(float)) {
                     return "float";
                 } else if ((py_type_name == "float" || py_type_name == "float64" || py_type_name == "np.float64" ||
                             py_type_name == "numpy.float64") && item_size == sizeof(double)) {


### PR DESCRIPTION
Add support for numpy/python 32 bit float type names in python bmi adapter.

## Changes

- python adapter now maps `float32`, `np.float32`, and `numpy.float32` to the cxx `float` type

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOs
