### PR TITLE
ci: fix macos brew include paths. differ based on arch

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -173,8 +173,8 @@ runs:
         - name: Setup macOS Default Compiler Includes
           if: runner.os == 'macOS'
           run: |
-            echo "C_INCLUDE_PATH=/usr/local/include" >> $GITHUB_ENV
-            echo "CPLUS_INCLUDE_PATH=/usr/local/include" >> $GITHUB_ENV
+            echo "C_INCLUDE_PATH=$(brew --prefix)/include" >> $GITHUB_ENV
+            echo "CPLUS_INCLUDE_PATH=$(brew --prefix)/include" >> $GITHUB_ENV
           shell: bash
 
         - name: Cmake Initialization


### PR DESCRIPTION
Homebrew puts headers files in `/usr/local/include` on x86 and `/opt/homebrew/include` on apple arm. Tests are failing in multiple repos b.c. they cannot find `udunits2.h` when the runner is apple arm. This fixes that issue and generalizes how the include path is determined.