### PR TITLE
Drop 'using std::shared_ptr' from high-level header

### DIFF
--- a/include/core/catchment/HY_CatchmentRealization.hpp
+++ b/include/core/catchment/HY_CatchmentRealization.hpp
@@ -6,8 +6,6 @@
 #include <AorcForcing.hpp>
 #include "GenericDataProvider.hpp"
 
-using std::shared_ptr;
-
 //Forward Declarations
 class HY_Catchment;
 
@@ -42,7 +40,7 @@ class HY_CatchmentRealization
 
     protected:
 
-    shared_ptr<HY_Catchment> realized_catchment;
+    std::shared_ptr<HY_Catchment> realized_catchment;
 
     virtual std::string get_catchment_id() = 0;
 

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -205,8 +205,8 @@ namespace realization {
          * @return Either the translated equivalent variable name, or the provided name if there is not a mapping entry.
          */
         const std::string &get_config_mapped_variable_name(const std::string &output_var_name,
-                                                      const shared_ptr<Bmi_Formulation>& out_module,
-                                                      const shared_ptr<Bmi_Formulation>& in_module);
+                                                           const std::shared_ptr<Bmi_Formulation>& out_module,
+                                                           const std::shared_ptr<Bmi_Formulation>& in_module);
 
         const std::string &get_forcing_file_path() const override;
 

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -20,7 +20,7 @@
 #endif
 
 namespace realization {
-    using constructor = std::shared_ptr<Catchment_Formulation> (*)(std::string, shared_ptr<data_access::GenericDataProvider>, utils::StreamHandler);
+    using constructor = std::shared_ptr<Catchment_Formulation> (*)(std::string, std::shared_ptr<data_access::GenericDataProvider>, utils::StreamHandler);
 
     extern std::map<std::string, constructor> formulations;
 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -268,8 +268,8 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
  * @return Either the translated equivalent variable name, or the provided name if there is not a mapping entry.
  */
 const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const std::string &output_var_name,
-                                                                     const shared_ptr<Bmi_Formulation>& out_module,
-                                                                     const shared_ptr<Bmi_Formulation>& in_module)
+                                                                     const std::shared_ptr<Bmi_Formulation>& out_module,
+                                                                     const std::shared_ptr<Bmi_Formulation>& in_module)
 {
     if (!out_module->is_bmi_output_variable(output_var_name))
         return output_var_name;

--- a/src/realizations/catchment/Bmi_Py_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Py_Formulation.cpp
@@ -12,7 +12,7 @@ using namespace pybind11::literals;
 Bmi_Py_Formulation::Bmi_Py_Formulation(std::string id, std::shared_ptr<data_access::GenericDataProvider> forcing, utils::StreamHandler output_stream)
 : Bmi_Module_Formulation(id, std::move(forcing), output_stream) { }
 
-shared_ptr<Bmi_Adapter> Bmi_Py_Formulation::construct_model(const geojson::PropertyMap &properties) {
+std::shared_ptr<Bmi_Adapter> Bmi_Py_Formulation::construct_model(const geojson::PropertyMap &properties) {
     auto python_type_name_iter = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__PYTHON_TYPE_NAME);
     if (python_type_name_iter == properties.end()) {
         throw std::runtime_error("BMI Python formulation requires Python model class type, but none given in config");


### PR DESCRIPTION
It's really poor form to lift standard library names into the global namespace. Drop the `using std::shared_ptr` statement, and qualify the handful of places across the code that depended on it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: