### PR TITLE
Running ngen on CONUS with Routing: Build, Realization Configs, Routing Config, and Documentation

### DIFF
--- a/data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json
+++ b/data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json
@@ -1,0 +1,106 @@
+{
+    "global": {
+        "formulations": [
+            {
+                "name": "bmi_multi",
+                "params": {
+                    "model_type_name": "bmi_multi_noahowp_cfe",
+                    "forcing_file": "",
+                    "init_config": "",
+                    "allow_exceed_end_time": true,
+                    "main_output_variable": "Q_OUT",
+                    "modules": [
+			{
+			    "name": "bmi_c++",
+			    "params": {
+                                "model_type_name": "bmi_c++_sloth",
+                                "library_file": "./extern/sloth/cmake_build/libslothmodel",
+                                "init_config": "/dev/null",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "z",
+                                "uses_forcing_file": false,
+                                "model_params": {
+				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
+				    "sloth_smp(1,double,1,node)": 0.0
+                                }
+			    }
+                        },
+                        {
+                            "name": "bmi_fortran",
+                            "params": {
+                                "model_type_name": "bmi_fortran_noahowp",
+                                "library_file": "./extern/noah-owp-modular/cmake_build/libsurfacebmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/NoahOWP_{{id}}.namelist",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "QINSUR",
+                                "variables_names_map": {
+                                    "PRCPNONC": "atmosphere_water__liquid_equivalent_precipitation_rate",
+                                    "Q2": "atmosphere_air_water~vapor__relative_saturation",
+                                    "SFCTMP": "land_surface_air__temperature",
+                                    "UU": "land_surface_wind__x_component_of_velocity",
+                                    "VV": "land_surface_wind__y_component_of_velocity",
+                                    "LWDN": "land_surface_radiation~incoming~longwave__energy_flux",
+                                    "SOLDN": "land_surface_radiation~incoming~shortwave__energy_flux",
+                                    "SFCPRS": "land_surface_air__pressure"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_pet",
+                                "library_file": "./extern/evapotranspiration/evapotranspiration/cmake_build/libpetbmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/PET_{{id}}.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "water_potential_evaporation_flux",
+                                "registration_function": "register_bmi_pet",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "potential_evapotranspiration"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_cfe",
+                                "library_file": "./extern/cfe/cmake_build/libcfebmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/CFE_{{id}}.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "Q_OUT",
+                                "registration_function": "register_bmi_cfe",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "potential_evapotranspiration",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        }
+                    ],
+                    "uses_forcing_file": false
+                }
+            }
+        ],
+        "forcing": {
+            "path": "./forcing/NextGen_forcing_2016010100.nc",
+            "provider": "NetCDF"
+        }
+    },
+    "time": {
+        "start_time": "2016-01-01 00:00:00",
+        "end_time": "2016-01-10 23:00:00",
+        "output_interval": 3600
+    },
+    "output_root": "./output_dir/",
+    "routing": {
+        "t_route_config_file_with_path": "./data/baseline/routing_config_CONUS.yaml"
+    }
+}

--- a/data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe_trt.json
+++ b/data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe_trt.json
@@ -1,0 +1,144 @@
+{
+    "global": {
+        "formulations": [
+            {
+                "name": "bmi_multi",
+                "params": {
+                    "model_type_name": "bmi_multi_noahowp_cfe",
+                    "forcing_file": "",
+                    "init_config": "",
+                    "allow_exceed_end_time": true,
+                    "main_output_variable": "Q_OUT",
+                    "modules": [
+			{
+			    "name": "bmi_c++",
+			    "params": {
+                                "model_type_name": "bmi_c++_sloth",
+                                "library_file": "./extern/sloth/cmake_build/libslothmodel",
+                                "init_config": "/dev/null",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "z",
+                                "uses_forcing_file": false,
+                                "model_params": {
+                                    "soil_moisture_wetting_fronts(1,double,1,node)": 0.0,
+                                    "soil_thickness_layered(1,double,1,node)": 0.0,
+                                    "soil_depth_wetting_fronts(1,double,1,node)": 0.0,
+                                    "num_wetting_fronts(1,int,1,node)": 1.0,
+                                    "Qb_topmodel(1,double,1,node)": 0.0,
+                                    "Qv_topmodel(1,double,1,node)": 0.0,
+                                    "global_deficit(1,double,1,node)": 0.0,
+                                    "sloth_SOIL_STORAGE(1,double,m,node)": 0.8,
+                                    "sloth_SOIL_STORAGE_CHANGE(1,double,m,node)": -0.000472,
+                                    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
+                                    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
+                                    "sloth_smp(1,double,1,node)": 0.1
+                                }
+			    }
+                        },
+                        {
+                            "name": "bmi_fortran",
+                            "params": {
+                                "model_type_name": "bmi_fortran_noahowp",
+                                "library_file": "./extern/noah-owp-modular/cmake_build/libsurfacebmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/NoahOWP_{{id}}.namelist",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "QINSUR",
+                                "variables_names_map": {
+                                    "PRCPNONC": "atmosphere_water__liquid_equivalent_precipitation_rate",
+                                    "Q2": "atmosphere_air_water~vapor__relative_saturation",
+                                    "SFCTMP": "land_surface_air__temperature",
+                                    "UU": "land_surface_wind__x_component_of_velocity",
+                                    "VV": "land_surface_wind__y_component_of_velocity",
+                                    "LWDN": "land_surface_radiation~incoming~longwave__energy_flux",
+                                    "SOLDN": "land_surface_radiation~incoming~shortwave__energy_flux",
+                                    "SFCPRS": "land_surface_air__pressure"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_pet",
+                                "library_file": "./extern/evapotranspiration/evapotranspiration/cmake_build/libpetbmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/PET_{{id}}.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "water_potential_evaporation_flux",
+                                "registration_function": "register_bmi_pet",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "potential_evapotranspiration"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c++",
+                            "params": {
+                                "model_type_name": "bmi_smp",
+                                "library_file": "./extern/SoilMoistureProfiles/SoilMoistureProfiles/cmake_build/libsmpbmi",
+                                "init_config": "./conus_smp_configs/SoilMoistureProfile_{{id}}.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "soil_water_table",
+                                "variables_names_map" : {
+                                    "soil_storage" : "sloth_SOIL_STORAGE",
+                                    "soil_storage_change" : "sloth_SOIL_STORAGE_CHANGE"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c++",
+                            "params": {
+                                "model_type_name": "bmi_sft",
+                                "library_file": "./extern/SoilFreezeThaw/SoilFreezeThaw/cmake_build/libsftbmi",
+                                "init_config": "./conus_sft_configs/SoilFreezeThaw_{{id}}.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "num_cells",
+                                "variables_names_map" : {
+                                    "ground_temperature" : "TGS"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_cfe",
+                                "library_file": "./extern/cfe/cmake_build/libcfebmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/CFE_{{id}}.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "Q_OUT",
+                                "registration_function": "register_bmi_cfe",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "potential_evapotranspiration",
+                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
+                                    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+                                    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
+                                    "soil_moisture_profile" : "sloth_smp"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        }
+                    ],
+                    "uses_forcing_file": false
+                }
+            }
+        ],
+        "forcing": {
+            "path": "./forcing/NextGen_forcing_2016010100.nc",
+            "provider": "NetCDF"
+        }
+    },
+    "time": {
+        "start_time": "2016-01-01 00:00:00",
+        "end_time": "2016-01-10 23:00:00",
+        "output_interval": 3600
+    },
+    "output_root": "./output_dir/",
+    "routing": {
+        "t_route_config_file_with_path": "./data/baseline/routing_config_CONUS.yaml"
+    }
+}

--- a/data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_trt.json
+++ b/data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_trt.json
@@ -1,0 +1,70 @@
+{
+    "global": {
+        "formulations": [
+            {
+                "name": "bmi_multi",
+                "params": {
+                    "model_type_name": "bmi_multi_noahowp_cfe",
+                    "forcing_file": "",
+                    "init_config": "",
+                    "allow_exceed_end_time": true,
+                    "main_output_variable": "QINSUR",
+                    "modules": [
+			{
+			    "name": "bmi_c++",
+			    "params": {
+                                "model_type_name": "bmi_c++_sloth",
+                                "library_file": "./extern/sloth/cmake_build/libslothmodel",
+                                "init_config": "/dev/null",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "z",
+                                "uses_forcing_file": false,
+                                "model_params": {
+				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
+				    "sloth_smp(1,double,1,node)": 0.0
+                                }
+			    }
+                        },
+                        {
+                            "name": "bmi_fortran",
+                            "params": {
+                                "model_type_name": "bmi_fortran_noahowp",
+                                "library_file": "./extern/noah-owp-modular/cmake_build/libsurfacebmi",
+                                "forcing_file": "",
+                                "init_config": "./conus_config/NoahOWP_{{id}}.namelist",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "QINSUR",
+                                "variables_names_map": {
+                                    "PRCPNONC": "atmosphere_water__liquid_equivalent_precipitation_rate",
+                                    "Q2": "atmosphere_air_water~vapor__relative_saturation",
+                                    "SFCTMP": "land_surface_air__temperature",
+                                    "UU": "land_surface_wind__x_component_of_velocity",
+                                    "VV": "land_surface_wind__y_component_of_velocity",
+                                    "LWDN": "land_surface_radiation~incoming~longwave__energy_flux",
+                                    "SOLDN": "land_surface_radiation~incoming~shortwave__energy_flux",
+                                    "SFCPRS": "land_surface_air__pressure"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        }
+                    ],
+                    "uses_forcing_file": false
+                }
+            }
+        ],
+        "forcing": {
+            "path": "./forcing/NextGen_forcing_2016010100.nc",
+            "provider": "NetCDF"
+        }
+    },
+    "time": {
+        "start_time": "2016-01-01 00:00:00",
+        "end_time": "2016-01-10 23:00:00",
+        "output_interval": 3600
+    },
+    "output_root": "./output_dir/",
+    "routing": {
+        "t_route_config_file_with_path": "./data/baseline/routing_config_CONUS.yaml"
+    }
+}

--- a/data/baseline/routing_config_CONUS.yaml
+++ b/data/baseline/routing_config_CONUS.yaml
@@ -1,0 +1,79 @@
+#--------------------------------------------------------------------------------
+log_parameters:
+  #----------
+  showtiming: True
+  log_level : DEBUG
+#--------------------------------------------------------------------------------
+network_topology_parameters:
+  #----------
+  supernetwork_parameters:
+    #----------
+    network_type: HYFeaturesNetwork 
+    geo_file_path: ./hydrofabric/conus.gpkg
+    columns: 
+      key: 'id'
+      downstream: 'toid'
+      dx : 'length_m'
+      n : 'n'
+      ncc : 'nCC'
+      s0 : 'So'
+      bw : 'BtmWdth'
+      waterbody : 'rl_NHDWaterbodyComID'
+      gages : 'rl_gages'
+      tw : 'TopWdth'
+      twcc : 'TopWdthCC'
+      musk : 'MusK'
+      musx : 'MusX'
+      cs : 'ChSlp'
+      alt: 'alt'
+      mainstem: 'mainstem'
+    #duplicate_wb_segments: None
+  waterbody_parameters:
+      #----------
+      break_network_at_waterbodies: False 
+#--------------------------------------------------------------------------------
+compute_parameters:
+  #----------
+  parallel_compute_method: by-subnetwork-jit-clustered #serial 
+  compute_kernel         : V02-structured
+  assume_short_ts        : True
+  subnetwork_target_size : 10000
+  cpu_pool               : 36
+  restart_parameters:
+    #----------
+    start_datetime: "2016-01-01_00:00:00"
+  forcing_parameters:
+    #----------
+    qts_subdivisions            : 12
+    dt                          : 300 # [sec]
+    qlat_input_folder           : ./output_dir/
+    qlat_file_pattern_filter    : "nex-*"
+    binary_nexus_file_folder    : #./ #NOTE: If memory issues arise while preprocessing forcing data, use this to create hourly binary files for forcing data.
+    nts                         : 2880 #288 for 1day
+    max_loop_size               : 240 # [hr]  
+  data_assimilation_parameters:
+    #----------
+    usgs_timeslices_folder   : ./usgs_TimeSlice/
+    usace_timeslices_folder  : #usace_TimeSlice/
+    timeslice_lookback_hours : #48 
+    qc_threshold             : #1
+    streamflow_da:
+      #----------
+      streamflow_nudging: False
+    reservoir_da:
+      #----------
+      reservoir_persistence_da:
+        #----------
+        reservoir_persistence_usgs : False
+        reservoir_persistence_usace: False
+      reservoir_rfc_da:
+        #----------
+        reservoir_rfc_forecasts: False
+#--------------------------------------------------------------------------------
+output_parameters:
+  #----------
+  stream_output : 
+    stream_output_directory: ./stream_output_dir/
+    stream_output_time: 1 #[hr]
+    stream_output_type: '.nc' #please select only between netcdf '.nc' or '.csv' or '.pkl'
+    stream_output_internal_frequency: 60 #[min] it should be order of 5 minutes. For instance if you want to output every hour put 60 

--- a/doc/NextGen_ON_CONUS.md
+++ b/doc/NextGen_ON_CONUS.md
@@ -191,31 +191,31 @@ To be added
 
 # Run Computation with Routing
 
-To run computation on CONUS with routing, we need to build the executable with routing option turned on. This can be done using the build script displayed in the [Build the Executable](#build-the-executable) and set `-DNGEN_WITH_ROUTING:BOOL=ON`. Make sure that Python is also on, and you can run the script to build the `ngen` executable.
+To run computation on CONUS with routing, we need to build the executable with the routing option turned on. This can be done using the build script displayed in the [Build the Executable](#build-the-executable) section, and ensure both `-DNGEN_WITH_PYTHON:BOOL=ON` and `-DNGEN_WITH_ROUTING:BOOL=ON` are enabled. Then, you can run the script to build the `ngen` executable.
 
-You also need to build the `t-route` submodule. First, as the automatically downloaded `t-route` is out of date, to get the latest version, you need to remove the old `t-route` and run `git clone https://github.com/NOAA-OWP/t-route` in the `extern` directory. For building `t-route` in general, we refer user to the documentation [PYTHON_ROUTING.md](PYTHON_ROUTING.md) for essential details. We just want to add some additional discussion here to make the process easier. Note that there are more than one ways to build the `t-route`. Do `cd t-route`, then run:
+You also need to build the `t-route` submodule. First, as the vendored `t-route` submodule is out of date, to get the latest version, you need to remove the old `t-route` and run `git clone https://github.com/NOAA-OWP/t-route` in the `extern` directory. For building `t-route` in general, we refer to the documentation [PYTHON_ROUTING.md](PYTHON_ROUTING.md) for essential details. We just want to add some additional discussion here to make the process easier. Note that there is more than one way to build `t-route`. Do `cd t-route`, then run:
 
 ```
 FC=mpif90 NETCDFINC=<path-to-netcdf-include-directory> ./compiler.sh
 ```
 
-This will let you to use the NetCDF library that you want to build `t-route`. Alternatively, you can edit the `compiler.sh` file, note these comment lines in the script:
+This will let you use the NetCDF library that you want to build `t-route`. Alternatively, you can edit the `compiler.sh` file, note these comment lines in the script:
 
 ```
 #if you have custom dynamic library paths, uncomment below and export them
 #export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
 ```
 
-You can uncomment the second line above and that put your NetCDF library in the path. In addition, change this line:
+You can uncomment the second line above and put your NetCDF library in the path. In addition, change this line:
 
 ```
-    export NETCDFINC=/usr/include/openmpi-x86_64/
+export NETCDFINC=/usr/include/openmpi-x86_64/
 ```
 
 to the path to your NetCDF include directory, i.e.
 
 ```
-    export NETCDFINC=<path to your NetCDF include directory>
+export NETCDFINC=<path to your NetCDF include directory>
 ```
 
 Then, run the command:
@@ -224,7 +224,7 @@ Then, run the command:
 FC=mpif90 ./compiler.sh
 ```
 
-After successfully building the `t-route`, you can run `ngen` with routing. Note that we have several realization configuration files and the `routing_config_CONUS.yaml` file for running `ngen` with routing. The realization configuration file and `routing_config_CONUS.yaml` specify where the input and output files are. For routing, we assume the existence of a `stream_output_dir` directory for writing output files. You need to do `mkdir stream_output_dir` before running `ngen`. With that, we can run an example with the command:
+After successfully building `t-route`, you can run `ngen` with routing. Note that we have several realization configuration files and the `routing_config_CONUS.yaml` file for running `ngen` with routing. The realization configuration file and `routing_config_CONUS.yaml` specify where the input and output files are. For routing, we assume the existence of a `stream_output_dir` directory for writing output files. You need to do `mkdir stream_output_dir` before running `ngen`. With that, we can run an example with the command:
 
 ```
 mpirun -n 32 ./cmake_build_mpi/ngen ./hydrofabric/conus.gpkg '' ./hydrofabric/conus.gpkg '' data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json conus_partition_32.json
@@ -240,5 +240,5 @@ In the following table, we display the CPU timing information for a few realizat
 | conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json | 32 | 1069.8 | 4606.3 | 4474.1 | 10150.2 |
 | conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe_trt.json | 32 | 2142.0 | 5632.4 | 4510.3 | 12284.7 |
 
-* trt - abrevitation for t-route
-* For all other abreviations, see [Resource Usage](#resource-usage).
+* trt - abbreviation for t-route
+* For all other abbreviations, see [Resource Usage](#resource-usage).

--- a/doc/NextGen_ON_CONUS.md
+++ b/doc/NextGen_ON_CONUS.md
@@ -166,16 +166,17 @@ Be aware that the above commands will generate over a million output files assoc
 
 # Resource Usage
 
-The following table lists the CPU wall clock ime used for various realization configurations running 10 day simulation time. Note that the `Initialization Time` may potentially be affected by system loads at the time of job start.
-| Realization | Number of CPUs | Initialization Time (s) | Computation Time (s) |
-| ------------- | :-----: | :--------: | :--------: |
-| conus_bmi_multi_realization_config_w_sloth.json | 32 | 2618.6 | 737.4 |
-| conus_bmi_multi_realization_config_w_sloth_noah.json | 32 | 1360.1 | 2143.9 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet.json | 32 | 12236.7 | 2118.6 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe.json | 32 | 1214.9 | 4069.2 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp.json | 32 | 1453.4 | 3087.0 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft.json | 32 | 3245.7 | 3808.1 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe.json | 32 | 1354.7 | 5283.1 |
+The following table lists the CPU wall clock ime used for various realization configurations running 10 day simulation time. The timing values reported in the table are from single run, not from average. Note in particular that the `Initialization Time` may be significantly affected by system loads at the time of job start.
+
+| Realization | Number of CPUs | Initialization Time (s) | Computation Time (s) | Total Time (s) |
+| ------------- | :-----: | :--------: | :--------: | :--------: |
+| conus_bmi_multi_realization_config_w_sloth.json | 32 | 2618.6 | 737.4 | 3356.0 |
+| conus_bmi_multi_realization_config_w_sloth_noah.json | 32 | 1360.1 | 2143.9 | 3504.0 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet.json | 32 | 3204.0 | 2106.5 | 5310.5 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe.json | 32 | 1214.9 | 4069.2 | 5284.1 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp.json | 32 | 1453.4 | 3087.0 | 4540.4 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft.json | 32 | 3245.7 | 3808.1 | 7053.8 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe.json | 32 | 1354.7 | 5283.1 | 6637.8 |
 
 The abreviation used for submodule names in the table:
 * noah - noah-owp-modular
@@ -232,11 +233,12 @@ mpirun -n 32 ./cmake_build_mpi/ngen ./hydrofabric/conus.gpkg '' ./hydrofabric/co
 If your run is successful, you should see the directory `stream_output_dir` populated with output files in NetCDF format with each file corresponding to each hour between 2016-01-01 to 2016-01-10.
 
 In the following table, we display the CPU timing information for a few realizations that we tested:
-| Realization | Number of CPUs | Initialization Time (s) | Ngen Computation Time (s) | Routing Computation Time (s) |
-| ------------- | :-----: | :--------: | :--------: | :--------: |
-| conus_bmi_multi_realization_config_w_sloth_noah_trt.json | 32 | 958.1 | 2288.4 | 3694.1 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json | 32 | 1069.8 | 4606.3 | 4474.1 |
-| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe_trt.json | 32 | 2142.0 | 5632.4 | 4510.3 |
+
+| Realization | Number of CPUs | Initialization Time (s) | Ngen Computation Time (s) | Routing Computation Time (s) | Total Time (s) |
+| ------------- | :-----: | :--------: | :--------: | :--------: | :--------: |
+| conus_bmi_multi_realization_config_w_sloth_noah_trt.json | 32 | 958.1 | 2288.4 | 3694.1 | 6940.6 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json | 32 | 1069.8 | 4606.3 | 4474.1 | 10150.2 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe_trt.json | 32 | 2142.0 | 5632.4 | 4510.3 | 12284.7 |
 
 * trt - abrevitation for t-route
 * For all other abreviations, see [Resource Usage](#resource-usage).

--- a/doc/NextGen_ON_CONUS.md
+++ b/doc/NextGen_ON_CONUS.md
@@ -11,6 +11,7 @@ This documentation provides instructions on all neccessary steps and components 
 * [Prepare the Input Data](#prepare-the-input-data)
 * [Build the Realization Configurations](#build-the-realization-configurations)
 * [Run Computations with submodules](#run-computations-with-submodules)
+* [Resource Usage](#resource-usage)
 * [Run Computation with Topmodel](#run-computation-with-topmodel)
 * [Run Computation with Routing](#run-computation-with-routing)
 
@@ -104,13 +105,13 @@ This will build an executable in the `cmake_build_mpi` directory named `ngen` an
 
 # CONUS Hydrofabric
 
-The CONUS hydrofabric is downloaded from [here](https://www.lynker-spatial.com/#v20.1/). The file name under the list is `conus.gpkg`. Note that since the data there is continually evolving, a newer version may be available in the future. When using a newer version, be mindful that the corresponding initial configuration file generation and validation for all submodules at CONUS scale is necessary, which may be a non-trivial process due to the sheer size of the spatial scale.
+The CONUS hydrofabric is downloaded from [here](https://www.lynker-spatial.com/#hydrofabric/v20.1/). The file name under the list is `conus.gpkg`. Note that since the data there is continually evolving, a newer version may be available in the future. When using a newer version, be mindful that the corresponding initial configuration file generation and validation for all submodules at CONUS scale is necessary, which may be a non-trivial process due to the sheer size of the spatial scale.
 
 As the file is fairly large, it is worth some consideration to store it in a proper place, then simply build a symbolic link in the `ngen` home directory, thus named `./hydrofabric/conus.gpkg`. Note the easiest way to create the symbolic link is to create a `hydrofabric` directory and then create a link to that directory.
 
 # Generate Partition For Parallel Computation
 
-For parallel computation using MPI on hydrofabric, a [partition generate tool](Distributed_Processing.md) is used to partition the hydrofabric features ids into a number of partitions equal to the number of MPI processing CPU cores. To generate the partition file, run the following command:
+For parallel computation using MPI on hydrofabric, a [partition generate tool](DISTRIBUTED_PROCESSING.md#partitioning-config-generator) is used to partition the hydrofabric features ids into a number of partitions equal to the number of MPI processing CPU cores. To generate the partition file, run the following command:
 
 ```
 ./cmake-build_mpi/partitionGenerator ./hydrofabric/conus.gpkg ./hydrofabric/conus.gpkg ./partition_config_32.json 32 '' ''
@@ -119,9 +120,7 @@ For parallel computation using MPI on hydrofabric, a [partition generate tool](D
 In the command above, `conus.gpkg` is the NextGen hydrofabric version 2.01 for CONUS, `partition_config_32.json` is the partition file that contains all features ids and their interconnected network information. The number `32` is intended number of processing cores for running parallel build `ngen` using MPI. The last two empty strings, as indicated by `''`, indicate there is no subsetting, i.e., we intend to run the whole CONUS hydrofabric.
 
 # Prepare the Input Data
-
 Input data includes the forcing data and initial parameter data for various submodules. These depend on what best suits the user's need. For our case, as of this documentation, beside forcing data, which can be accessed at `./forcing/NextGen_forcing_2016010100.nc` using the symbolic link scheme, we also generated initial input data for various submodules `noah-owp-modular`, `PET`, `CFE`, `SoilMoistureProfiles (SMP)`, `SoilFreezeThaw (SFT)`. The first three are located in `./conus_config/`, the SMP initial configs are located in `./conus_smp_configs/` and the SFT initial configs are located in `./conus_sft_configs/`.
-
 For code used to generate the initial config files for the various modules, the interested users are directed to this [web location](https://github.com/NOAA-OWP/ngen-cal/tree/master/python/ngen_config_gen). 
 
 The users are warned that since the simulated region is large, some of the initial config parameters values for some catchments may be unsuitable and cause the `ngen` execution to stop due to errors. Usually, in such cases, either `ngen` or the submodule itself may provide some hint as to the catchment ids or the location of the code that caused the error. Users may follow these hints to figure out as to which initial input parameter or parameters are initialized with inappropriate values. In the case of SFT, an initial value of `smcmax=1.0` would be too large. In the case of SMP, an initial value of `b=0.01` would be too small, for example.
@@ -161,9 +160,29 @@ For an example taking into account more realistic contributions, you can try:
 mpirun -n 32 ./cmake_build_mpi/ngen ./hydrofabric/conus.gpkg '' ./hydrofabric/conus.gpkg '' data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe.json conus_partition_32.json
 ```
 
-where `ngen` is the executable we build in the [Building the Executable](#Building the Executable) section. All other terms have been discussed above in details. With the current existing realization config files, the above jobs run 10 days simulation time on CONUS scale.
+where `ngen` is the executable we build in the [Building the Executable](#build-the-executable) section. All other terms have been discussed above in details. With the current existing realization config files, the above jobs run 10 days simulation time on CONUS scale.
 
 Be aware that the above commands will generate over a million output files associated with catchment and nexus ids. In the realization config files used above, we have specified a directory `./output_dir/` to store these files. If you `cd` to `./output_dir` and issue a `ls` command, it will be significantly slower than usual to list all the file names. You can choose a different output file directory name than `./output_dir/` by modifying the directory name in the realization configuration file if you prefer. Note that you need to create the output file directory before running the executable.
+
+# Resource Usage
+
+The following table lists the CPU wall clock ime used for various realization configurations running 10 day simulation time. Note that the `Initialization Time` may potentially be affected by system loads at the time of job start.
+| Realization | Number of CPUs | Initialization Time (s) | Computation Time (s) |
+| ------------- | :-----: | :--------: | :--------: |
+| conus_bmi_multi_realization_config_w_sloth.json | 32 | 2618.6 | 737.4 |
+| conus_bmi_multi_realization_config_w_sloth_noah.json | 32 | 1360.1 | 2143.9 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet.json | 32 | 12236.7 | 2118.6 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe.json | 32 | 1214.9 | 4069.2 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp.json | 32 | 1453.4 | 3087.0 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft.json | 32 | 3245.7 | 3808.1 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe.json | 32 | 1354.7 | 5283.1 |
+
+The abreviation used for submodule names in the table:
+* noah - noah-owp-modular
+* pet - potential evapotranspiration
+* cfe - Conceptual functional equivalence
+* smp - SoilMoistureProfiles
+* sft - SoilFreezeThaw 
 
 # Run Computation with Topmodel
 
@@ -171,4 +190,53 @@ To be added
 
 # Run Computation with Routing
 
-To be added
+To run computation on CONUS with routing, we need to build the executable with routing option turned on. This can be done using the build script displayed in the [Build the Executable](#build-the-executable) and set `-DNGEN_WITH_ROUTING:BOOL=ON`. Make sure that Python is also on, and you can run the script to build the `ngen` executable.
+
+You also need to build the `t-route` submodule. First, as the automatically downloaded `t-route` is out of date, to get the latest version, you need to remove the old `t-route` and run `git clone https://github.com/NOAA-OWP/t-route` in the `extern` directory. For building `t-route` in general, we refer user to the documentation [PYTHON_ROUTING.md](PYTHON_ROUTING.md) for essential details. We just want to add some additional discussion here to make the process easier. Note that there are more than one ways to build the `t-route`. Do `cd t-route`, then run:
+
+```
+FC=mpif90 NETCDFINC=<path-to-netcdf-include-directory> ./compiler.sh
+```
+
+This will let you to use the NetCDF library that you want to build `t-route`. Alternatively, you can edit the `compiler.sh` file, note these comment lines in the script:
+
+```
+#if you have custom dynamic library paths, uncomment below and export them
+#export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
+```
+
+You can uncomment the second line above and that put your NetCDF library in the path. In addition, change this line:
+
+```
+    export NETCDFINC=/usr/include/openmpi-x86_64/
+```
+
+to the path to your NetCDF include directory, i.e.
+
+```
+    export NETCDFINC=<path to your NetCDF include directory>
+```
+
+Then, run the command:
+
+```
+FC=mpif90 ./compiler.sh
+```
+
+After successfully building the `t-route`, you can run `ngen` with routing. Note that we have several realization configuration files and the `routing_config_CONUS.yaml` file for running `ngen` with routing. The realization configuration file and `routing_config_CONUS.yaml` specify where the input and output files are. For routing, we assume the existence of a `stream_output_dir` directory for writing output files. You need to do `mkdir stream_output_dir` before running `ngen`. With that, we can run an example with the command:
+
+```
+mpirun -n 32 ./cmake_build_mpi/ngen ./hydrofabric/conus.gpkg '' ./hydrofabric/conus.gpkg '' data/baseline/conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json conus_partition_32.json
+```
+
+If your run is successful, you should see the directory `stream_output_dir` populated with output files in NetCDF format with each file corresponding to each hour between 2016-01-01 to 2016-01-10.
+
+In the following table, we display the CPU timing information for a few realizations that we tested:
+| Realization | Number of CPUs | Initialization Time (s) | Ngen Computation Time (s) | Routing Computation Time (s) |
+| ------------- | :-----: | :--------: | :--------: | :--------: |
+| conus_bmi_multi_realization_config_w_sloth_noah_trt.json | 32 | 958.1 | 2288.4 | 3694.1 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_cfe_trt.json | 32 | 1069.8 | 4606.3 | 4474.1 |
+| conus_bmi_multi_realization_config_w_sloth_noah_pet_smp_sft_cfe_trt.json | 32 | 2142.0 | 5632.4 | 4510.3 |
+
+* trt - abrevitation for t-route
+* For all other abreviations, see [Resource Usage](#resource-usage).


### PR DESCRIPTION
This PR adds several realization config files and the routing config file for running ngen with routing on CONUS. It also provides specific documentation on how to build and run MPI jobs with routing in ngen framework,

## Additions

Realization config files for runing routing after noah-owp-modular, running routing after noah+pet+cfe, running routing 
after noah+pet+smp+sft+cfe, all on CONUS.

Also the configuration file for running routing on CONUS: routing_config_CONUS.yaml.

Updated documentation.

## Removals

-

## Changes

-

## Testing

Running ngen tests with all 3 realization configs.

## Screenshots


## Notes

This PR should be merged after PR#775 and PR#794. Although no real conflict, it is better for understanding the construction of the realization configs and the documentation.

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [x ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [x ] New functions are documented (with a description, list of inputs, and expected output)
- [x ] Placeholder code is flagged / future todos are captured in comments
- [x ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
