### PR TITLE
Routing test: Minor cleanups

### DIFF
--- a/test/routing/Routing_Py_Bind_Test.cpp
+++ b/test/routing/Routing_Py_Bind_Test.cpp
@@ -7,9 +7,6 @@
 #include <pybind11/stl.h>
 namespace py = pybind11;
 
-//using namespace std;
-
-
 class RoutingPyBindTest : public ::testing::Test {
 private:
   static std::shared_ptr<utils::ngenPy::InterpreterUtil> interpreter;
@@ -24,7 +21,7 @@ protected:
 
     }
 };
-//Make sure the interpreter is instansiated and lives throught the test class
+//Make sure the interpreter is instantiated and lives throughout the test class
 std::shared_ptr<utils::ngenPy::InterpreterUtil> RoutingPyBindTest::interpreter = utils::ngenPy::InterpreterUtil::getInstance();
 
 TEST_F(RoutingPyBindTest, TestRoutingPyBind)


### PR DESCRIPTION
Fix one-off typos and infelicities in Routing test

## Removals

- Delete commented out `using namespace std;`

## Changes

- Fix typos

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
