### PR TITLE
re-throw exceptions as std::runtime_error with original error

### DIFF
--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -41,6 +41,9 @@ namespace models {
              * BMI ``GetTimeUnits`` function. This function retrieves (and interprets) its model's units and
              * return an appropriate factor for converting its internal time values to equivalent representations
              * within the model, and vice versa. This function complies with the BMI get_time_units standard
+             * 
+             * @throws runtime_error  If the delegated BMI functions to query time throw an exception, the
+             *                        exception is caught and wrapped in a runtime_error
              */
             double get_time_convert_factor();
 

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -37,7 +37,19 @@ Bmi_Adapter::~Bmi_Adapter() = default;
 
 double Bmi_Adapter::get_time_convert_factor() {
     double value             = 1.0;
-    std::string input_units  = GetTimeUnits();
+    std::string input_units("-");
+    try{
+        input_units  = GetTimeUnits();
+    }
+    catch(std::exception &e){
+        //Re-throwing any exception as a runtime_error so we don't lose
+        //the error context/message.  We will lose the original exception type, though
+        //When a python exception is raised from the py adapter subclass, the
+        //pybind exception is lost and all we see is a generic "uncaught exception"
+        //with no context.  This way we at least get the error message wrapped in
+        //a runtime error.
+        throw std::runtime_error(e.what());
+    }
     std::string output_units = "s";
     return UnitsHelper::get_converted_value(input_units, value, output_units);
 }


### PR DESCRIPTION
When getting time units from the base BMI class, exception context is lost from the subclasses which raise them.  For example, delegating to to the python adapter where the python module raises an exception, the pybind::error_already_set exception and message is lost, and we are left with just an uncaught std::exception with no context.  Catching the generic exception and copying the message into a runtime_error at least provides the error context provided by the original exception.

## Changes

- `get_time_convert_factor` now does a try/catch and throws runtime_error if any std::exception is caught

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOs
