### PR TITLE
Delete defunct DataSelector classes

### DIFF
--- a/include/forcing/DataProviderSelectors.hpp
+++ b/include/forcing/DataProviderSelectors.hpp
@@ -3,12 +3,6 @@
 
 #include <string>
 
-/**  
- * @brief This class is intended to be the virtual base for all data selectors used with the 
- * DataProvider API
- * 
- */
-
 class CatchmentAggrDataSelector
 {
     public:
@@ -120,74 +114,5 @@ class CatchmentAggrDataSelector
     std::string output_units; //!< required units for the result to be return in
     std::string id_str; //< the catchment to access data for
 };
-
-
-#if !defined(__APPLE__) && !defined(__llvm__) && defined(__GNUC__) && __GNUC__ < 8
-// Enable a workaround for old GCC versions (but not Clang or Apple's fake-GCC that's actually Clang)
-#define NGEN_SELECTOR_CAST
-#endif
-
-/**
- * @brief This a data selector intended for use with CSV data
- * 
- */
-
-class CSVDataSelector : public CatchmentAggrDataSelector
-{
-    public:
-
-    CSVDataSelector(std::string var, time_t start, long dur, std::string units) : 
-        CatchmentAggrDataSelector(std::string(), var, start, dur, units)
-    {}
-
-    #if defined(NGEN_SELECTOR_CAST)
-    operator const CatchmentAggrDataSelector&() const { return *this; }
-    #endif
-
-    private:
-};
-
-class BMIDataSelector : public CatchmentAggrDataSelector
-{
-    public:
-
-    BMIDataSelector(std::string var, time_t start, long dur, std::string units) : 
-        CatchmentAggrDataSelector(std::string(), var, start, dur, units)
-    {}
-
-    #if defined(NGEN_SELECTOR_CAST)
-    operator const CatchmentAggrDataSelector&() const { return *this; }
-    #endif
-
-    private:
-};
-
-#ifdef NETCDF_ACTIVE
-/**
- * @brief This is the data selector intended for use with netcdf providers
- * 
- */
-
-class NetCDFDataSelector : public CatchmentAggrDataSelector
-{
-    public:
-
-    NetCDFDataSelector(std::string id) : CatchmentAggrDataSelector(id,std::string(),0,0,std::string()) {}
-    NetCDFDataSelector(const char* id) : CatchmentAggrDataSelector(std::string(id),std::string(),0,0,std::string()) {}
-    NetCDFDataSelector(std::string id, std::string var, time_t start, long dur, std::string units) :
-        CatchmentAggrDataSelector(id, var, start, dur, units)
-    {
-        
-    }
-
-    #if defined(NGEN_SELECTOR_CAST)
-    operator const CatchmentAggrDataSelector&() const { return *this; }
-    #endif
-
-    private: 
-};
-#endif // NETCDF_ACTIVE
-
-#undef NGEN_SELECTOR_CAST
 
 #endif

--- a/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
+++ b/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
@@ -94,24 +94,24 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataRead)
     time_t t = begin+(i*3600);
     std::cerr << std::ctime(&t) << std::endl;
 
-    current_precipitation = Forcing_Object->get_value(CSVDataSelector(CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 7.9999999999999996e-07, 0.00000005);
 
-    double temp_k = Forcing_Object->get_value(CSVDataSelector(CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, ""), data_access::MEAN);
+    double temp_k = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, ""), data_access::MEAN);
 
     EXPECT_NEAR(temp_k, 286.9, 0.00001);
 
     int current_epoch;
 
     i = 387;
-    current_precipitation = Forcing_Object->get_value(CSVDataSelector(CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 6.9999999999999996e-07, 0.00000005);
 
     //Check exceeding the forcing range to retrieve the last forcing precipation rate
     i = 388;
-    current_precipitation = Forcing_Object->get_value(CSVDataSelector(CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 6.9999999999999996e-07, 0.00000005);
 }
@@ -127,18 +127,18 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataReadAltFormat)
     time_t t = begin+(i*3600);
     std::cerr << std::ctime(&t) << std::endl;
 
-    current_precipitation = Forcing_Object_2->get_value(CSVDataSelector(CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 0.00032685, 0.00000001);
 
-    double temp_k = Forcing_Object_2->get_value(CSVDataSelector(CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, ""), data_access::MEAN);
+    double temp_k = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, ""), data_access::MEAN);
 
     EXPECT_NEAR(temp_k, 265.77, 0.00001);
 
     int current_epoch;
 
     i = 34;
-    current_precipitation = Forcing_Object_2->get_value(CSVDataSelector(CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 0.00013539, 0.00000001);
 
@@ -156,11 +156,11 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataUnitConversion)
     time_t t = begin+(i*3600);
     std::cerr << std::ctime(&t) << std::endl;
 
-    current_precipitation = Forcing_Object->get_value(CSVDataSelector(CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 7.9999999999999996e-07, 0.00000005);
 
-    double temp_f = Forcing_Object->get_value(CSVDataSelector(CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, "degF"), data_access::MEAN);
+    double temp_f = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, "degF"), data_access::MEAN);
 
     EXPECT_NEAR(temp_f, 56.749989014, 0.00001);
 
@@ -199,12 +199,12 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingUnitHeaderParsing)
         const auto expected_out_units = std::get<2>(*ite);
 
         const double in_value = this->Forcing_Object_3->get_value(
-            CSVDataSelector(expected_name, t, 3600, expected_in_units),
+            CatchmentAggrDataSelector("", expected_name, t, 3600, expected_in_units),
             data_access::SUM
         );
     
         const double out_value = this->Forcing_Object_3->get_value(
-            CSVDataSelector(expected_name, t, 3600, expected_out_units),
+            CatchmentAggrDataSelector("", expected_name, t, 3600, expected_out_units),
             data_access::SUM
         );
 

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -89,7 +89,7 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
     //std::cout << "Checking values in catchment "<<ids[0]<<" at time "<<start_time<<" with duration "<<duration<<"..."<<std::endl;
 
     // read exactly one time step correctly aligned
-    double val1 = nc_provider->get_value(NetCDFDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+    double val1 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
 
     //double tol = 0.00000612;
     double tol = 0.00002;
@@ -97,18 +97,18 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
     EXPECT_NEAR(val1, 285.8, tol);
 
     // read 1/2 of a time step correctly aligned
-    double val2 = nc_provider->get_value(NetCDFDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration / 2, "K"), data_access::MEAN);
+    double val2 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration / 2, "K"), data_access::MEAN);
 
     EXPECT_NEAR(val2, 285.8, tol);
 
     // read 4 time steps correctly aligned
-    double val3 = nc_provider->get_value(NetCDFDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration * 4, "K"), data_access::MEAN);
+    double val3 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration * 4, "K"), data_access::MEAN);
 
     EXPECT_NEAR(val3, 284.95, tol);
 
     // read exactly one time step correctly aligned but with a incorrect variable
     EXPECT_THROW(
-        double val4 = nc_provider->get_value(NetCDFDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);, 
+        double val4 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);, 
         std::runtime_error);
     
 }


### PR DESCRIPTION
The uses of these classes were deleted in commit acea24d0ef1acdac036e29ba1dd1032bef4755d0 in 2022. Clear them out so they don't distract from on-going work

## Removals

- Classes `{BMI,CSV,NetCDF}DataSelector` that were all empty subclasses of `CatchmentAggrDataSelector`

## Changes

- `{CSV,NetCDF}DataProvider` tests modified to use base class instead of specific derived classes

## Testing

1. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
