### PR TITLE
Fix common typos

### DIFF
--- a/include/core/nexus/HY_PointHydroNexusRemote.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemote.hpp
@@ -35,7 +35,7 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
         virtual ~HY_PointHydroNexusRemote();
 
         /** get the request percentage of downstream flow through this nexus at timestep t. If the indicated catchment is not local a async send will be
-            created. Will attempt to process all async recieves currently queued before processing flows*/
+            created. Will attempt to process all async receives currently queued before processing flows*/
         double get_downstream_flow(std::string catchment_id, time_step_t t, double percent_flow);
 
         /** add flow to this nexus for timestep t. If the indicated catchment is not local an async receive will be started*/
@@ -96,7 +96,7 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
             MPI_Request mpi_request;
         };
 
-        std::list<async_request> stored_recieves;
+        std::list<async_request> stored_receives;
         std::list<async_request> stored_sends;
 
         std::string nexus_prefix = "cat-";

--- a/include/routing/Routing_Py_Adapter.hpp
+++ b/include/routing/Routing_Py_Adapter.hpp
@@ -61,9 +61,9 @@ namespace routing_py_adapter {
          * Currently, these parameters are ignored and are read instead from the yaml configuration
          * file contained in #t_route_config_path
          * 
-         * NOTE this funtion uses a pybind11 embedded interperter to load the t-route namespace package
-         * ngen-main and then executes the routing in the python interperter.  
-         * It is assumed that the ngen-main module is available in the interperters PYTHON_PATH.
+         * NOTE this funtion uses a pybind11 embedded interpreter to load the t-route namespace package
+         * ngen-main and then executes the routing in the python interpreter.
+         * It is assumed that the ngen-main module is available in the interpreters PYTHON_PATH.
          * If the module cannot be found, then a ModuleNotFoundError will be thrown.
          * Similarly, ngen-main depends on severl other python modules.  If any of these are not in the
          * environments PYTHON_PATH, errors will occur.
@@ -110,12 +110,12 @@ namespace routing_py_adapter {
     private:
 
 
-        /** Handle to the interperter util.
+        /** Handle to the interpreter util.
          * 
          * Order is important, must be constructed before anything depending on it
          * and destructed after all dependent members.
         */
-        std::shared_ptr<utils::ngenPy::InterpreterUtil> interperter;
+        std::shared_ptr<utils::ngenPy::InterpreterUtil> interpreter;
 
         /** A binding to the Python numpy package/module. */
         py::object np;

--- a/src/core/nexus/HY_PointHydroNexus.cpp
+++ b/src/core/nexus/HY_PointHydroNexus.cpp
@@ -54,7 +54,7 @@ double HY_PointHydroNexus::get_downstream_flow(std::string catchment_id, time_st
 
     if ( percent_flow > 100.0)
     {
-        // no downstream may ever recieve more than 100% of flows
+        // no downstream may ever receive more than 100% of flows
 
         BOOST_THROW_EXCEPTION(invalid_downstream_request());
     }

--- a/src/core/nexus/HY_PointHydroNexusRemote.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemote.cpp
@@ -99,7 +99,7 @@ HY_PointHydroNexusRemote::~HY_PointHydroNexusRemote()
     int mpi_finalized;
     MPI_Finalized(&mpi_finalized);
 
-    while ( (stored_recieves.size() > 0 || stored_sends.size() > 0) && !mpi_finalized )
+    while ( (stored_receives.size() > 0 || stored_sends.size() > 0) && !mpi_finalized )
     {
         //std::cerr << "Neuxs with rank " << id << " has pending communications\n";
 
@@ -134,28 +134,28 @@ double HY_PointHydroNexusRemote::get_downstream_flow(std::string catchment_id, t
     	{
        		int status;
 
-       		stored_recieves.resize(stored_recieves.size() + 1);
-       		stored_recieves.back().buffer = std::make_shared<time_step_and_flow_t>();
+                stored_receives.resize(stored_receives.size() + 1);
+                stored_receives.back().buffer = std::make_shared<time_step_and_flow_t>();
 
        		int tag = extract(id);
 
        		//Receive downstream_flow from Upstream Remote Nexus to this Downstream Remote Nexus
        		status = MPI_Irecv(
-          		stored_recieves.back().buffer.get(),
+                        stored_receives.back().buffer.get(),
           		1,
           		time_step_and_flow_type,
           		rank,
           		tag,
           		MPI_COMM_WORLD,
-          		&stored_recieves.back().mpi_request);
+                        &stored_receives.back().mpi_request);
 
        		MPI_Handle_Error(status); 
        		
-       		//std::cerr << "Creating recieve with target_rank=" << rank << " on tag=" << tag << "\n";  	
+                //std::cerr << "Creating receive with target_rank=" << rank << " on tag=" << tag << "\n";
     	}
     	
-    	//std::cerr << "Waiting on recieves\n";
-    	while ( stored_recieves.size() > 0 )
+        //std::cerr << "Waiting on receives\n";
+        while ( stored_receives.size() > 0 )
     	{
     		process_communications();
     		std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -231,7 +231,7 @@ void HY_PointHydroNexusRemote::process_communications()
     int flag;                                      // boolean value for if a request has completed
     MPI_Status status;                              // status of the completed request
 
-    for ( auto i = stored_recieves.begin(); i != stored_recieves.end(); )
+    for ( auto i = stored_receives.begin(); i != stored_receives.end(); )
     {
         MPI_Handle_Error( MPI_Test(&i->mpi_request, &flag, &status) );
 
@@ -243,9 +243,9 @@ void HY_PointHydroNexusRemote::process_communications()
             double flow = i->buffer->flow;
 
             // remove this object from the vector
-            i = stored_recieves.erase(i);
+            i = stored_receives.erase(i);
 
-            // add the recieved flow
+            // add the received flow
             HY_PointHydroNexus::add_upstream_flow(flow, contributing_id, time_step);
         }
         else

--- a/src/routing/Routing_Py_Adapter.cpp
+++ b/src/routing/Routing_Py_Adapter.cpp
@@ -11,10 +11,10 @@ using namespace routing_py_adapter;
 
 Routing_Py_Adapter::Routing_Py_Adapter(std::string t_route_config_file_with_path):
   t_route_config_path(t_route_config_file_with_path){
-  //hold a reference to the interpreter, ensures an interperter exists as long as the reference is held
-  interperter = utils::ngenPy::InterpreterUtil::getInstance();
+  //hold a reference to the interpreter, ensures an interpreter exists as long as the reference is held
+  interpreter = utils::ngenPy::InterpreterUtil::getInstance();
   //Import ngen_main.  Will throw error if module isn't available
-  //in the embedded interperters PYTHON_PATH
+  //in the embedded interpreters PYTHON_PATH
   try {
     this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("ngen_routing.ngen_main");
     std::cout<<"WARN: Legacy t-route module detected; use of this version is deprecated!"<<std::endl;

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -27,7 +27,7 @@ typedef struct example_scenario {
 
 class Bmi_Py_Adapter_Test : public ::testing::Test {
 private:
-    static std::shared_ptr<InterpreterUtil> interperter;
+    static std::shared_ptr<InterpreterUtil> interpreter;
 protected:
 
     static std::shared_ptr<py::object> friend_get_raw_model(Bmi_Py_Adapter *adapter) {
@@ -116,8 +116,8 @@ protected:
     int expected_var_nbytes = 8; //type double
 
 };
-//Make sure the interperter is instansiated and lives throught the test class
-std::shared_ptr<InterpreterUtil> Bmi_Py_Adapter_Test::interperter = InterpreterUtil::getInstance();
+//Make sure the interpreter is instansiated and lives throught the test class
+std::shared_ptr<InterpreterUtil> Bmi_Py_Adapter_Test::interpreter = InterpreterUtil::getInstance();
 py::object Bmi_Py_Adapter_Test::Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});
 
 void Bmi_Py_Adapter_Test::SetUp() {

--- a/test/core/nexus/NexusRemoteTests.cpp
+++ b/test/core/nexus/NexusRemoteTests.cpp
@@ -106,9 +106,9 @@ TEST_F(Nexus_Remote_Test, TestInit0)
 
             case 1:
                 //nexus->add_upstream_flow(dummy_flow,"cat-26",ts);
-                double recieved_flow = nexus->get_downstream_flow("cat-27",ts,100);
-                ASSERT_EQ(discharge,recieved_flow);
-                std::cerr << "Rank 1: Recieving flow of " << recieved_flow << " from catchment Nexus connected to catchment 26\n";
+                double received_flow = nexus->get_downstream_flow("cat-27",ts,100);
+                ASSERT_EQ(discharge,received_flow);
+                std::cerr << "Rank 1: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 26\n";
             break;
         }
 
@@ -167,7 +167,7 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders)
 
     double dummy_flow = -9999.0;
     long ts = 0;
-    double recieved_flow = -9999.0;
+    double received_flow = -9999.0;
 
     for ( auto discharge : stored_discharge)
     {
@@ -175,9 +175,9 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders)
         {
             
             case 0:
-                recieved_flow = nexus->get_downstream_flow("cat-27",ts,100);
-                ASSERT_EQ(discharge+discharge,recieved_flow);
-                std::cerr << "Rank 0: Recieving flow of " << recieved_flow << " from catchment Nexus connected to catchment 27\n";
+                received_flow = nexus->get_downstream_flow("cat-27",ts,100);
+                ASSERT_EQ(discharge+discharge,received_flow);
+                std::cerr << "Rank 0: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
             break;
             
             case 1:
@@ -248,7 +248,7 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders1LocalSender)
 
     double dummy_flow = -9999.0;
     long ts = 0;
-    double recieved_flow = -9999.0;
+    double received_flow = -9999.0;
 
     for ( auto discharge : stored_discharge)
     {
@@ -257,9 +257,9 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders1LocalSender)
             
             case 0:
                 nexus->add_upstream_flow(discharge,"cat-24",ts);
-                recieved_flow = nexus->get_downstream_flow("cat-27",ts,100);
-                ASSERT_EQ(discharge*3,recieved_flow);
-                std::cerr << "Rank 0: Recieving flow of " << recieved_flow << " from catchment Nexus connected to catchment 27\n";
+                received_flow = nexus->get_downstream_flow("cat-27",ts,100);
+                ASSERT_EQ(discharge*3,received_flow);
+                std::cerr << "Rank 0: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
             break;
             
             case 1:
@@ -357,7 +357,7 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
 
     double dummy_flow = -9999.0;
     long ts = 0;
-    double recieved_flow = -9999.0;
+    double received_flow = -9999.0;
 
     for ( auto discharge : stored_discharge)
     {
@@ -366,9 +366,9 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
             
             case 0:
                 nexus->add_upstream_flow(discharge,"cat-24",ts);
-                recieved_flow = nexus->get_downstream_flow("cat-27",ts,100);
-                ASSERT_EQ(discharge*3,recieved_flow);
-                std::cerr << "Rank 0: Recieving flow of " << recieved_flow << " from catchment Nexus connected to catchment 27\n";
+                received_flow = nexus->get_downstream_flow("cat-27",ts,100);
+                ASSERT_EQ(discharge*3,received_flow);
+                std::cerr << "Rank 0: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
             break;
             
             case 1:
@@ -383,9 +383,9 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
             
             case 3:
                 nexus->add_upstream_flow(discharge,"cat-14",ts);
-                recieved_flow = nexus->get_downstream_flow("cat-17",ts,100);
-                ASSERT_EQ(discharge*3,recieved_flow);
-                std::cerr << "Rank 3: Recieving flow of " << recieved_flow << " from catchment Nexus connected to catchment 27\n";
+                received_flow = nexus->get_downstream_flow("cat-17",ts,100);
+                ASSERT_EQ(discharge*3,received_flow);
+                std::cerr << "Rank 3: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
             break;
             
             case 4:
@@ -423,7 +423,7 @@ TEST_F(Nexus_Remote_Test, TestDeadlock1)
     std::shared_ptr<HY_PointHydroNexusRemote> nexus2;
 
     double dummy_flow = -9999.0;
-    double recieved_flow;
+    double received_flow;
     long ts = 0;
 
     std::vector<std::string> downstream_catchments;
@@ -444,8 +444,8 @@ TEST_F(Nexus_Remote_Test, TestDeadlock1)
         // We use two differnt time steps becuase a nexus does not allow water to be added after a send
         nexus1->add_upstream_flow(200.0,"cat-25",ts);						// sending to rank 1
                               
-        recieved_flow = nexus2->get_downstream_flow("cat-26",ts,100);       // get the recieved flow
-        std::cout << "rank 0 recieved a flow of " << recieved_flow << "\n";
+        received_flow = nexus2->get_downstream_flow("cat-26",ts,100);       // get the received flow
+        std::cout << "rank 0 received a flow of " << received_flow << "\n";
     }
     else if ( mpi_rank == 1)
     {
@@ -459,8 +459,8 @@ TEST_F(Nexus_Remote_Test, TestDeadlock1)
         // We use two differnt time steps becuase a nexus does not allow water to be added after a send
         nexus1->add_upstream_flow(200.0,"cat-26",ts);						// sending to rank 0
                               
-        recieved_flow = nexus2->get_downstream_flow("cat-25",ts,100);       // get the recieved flow
-        std::cout << "rank 1 recieved a flow of " << recieved_flow << "\n";
+        received_flow = nexus2->get_downstream_flow("cat-25",ts,100);       // get the received flow
+        std::cout << "rank 1 received a flow of " << received_flow << "\n";
     }
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -34,7 +34,7 @@ typedef struct py_formulation_example_scenario {
 
 class Bmi_Py_Formulation_Test : public ::testing::Test {
 private:
-    static std::shared_ptr<InterpreterUtil> interperter;
+    static std::shared_ptr<InterpreterUtil> interpreter;
 protected:
     
     py::object Path;
@@ -168,8 +168,8 @@ protected:
                                    const std::vector<std::string> &file_basenames);
 
 };
-//Make sure the interperter is instansiated and lives throught the test class
-std::shared_ptr<InterpreterUtil> Bmi_Py_Formulation_Test::interperter = InterpreterUtil::getInstance();
+//Make sure the interpreter is instansiated and lives throught the test class
+std::shared_ptr<InterpreterUtil> Bmi_Py_Formulation_Test::interpreter = InterpreterUtil::getInstance();
 
 void Bmi_Py_Formulation_Test::SetUp() {
     Path = InterpreterUtil::getPyModule(std::vector<std::string> {"pathlib", "Path"});

--- a/test/routing/Routing_Py_Bind_Test.cpp
+++ b/test/routing/Routing_Py_Bind_Test.cpp
@@ -12,7 +12,7 @@ namespace py = pybind11;
 
 class RoutingPyBindTest : public ::testing::Test {
 private:
-  static std::shared_ptr<utils::ngenPy::InterpreterUtil> interperter;
+  static std::shared_ptr<utils::ngenPy::InterpreterUtil> interpreter;
 
 protected:
 
@@ -24,8 +24,8 @@ protected:
 
     }
 };
-//Make sure the interperter is instansiated and lives throught the test class
-std::shared_ptr<utils::ngenPy::InterpreterUtil> RoutingPyBindTest::interperter = utils::ngenPy::InterpreterUtil::getInstance();
+//Make sure the interpreter is instansiated and lives throught the test class
+std::shared_ptr<utils::ngenPy::InterpreterUtil> RoutingPyBindTest::interpreter = utils::ngenPy::InterpreterUtil::getInstance();
 
 TEST_F(RoutingPyBindTest, TestRoutingPyBind)
 {


### PR DESCRIPTION
A few spelling typos were very prevalent throughout our codebase

## Changes

- Correct `interperter`
- Correct `recieve`

## Testing

1. Local `ctest`
2. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
