### PR TITLE
Grid Data Selector for Uniform Structured Grids

### DIFF
--- a/include/forcing/GridDataSelector.hpp
+++ b/include/forcing/GridDataSelector.hpp
@@ -9,10 +9,15 @@
 #include <geojson/JSONGeometry.hpp>
 
 struct Cell {
-    std::uint64_t x;
-    std::uint64_t y;
-    std::uint64_t z;
-    double value;
+    std::uint64_t x = 0;
+    std::uint64_t y = 0;
+    std::uint64_t z = 0;
+    double    value = NAN;
+
+    friend inline bool operator<(const Cell& a, const Cell& b) {
+        // TODO: Not really meaningful
+        return a.x < b.x || a.y < b.y || a.z < b.z;
+    }
 };
 
 struct Extent {
@@ -90,12 +95,12 @@ struct GridDataSelector {
         // the same grid cell. This ensures that each cell is uniquely indexed.
         std::set<Cell> cells;
         for (const auto& point : points) {
-            cells.emplace(
+            cells.emplace(Cell{
                 /*x=*/position_(point.get<0>(), grid.extent.xmin, grid.extent.xmax, grid.columns),
                 /*y=*/position_(point.get<1>(), grid.extent.ymin, grid.extent.ymax, grid.rows),
-                /*z=*/0,
+                /*z=*/0UL,
                 /*value=*/NAN
-            );
+            });
         }
 
         cells_.assign(cells.begin(), cells.end());
@@ -154,12 +159,12 @@ struct GridDataSelector {
         const auto col_max = position_(extent.xmax, grid.extent.xmin, grid.extent.xmax, grid.columns);
         const auto row_min = position_(extent.ymin, grid.extent.ymin, grid.extent.ymax, grid.rows);
         const auto row_max = position_(extent.ymax, grid.extent.ymin, grid.extent.ymax, grid.rows);
-        const auto ncells  = (row_max - row_min + 1) * (col_max - col_min + 1);
+        const auto ncells  = (row_max - row_min) * (col_max - col_min);
 
         cells_.reserve(ncells);
-        for (auto row = row_min; row <= row_max; row++) {
-            for (auto col = col_min; col <= col_max; col++) {
-                cells_.emplace_back(/*x=*/col, /*y=*/row, /*z=*/0, /*value=*/NAN);
+        for (auto row = row_min; row < row_max; row++) {
+            for (auto col = col_min; col < col_max; col++) {
+                cells_.emplace_back(Cell{/*x=*/col, /*y=*/row, /*z=*/0UL, /*value=*/NAN});
             }
         }
     }

--- a/include/forcing/GridDataSelector.hpp
+++ b/include/forcing/GridDataSelector.hpp
@@ -15,12 +15,6 @@ struct Cell {
     double value;
 };
 
-struct LessXY {
-    bool operator()(Cell a, Cell b) const noexcept {
-        return a.x < b.x && a.y < b.y;
-    }
-};
-
 struct Extent {
     double xmin;
     double xmax;
@@ -119,28 +113,28 @@ struct GridDataSelector {
      *
      * @todo Sweep line or ray casting to get polygon grid cells
      */
-    GridDataSelector(
-        SelectorConfig config,
-        const GridSpecification& grid,
-        const geojson::polygon_t& polygon
-    )
-        : config_(std::move(config))
-    {
-        static constexpr auto epsilon = 1e-7;
-
-        std::set<Cell, LessXY> boundary;
-        const auto ydiff = static_cast<double>(grid.rows) / (grid.extent.ymax - grid.extent.ymin);
-        const auto xdiff = static_cast<double>(grid.columns) / (grid.extent.xmax - grid.extent.xmin);
-        const auto bbox = bounding_box_(polygon);
-
-        for (const auto& p : polygon.outer()) {
-            const auto x_index = position_(p.get<0>(), grid.extent.xmin, grid.extent.xmax, grid.columns);
-            const auto y_index = position_(p.get<1>(), grid.extent.ymin, grid.extent.ymax, grid.rows);
-            const auto set_pair = boundary.emplace(x_index, y_index, 0, NAN);
-        }
-
-        throw std::runtime_error{"Boundary-constructor not implemented"};
-    }
+    // GridDataSelector(
+    //     SelectorConfig config,
+    //     const GridSpecification& grid,
+    //     const geojson::polygon_t& polygon
+    // )
+    //     : config_(std::move(config))
+    // {
+    //     static constexpr auto epsilon = 1e-7;
+    // 
+    //     std::set<Cell> boundary;
+    //     const auto ydiff = static_cast<double>(grid.rows) / (grid.extent.ymax - grid.extent.ymin);
+    //     const auto xdiff = static_cast<double>(grid.columns) / (grid.extent.xmax - grid.extent.xmin);
+    //     const auto bbox = bounding_box_(polygon);
+    // 
+    //     for (const auto& p : polygon.outer()) {
+    //         const auto x_index = position_(p.get<0>(), grid.extent.xmin, grid.extent.xmax, grid.columns);
+    //         const auto y_index = position_(p.get<1>(), grid.extent.ymin, grid.extent.ymax, grid.rows);
+    //         const auto set_pair = boundary.emplace(x_index, y_index, 0, NAN);
+    //     }
+    // 
+    //     throw std::runtime_error{"Boundary-constructor not implemented"};
+    // }
 
     /**
      * Extent-based constructor

--- a/include/forcing/GridDataSelector.hpp
+++ b/include/forcing/GridDataSelector.hpp
@@ -89,7 +89,23 @@ struct GridDataSelector {
         SelectorConfig config,
         const GridSpecification& grid,
         boost::span<const geojson::coordinate_t> points
-    ) noexcept;
+    ) noexcept
+      : config_(std::move(config))
+    {
+        // Using a std::set since points may be close enough that they are within
+        // the same grid cell. This ensures that each cell is uniquely indexed.
+        std::set<Cell> cells;
+        for (const auto& point : points) {
+            cells.emplace(
+                /*x=*/position_(point.get<0>(), grid.extent.xmin, grid.extent.xmax, grid.columns),
+                /*y=*/position_(point.get<1>(), grid.extent.ymin, grid.extent.ymax, grid.rows),
+                /*z=*/0,
+                /*value=*/NAN
+            );
+        }
+
+        cells_.assign(cells.begin(), cells.end());
+    }
 
     /**
      * Boundary-based constructor

--- a/include/forcing/GridDataSelector.hpp
+++ b/include/forcing/GridDataSelector.hpp
@@ -6,6 +6,8 @@
 
 #include <boost/core/span.hpp>
 
+#include <geojson/JSONGeometry.hpp>
+
 struct Cell {
     std::uint64_t x;
     std::uint64_t y;
@@ -13,50 +15,271 @@ struct Cell {
     double value;
 };
 
-struct GridDataSelector {
+struct LessXY {
+    bool operator()(Cell a, Cell b) const noexcept {
+        return a.x < b.x && a.y < b.y;
+    }
+};
 
-    GridDataSelector(
-        std::string variable,
-        time_t init_time,
-        long duration,
-        std::string units,
-        boost::span<const Cell> cells
-    )
-      : init_(init_time)
-      , duration_seconds_(duration)
-      , variable_(std::move(variable))
-      , output_units_(std::move(units))
-      , cells_(cells.begin(), cells.end())
-    {}
+struct Extent {
+    double xmin;
+    double xmax;
+    double ymin;
+    double ymax;
 
-    GridDataSelector() noexcept = default;
-    virtual ~GridDataSelector() = default;
+    geojson::polygon_t as_polygon() const noexcept {
+        geojson::polygon_t result;
+        result.outer().reserve(4);
+        result.outer().emplace_back(xmin, ymin);
+        result.outer().emplace_back(xmax, ymin);
+        result.outer().emplace_back(xmax, ymax);
+        result.outer().emplace_back(xmin, ymax);
+        return result;
+    }
+};
 
-    time_t& initial_time() noexcept { return init_; }
-    time_t initial_time() const noexcept { return init_; }
-    long& duration() noexcept { return duration_seconds_; }
-    long duration() const noexcept { return duration_seconds_; }
-    std::string& variable() noexcept { return variable_; }
-    const std::string& variable() const noexcept { return variable_; }
-    std::string& units() noexcept { return output_units_; }
-    const std::string& units() const noexcept { return output_units_; }
-    boost::span<Cell> cells() noexcept { return cells_; }
-    boost::span<const Cell> cells() const noexcept { return cells_; }
+struct GridSpecification {
+    //! Total number of rows (aka y)
+    std::uint64_t rows;
 
-  private:
+    //! Total number of columns (aka x)
+    std::uint64_t columns;
+
+    //! Extent of the grid region (aka min-max corner points)
+    Extent extent;
+};
+
+struct SelectorConfig {
     //! Initial time for query.
     //! @todo Refactor to use std::chrono
-    time_t init_;
+    time_t init_time;
 
     //! Duration for query, in seconds.
     //! @todo Refactor to use std::chrono
-    long duration_seconds_;
+    long duration_seconds;
 
     //! Variable to return from query.
-    std::string variable_;
+    std::string variable_name;
 
     //! Units for output variable.
-    std::string output_units_;
+    std::string variable_units;
+};
+
+struct GridDataSelector {
+
+    //! Cell-based constructor
+    GridDataSelector(SelectorConfig config, boost::span<const Cell> cells) noexcept
+        : config_(std::move(config))
+        , cells_(cells.begin(), cells.end()) {
+    }
+
+    /**
+     * Point-based constructor
+     *
+     * Constructs a selector taking only the cells
+     * from @p grid that correspond to coordinates in @p points.
+     *
+     * @param config Selector configuration options
+     * @param grid Source grid specification
+     * @param points Target points used for extraction
+     *
+     * @todo Implementation
+     */
+    GridDataSelector(
+        SelectorConfig config,
+        const GridSpecification& grid,
+        boost::span<const geojson::coordinate_t> points
+    ) noexcept;
+
+    /**
+     * Boundary-based constructor
+     *
+     * Constructs a selector taking only the cells
+     * from @p grid that intersect @p polygon.
+     *
+     * @param config Selector configuration options
+     * @param grid Source grid specification
+     * @param polygon Target polygon used as mask
+     *
+     * @todo Sweep line or ray casting to get polygon grid cells
+     */
+    GridDataSelector(
+        SelectorConfig config,
+        const GridSpecification& grid,
+        const geojson::polygon_t& polygon
+    ) noexcept
+        : config_(std::move(config))
+    {
+        static constexpr auto epsilon = 1e-7;
+
+        std::set<Cell, LessXY> boundary;
+        const auto ydiff = static_cast<double>(grid.rows) / (grid.extent.ymax - grid.extent.ymin);
+        const auto xdiff = static_cast<double>(grid.columns) / (grid.extent.xmax - grid.extent.xmin);
+        const auto bbox = bounding_box_(polygon);
+
+        std::cout << "Polygon: ";
+        for (const auto& p : polygon.outer()) {
+            std::cout << "(" << p.get<0>() << ' ' << p.get<1>() << ") ";
+            const auto x_index = position_(p.get<0>(), grid.extent.xmin, grid.extent.xmax, grid.columns);
+            const auto y_index = position_(p.get<1>(), grid.extent.ymin, grid.extent.ymax, grid.rows);
+            const auto set_pair = boundary.emplace(x_index, y_index, 0, NAN);
+        }
+        std::cout << '\n';
+    }
+
+    /**
+     * Extent-based constructor
+     *
+     * @param config Selector configuration options
+     * @param grid Source grid specification
+     * @param extent Target bounding box used as mask
+     */
+    GridDataSelector(
+      SelectorConfig config,
+      const GridSpecification& grid,
+      const Extent& extent
+    ) noexcept
+      : config_(std::move(config))
+    {
+        const auto col_min = position_(extent.xmin, grid.extent.xmin, grid.extent.xmax, grid.columns);
+        const auto col_max = position_(extent.xmax, grid.extent.xmin, grid.extent.xmax, grid.columns);
+        const auto row_min = position_(extent.ymin, grid.extent.ymin, grid.extent.ymax, grid.rows);
+        const auto row_max = position_(extent.ymax, grid.extent.ymin, grid.extent.ymax, grid.rows);
+        const auto ncells  = (row_max - row_min + 1) * (col_max - col_min + 1);
+
+        cells_.reserve(ncells);
+        for (auto row = row_min; row <= row_max; row++) {
+            for (auto col = col_min; col <= col_max; col++) {
+                cells_.emplace_back(/*x=*/col, /*y=*/row, /*z=*/0, /*value=*/NAN);
+            }
+        }
+    }
+
+    GridDataSelector() noexcept = default;
+
+    virtual ~GridDataSelector() = default;
+
+    time_t& initial_time() noexcept {
+        return config_.init_time;
+    }
+
+    time_t initial_time() const noexcept {
+        return config_.init_time;
+    }
+
+    long& duration() noexcept {
+        return config_.duration_seconds;
+    }
+
+    long duration() const noexcept {
+        return config_.duration_seconds;
+    }
+
+    std::string& variable() noexcept {
+        return config_.variable_name;
+    }
+
+    const std::string& variable() const noexcept {
+        return config_.variable_name;
+    }
+
+    std::string& units() noexcept {
+        return config_.variable_units;
+    }
+
+    const std::string& units() const noexcept {
+        return config_.variable_units;
+    }
+
+    boost::span<Cell> cells() noexcept {
+        return cells_;
+    }
+
+    boost::span<const Cell> cells() const noexcept {
+        return cells_;
+    }
+
+  private:
+    //! Returns true if point is inside polygon or on its boundary.
+    //! @note may not be needed
+    static bool intersects_(const geojson::coordinate_t& point, const geojson::polygon_t& polygon) {
+        const auto& boundary = polygon.outer();
+        const auto px        = point.get<0>();
+        const auto py        = point.get<1>();
+        size_t intersects    = 0;
+
+        for (size_t i = 0; i < boundary.size() - 1; i++) {
+            const auto& current_bpoint = boundary[i];
+            const auto& next_bpoint    = boundary[i + 1];
+            const double ix            = current_bpoint.get<0>();
+            const double iy            = current_bpoint.get<1>();
+            const double jx            = next_bpoint.get<0>();
+            const double jy            = next_bpoint.get<1>();
+            const double idx           = px - ix;
+            const double idy           = py - iy;
+            const double jdx           = px - jx;
+            const double jdy           = py - jy;
+            const double crossing      = ((idx - jdx) * idy) - (idx * (idy - jdy));
+
+            if (crossing == 0 && idx * jdx <= 0 and idy * jdy <= 0) {
+                return true;
+            }
+
+            if ((idy >= 0 && jdy < 0) || (jdy >= 0 && idy < 0)) {
+                if (crossing > 0) {
+                    intersects++;
+                } else if (crossing < 0) {
+                    intersects--;
+                }
+            }
+        }
+
+        return intersects != 0;
+    }
+
+    static Extent bounding_box_(const geojson::polygon_t& polygon) {
+        Extent bbox{
+            /*xmin=*/std::numeric_limits<double>::max(),
+            /*xmax=*/std::numeric_limits<double>::lowest(),
+            /*ymin=*/std::numeric_limits<double>::max(),
+            /*ymax=*/std::numeric_limits<double>::lowest()
+        };
+
+        for (const auto& point : polygon.outer()) {
+            const auto xcoord = point.get<0>();
+
+            if (xcoord < bbox.xmin) {
+                bbox.xmin = xcoord;
+            }
+
+            if (xcoord > bbox.xmax) {
+                bbox.xmax = xcoord;
+            }
+
+            const auto ycoord = point.get<1>();
+
+            if (ycoord < bbox.ymin) {
+                bbox.ymin = ycoord;
+            }
+
+            if (ycoord > bbox.ymax) {
+                bbox.ymax = ycoord;
+            }
+        }
+
+        return bbox;
+    }
+
+    static std::uint64_t position_(double position, double min, double max, std::uint64_t upper_bound) {
+        if (position < min || position > max) {
+            return static_cast<std::uint64_t>(-1);
+        }
+
+        return std::floor((position - min) * (static_cast<double>(upper_bound) / (max - min)));
+    }
+
+    //! General selector configuration
+    SelectorConfig config_;
 
     //! Cells to gather.
     std::vector<Cell> cells_;

--- a/include/forcing/GridDataSelector.hpp
+++ b/include/forcing/GridDataSelector.hpp
@@ -107,7 +107,7 @@ struct GridDataSelector {
         SelectorConfig config,
         const GridSpecification& grid,
         const geojson::polygon_t& polygon
-    ) noexcept
+    )
         : config_(std::move(config))
     {
         static constexpr auto epsilon = 1e-7;
@@ -117,14 +117,13 @@ struct GridDataSelector {
         const auto xdiff = static_cast<double>(grid.columns) / (grid.extent.xmax - grid.extent.xmin);
         const auto bbox = bounding_box_(polygon);
 
-        std::cout << "Polygon: ";
         for (const auto& p : polygon.outer()) {
-            std::cout << "(" << p.get<0>() << ' ' << p.get<1>() << ") ";
             const auto x_index = position_(p.get<0>(), grid.extent.xmin, grid.extent.xmax, grid.columns);
             const auto y_index = position_(p.get<1>(), grid.extent.ymin, grid.extent.ymax, grid.rows);
             const auto set_pair = boundary.emplace(x_index, y_index, 0, NAN);
         }
-        std::cout << '\n';
+
+        throw std::runtime_error{"Boundary-constructor not implemented"};
     }
 
     /**

--- a/include/forcing/GridDataSelector.hpp
+++ b/include/forcing/GridDataSelector.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <boost/core/span.hpp>
+
+struct Cell {
+    std::uint64_t x;
+    std::uint64_t y;
+    std::uint64_t z;
+    double value;
+};
+
+struct GridDataSelector {
+
+    GridDataSelector(
+        std::string variable,
+        time_t init_time,
+        long duration,
+        std::string units,
+        boost::span<const Cell> cells
+    )
+      : init_(init_time)
+      , duration_seconds_(duration)
+      , variable_(std::move(variable))
+      , output_units_(std::move(units))
+      , cells_(cells.begin(), cells.end())
+    {}
+
+    GridDataSelector() noexcept = default;
+    virtual ~GridDataSelector() = default;
+
+    time_t& initial_time() noexcept { return init_; }
+    time_t initial_time() const noexcept { return init_; }
+    long& duration() noexcept { return duration_seconds_; }
+    long duration() const noexcept { return duration_seconds_; }
+    std::string& variable() noexcept { return variable_; }
+    const std::string& variable() const noexcept { return variable_; }
+    std::string& units() noexcept { return output_units_; }
+    const std::string& units() const noexcept { return output_units_; }
+    boost::span<Cell> cells() noexcept { return cells_; }
+    boost::span<const Cell> cells() const noexcept { return cells_; }
+
+  private:
+    //! Initial time for query.
+    //! @todo Refactor to use std::chrono
+    time_t init_;
+
+    //! Duration for query, in seconds.
+    //! @todo Refactor to use std::chrono
+    long duration_seconds_;
+
+    //! Variable to return from query.
+    std::string variable_;
+
+    //! Units for output variable.
+    std::string output_units_;
+
+    //! Cells to gather.
+    std::vector<Cell> cells_;
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -178,6 +178,7 @@ ngen_add_test(
         forcing/GridDataSelector_Test.cpp
     LIBRARIES
         NGen::forcing
+        NGen::geojson
 )
 
 ########################## Series Unit Tests
@@ -451,6 +452,7 @@ ngen_add_test(
         forcing/CsvPerFeatureForcingProvider_Test.cpp
         forcing/OptionalWrappedDataProvider_Test.cpp
         forcing/NetCDFPerFeatureDataProvider_Test.cpp
+        forcing/GridDataSelector_Test.cpp
         core/mediator/UnitsHelper_Tests.cpp
         simulation_time/Simulation_Time_Test.cpp
         core/NetworkTests.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -172,6 +172,14 @@ ngen_add_test(
         testbmicppmodel
 )
 
+ngen_add_test(
+    test_gridselector
+    OBJECTS
+        forcing/GridDataSelector_Test.cpp
+    LIBRARIES
+        NGen::forcing
+)
+
 ########################## Series Unit Tests
 ngen_add_test(
     test_mdarray

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -160,9 +160,9 @@ TEST(GridDataSelectorTest, ExtentSelection) {
 
     for (const auto& cell : cells) {
         EXPECT_LE(cell.x, 10);
-        EXPECT_GE(cell.x, 0);
+        EXPECT_GE(cell.x, 5);
         EXPECT_LE(cell.y, 10);
-        EXPECT_GE(cell.y, 0);
+        EXPECT_GE(cell.y, 5);
     }
 }
 
@@ -196,3 +196,6 @@ TEST(GridDataSelectorTest, PointSelection) {
     EXPECT_EQ(cells[1].x, 5);
     EXPECT_EQ(cells[1].y, 5);
 }
+
+// TODO: Add boundary/polygon constructor test
+// TEST(GridDataSelectorTest, PolygonSelection)

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -157,8 +157,7 @@ TEST(GridDataSelectorTest, ExtentSelection) {
     };
 
     const auto cells = provider.get_values(selector, data_access::ReSampleMethod::SUM);
-    ASSERT_GT(cells.size(), 0);
-    EXPECT_EQ(cells.size(), 25);
+    ASSERT_EQ(cells.size(), 25);
 
     for (const auto& cell : cells) {
         EXPECT_LE(cell.x, 10);

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -1,4 +1,3 @@
-#include "JSONGeometry.hpp"
 #include <gtest/gtest.h>
 
 #include <cmath>
@@ -19,7 +18,7 @@ struct TestGridDataProvider
 
     //! Default constructor, defaults to a 10x10 grid with extent [0, 10] in both x and y dimensions. 
     TestGridDataProvider()
-      : TestGridDataProvider(GridSpecification{10, 10, {0, 10, 0, 10}})
+      : TestGridDataProvider(GridSpecification{10, 10, box_t{{0, 0},{10, 10}}})
     {}
 
     boost::span<const std::string> get_available_variable_names() override
@@ -144,7 +143,7 @@ TEST(GridDataSelectorTest, ExtentSelection) {
     GridSpecification grid_spec {
         10, // rows 
         10, // cols
-        {20, 30, 20, 30}
+        /*extent=*/box_t{{20, 20}, {30, 30}}
     };
 
     TestGridDataProvider provider{grid_spec};
@@ -153,7 +152,7 @@ TEST(GridDataSelectorTest, ExtentSelection) {
     GridDataSelector selector{
         TestGridDataProvider::default_selector,
         grid_spec,
-        { 25, 30, 25, 30}
+        box_t{{25, 25}, {30, 30}}
     };
 
     const auto cells = provider.get_values(selector, data_access::ReSampleMethod::SUM);
@@ -174,7 +173,7 @@ TEST(GridDataSelectorTest, PointSelection) {
         10,
         10,
         // Extent around Tuscaloosa county
-        {-87.84068, -87.06574, 33.00338, 33.60983}
+        box_t{{-87.84068, 33.00338}, {-87.06574, 33.60983}}
     };
 
     TestGridDataProvider provider{grid_spec};

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -154,7 +154,6 @@ TEST(GridDataSelectorTest, ExtentSelection) {
     EXPECT_EQ(cells.size(), 25);
 
     for (const auto& cell : cells) {
-        std::cout << "Cell: (" << cell.x << ", " << cell.y << "): " << cell.value << '\n';
         EXPECT_LE(cell.x, 10);
         EXPECT_GE(cell.x, 0);
         EXPECT_LE(cell.y, 10);

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -102,7 +102,7 @@ const SelectorConfig TestGridDataProvider::default_selector = {
 inline Cell make_cell_xy(std::uint64_t x, std::uint64_t y)
 { return { x, y, static_cast<uint64_t>(-1), NAN}; }
 
-inline geojson::coordinate_t make_point(double x, double y)
+inline constexpr geojson::coordinate_t make_point(double x, double y)
 { return { x, y }; }
 
 // Tests for individual cell selection, providing the exact cells
@@ -180,7 +180,7 @@ TEST(GridDataSelectorTest, PointSelection) {
 
     TestGridDataProvider provider{grid_spec};
 
-    const auto coordinates = {
+    constexpr std::array<const geojson::coordinate_t, 2> coordinates = {
         make_point(-87.8, 33.01), // 0, 0
         make_point(-87.4, 33.31) // 5, 5
     };

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <forcing/DataProvider.hpp>
+#include <forcing/GridDataSelector.hpp>
+
+// A fake grid data provider containing a 10x10 uniform grid
+// with x/y indices in [0, 10). Temporal domain is [0, 1 hour).
+struct TestGridDataProvider
+  : public data_access::DataProvider<Cell, GridDataSelector>
+{
+    TestGridDataProvider()
+    {
+        values_.reserve(cols_ * rows_);
+        for (size_t i = 0; i < rows_; ++i) {
+            for (size_t j = 0; j < cols_; ++j) {
+                values_[j + (i * cols_)] = static_cast<double>(i + j);
+            }
+        }
+    }
+
+    boost::span<const std::string> get_available_variable_names() override
+    { return { &variable_, 1 }; }
+
+    long get_data_start_time() override
+    { return 0; }
+
+    long get_data_stop_time() override
+    { return get_data_start_time() + record_duration(); }
+
+    long record_duration() override
+    { return 3600; }
+
+    size_t get_ts_index_for_time(const time_t& epoch_time) override
+    { return -1; }
+
+    Cell get_value(const GridDataSelector& selector, data_access::ReSampleMethod method) override
+    { return {}; };
+
+    std::vector<Cell> get_values(const GridDataSelector& selector, data_access::ReSampleMethod method) override
+    {
+        const auto start = selector.initial_time();
+        const auto end   = selector.initial_time() + selector.duration();
+
+        if (start < get_data_start_time() || start >= get_data_stop_time()) {
+            throw std::out_of_range{"Starting time out of range"};
+        }
+
+        if (end < get_data_start_time() || end >= get_data_stop_time()) {
+            throw std::out_of_range{"Ending time out of range"};
+        }
+
+        const auto scells = selector.cells();
+        std::vector<Cell> result{scells.begin(), scells.end()};
+        
+        for (auto& cell : result) {
+            if (cell.x < 0 || cell.x >= cols_) {
+                throw std::out_of_range{"Column " + std::to_string(cell.x) + " out of range of " + std::to_string(cols_)};
+            }
+
+            if (cell.y < 0 || cell.y >= rows_) {
+                throw std::out_of_range{"Row " + std::to_string(cell.y) + " out of range of " + std::to_string(rows_)};
+            }
+
+            cell.value = values_[cell.x + (cell.y * cols_)];
+        }
+
+        return result;
+    }
+
+  private:
+    static const std::string variable_;
+    size_t cols_ = 10;
+    size_t rows_ = 10;
+    std::vector<double> values_;
+};
+
+const std::string TestGridDataProvider::variable_ = "variable";
+
+// x is column
+// y is row
+inline Cell make_cell_xy(std::uint64_t x, std::uint64_t y)
+{ return { x, y, static_cast<uint64_t>(-1), NAN}; }
+
+TEST(GridDataSelectorTest, Example) {
+    TestGridDataProvider provider{};
+    GridDataSelector selector{
+        "variable",             // variable
+        0,                      // init_time
+        3599,                   // duration
+        "m",                    // units
+        {{                      // cells
+            make_cell_xy(0, 0),
+            make_cell_xy(5, 2),
+            make_cell_xy(9, 9)
+        }}
+    };
+    
+    const auto cells = provider.get_values(selector, data_access::ReSampleMethod::SUM);
+
+    const auto expect_cell = [&cells](std::size_t index, std::uint64_t x, std::uint64_t y)
+    {
+        const auto& cell = cells[index];
+        EXPECT_EQ(cell.x, x);
+        EXPECT_EQ(cell.y, y);
+        EXPECT_EQ(cell.z, static_cast<uint64_t>(-1));
+        EXPECT_EQ(cell.value, static_cast<double>(x + y));
+    };
+    
+    ASSERT_EQ(cells.size(), 3);
+    expect_cell(/*index=*/ 0, /*x=*/ 0, /*y=*/ 0);
+    expect_cell(/*index=*/ 1, /*x=*/ 5, /*y=*/ 2);
+    expect_cell(/*index=*/ 2, /*x=*/ 9, /*y=*/ 9);
+}

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -11,9 +11,7 @@ struct TestGridDataProvider
   : public data_access::DataProvider<Cell, GridDataSelector>
 {
     explicit TestGridDataProvider(GridSpecification spec)
-      : cols_(spec.columns)
-      , rows_(spec.rows)
-      , spec_(spec)
+      : spec_(spec)
     {
         initialize_();
     }
@@ -57,15 +55,15 @@ struct TestGridDataProvider
         std::vector<Cell> result{scells.begin(), scells.end()};
         
         for (auto& cell : result) {
-            if (cell.x < 0 || cell.x >= cols_) {
-                throw std::out_of_range{"Column " + std::to_string(cell.x) + " out of range of " + std::to_string(cols_)};
+            if (cell.x < 0 || cell.x >= spec_.columns) {
+                throw std::out_of_range{"Column " + std::to_string(cell.x) + " out of range of " + std::to_string(spec_.columns)};
             }
 
-            if (cell.y < 0 || cell.y >= rows_) {
-                throw std::out_of_range{"Row " + std::to_string(cell.y) + " out of range of " + std::to_string(rows_)};
+            if (cell.y < 0 || cell.y >= spec_.rows) {
+                throw std::out_of_range{"Row " + std::to_string(cell.y) + " out of range of " + std::to_string(spec_.rows)};
             }
 
-            cell.value = values_[cell.x + (cell.y * cols_)];
+            cell.value = values_[cell.x + (cell.y * spec_.columns)];
         }
 
         return result;
@@ -76,17 +74,15 @@ struct TestGridDataProvider
   private:
 
     void initialize_() noexcept {
-        values_.reserve(cols_ * rows_);
-        for (size_t i = 0; i < rows_; ++i) {
-            for (size_t j = 0; j < cols_; ++j) {
-                values_[j + (i * cols_)] = static_cast<double>(i + j);
+        values_.reserve(spec_.columns * spec_.rows);
+        for (size_t i = 0; i < spec_.rows; ++i) {
+            for (size_t j = 0; j < spec_.columns; ++j) {
+                values_[j + (i * spec_.columns)] = static_cast<double>(i + j);
             }
         }
     }
 
     static const std::string variable_;
-    size_t cols_;
-    size_t rows_;
     GridSpecification spec_;
     std::vector<double> values_;
 };

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -74,10 +74,10 @@ struct TestGridDataProvider
   private:
 
     void initialize_() noexcept {
-        values_.reserve(spec_.columns * spec_.rows);
+        values_.resize(spec_.columns * spec_.rows);
         for (size_t i = 0; i < spec_.rows; ++i) {
             for (size_t j = 0; j < spec_.columns; ++j) {
-                values_[j + (i * spec_.columns)] = static_cast<double>(i + j);
+                values_.at(j + (i * spec_.columns)) = static_cast<double>(i + j);
             }
         }
     }


### PR DESCRIPTION
This PR implements Cell, Point, Boundary, and Bounding Box based constructors for a `GridDataSelector`.

## Additions

- GridDataSelector class
- Cell-based constructor for GridDataSelector
- Extent-based constructor for GridDataSelector
- Point-based constructor for GridDataSelector
- GridDataSelector tests with an example gridded data provider deriving from `DataProvider<Cell, GridDataSelector>`

## TODOs

TODOs are documented alongside code documentation.

## Testing

Unit tests pass locally with GCC 13.2.1 and Clang 17

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
