### PR TITLE
#570: Remove 'uses_forcing_file' and 'forcing_file'(_path)

### DIFF
--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -15,16 +15,14 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
             AbstractCLibBmiAdapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                                   std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
-                                   std::string registration_func, utils::StreamHandler output);
+                                   bool allow_exceed_end, bool has_fixed_time_step, std::string registration_func,
+                                   utils::StreamHandler output);
 
             /**
              * Class destructor.

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -19,7 +19,7 @@ namespace models {
         class Bmi_Adapter : public ::bmi::Bmi {
         public:
 
-            Bmi_Adapter(std::string model_name, std::string bmi_init_config, std::string forcing_file_path, bool allow_exceed_end,
+            Bmi_Adapter(std::string model_name, std::string bmi_init_config, bool allow_exceed_end,
                         bool has_fixed_time_step, utils::StreamHandler output);
 
             Bmi_Adapter(Bmi_Adapter const&) = delete;
@@ -156,9 +156,6 @@ namespace models {
             double bmi_model_time_convert_factor;
             /** Pointer to stored time step size value of backing model, if it is fixed and has been retrieved. */
             std::shared_ptr<double> bmi_model_time_step_size = nullptr;
-            /** Whether this particular model implementation directly reads input data from the forcing file. */
-            bool bmi_model_uses_forcing_file;
-            std::string forcing_file_path;
             /** Message from an exception (if encountered) on the first attempt to initialize the backing model. */
             std::string init_exception_msg;
             /** Pointer to collection of input variable names for backing model, used by ``GetInputVarNames()``. */

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -32,14 +32,12 @@ namespace models {
              *
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
-            explicit Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string forcing_file_path,
+            explicit Bmi_C_Adapter(const std::string &type_name, std::string library_file_path,
                                    bool allow_exceed_end, bool has_fixed_time_step,
                                    const std::string& registration_func, utils::StreamHandler output);
 
@@ -49,15 +47,13 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
             Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                          std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                          bool allow_exceed_end, bool has_fixed_time_step,
                           std::string registration_func, utils::StreamHandler output);
 
         protected:
@@ -76,8 +72,6 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
@@ -85,7 +79,7 @@ namespace models {
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
             Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                          std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                          bool allow_exceed_end, bool has_fixed_time_step,
                           std::string registration_func, utils::StreamHandler output, bool do_initialization);
 
         public:

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -35,15 +35,13 @@ namespace models {
              *
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
              * @param output The output stream handler.
              */
-            explicit Bmi_Cpp_Adapter(const std::string &type_name, std::string library_file_path, std::string forcing_file_path,
+            explicit Bmi_Cpp_Adapter(const std::string &type_name, std::string library_file_path,
                                    bool allow_exceed_end, bool has_fixed_time_step,
                                    std::string creator_func, std::string destroyer_func,
                                    utils::StreamHandler output);
@@ -54,8 +52,6 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
@@ -63,7 +59,7 @@ namespace models {
              * @param output The output stream handler.
              */
             Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                          std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                          bool allow_exceed_end, bool has_fixed_time_step,
                           std::string creator_func, std::string destroyer_func,
                           utils::StreamHandler output);
 
@@ -83,8 +79,6 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
-             *                          use one directly.
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
@@ -93,7 +87,7 @@ namespace models {
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
             Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                          std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                          bool allow_exceed_end, bool has_fixed_time_step,
                           std::string creator_func, std::string destroyer_func,
                           utils::StreamHandler output, bool do_initialization);
 

--- a/include/bmi/Bmi_Fortran_Adapter.hpp
+++ b/include/bmi/Bmi_Fortran_Adapter.hpp
@@ -30,20 +30,18 @@ namespace models {
         public:
 
             explicit Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path,
-                                         std::string forcing_file_path,
                                          bool allow_exceed_end, bool has_fixed_time_step,
                                          const std::string &registration_func, utils::StreamHandler output)
-                    : Bmi_Fortran_Adapter(type_name, library_file_path, "", forcing_file_path, allow_exceed_end,
+                    : Bmi_Fortran_Adapter(type_name, library_file_path, "", allow_exceed_end,
                                           has_fixed_time_step,
                                           registration_func, output) {}
 
             Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                                std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                                bool allow_exceed_end, bool has_fixed_time_step,
                                 std::string registration_func,
                                 utils::StreamHandler output) : AbstractCLibBmiAdapter(type_name,
                                                                                       library_file_path,
                                                                                       bmi_init_config,
-                                                                                      forcing_file_path,
                                                                                       allow_exceed_end,
                                                                                       has_fixed_time_step,
                                                                                       registration_func,

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -42,10 +42,6 @@ namespace models {
             Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
                            bool allow_exceed_end, bool has_fixed_time_step, utils::StreamHandler output);
 
-            Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                           std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
-                           utils::StreamHandler output);
-
             Bmi_Py_Adapter(Bmi_Py_Adapter const&) = delete;
             Bmi_Py_Adapter(Bmi_Py_Adapter&&) = delete;
 

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -14,9 +14,9 @@
 #define BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG "init_config"
 #define BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR "main_output_variable"
 #define BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE "model_type_name"
-#define BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS "uses_forcing_file"
 
 // Then the optional
+#define BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS "uses_forcing_file"
 #define BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE "forcing_file"
 #define BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "variables_names_map"
 // TODO: change this (and output_header_fields) to something like output_file_variables to distinguish from BMI output variables

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -129,8 +129,6 @@ namespace realization {
          */
         virtual const double get_model_end_time() = 0;
 
-        virtual const std::string &get_forcing_file_path() const = 0;
-
         /**
          * Get the name of the specific type of the backing model object.
          *
@@ -188,13 +186,6 @@ namespace realization {
         virtual bool is_bmi_model_time_step_fixed() = 0;
 
         virtual bool is_bmi_output_variable(const std::string &var_name) = 0;
-
-        /**
-         * Whether the backing model uses/reads the forcing file directly for getting input data.
-         *
-         * @return Whether the backing model uses/reads the forcing file directly for getting input data.
-         */
-        virtual bool is_bmi_using_forcing_file() const = 0;
 
         /**
          * Test whether the backing model has been initialize using the BMI standard ``Initialize`` function.

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -308,8 +308,6 @@ namespace realization {
          */
         std::shared_ptr<models::bmi::Bmi_Adapter> get_bmi_model();
 
-        const std::string &get_forcing_file_path() const override;
-
         const time_t &get_bmi_model_start_time_forcing_offset_s() override;
 
         /**
@@ -346,13 +344,6 @@ namespace realization {
         bool is_bmi_model_time_step_fixed() override;
 
         /**
-         * Whether the backing model uses/reads the forcing file directly for getting input data.
-         *
-         * @return Whether the backing model uses/reads the forcing file directly for getting input data.
-         */
-        bool is_bmi_using_forcing_file() const override;
-
-        /**
          * Test whether the backing model object has been initialize using the BMI standard ``Initialize`` function.
          *
          * @return Whether backing model object has been initialize using the BMI standard ``Initialize`` function.
@@ -373,15 +364,6 @@ namespace realization {
         void set_bmi_model_start_time_forcing_offset_s(const time_t &offset_s);
 
         void set_bmi_model_time_step_fixed(bool is_fix_time_step);
-
-        /**
-         * Set whether the backing model uses/reads the forcing file directly for getting input data.
-         *
-         * @param uses_forcing_file Whether the backing model uses/reads forcing file directly for getting input data.
-         */
-        void set_bmi_using_forcing_file(bool uses_forcing_file);
-
-        void set_forcing_file_path(const std::string &forcing_path);
 
         /**
          * Set whether the backing model object has been initialize using the BMI standard ``Initialize`` function.
@@ -455,12 +437,10 @@ namespace realization {
         time_t bmi_model_start_time_forcing_offset_s;
         /** A configured mapping of BMI model variable names to standard names for use inside the framework. */
         std::map<std::string, std::string> bmi_var_names_map;
-        /** Whether the backing model uses/reads the forcing file directly for getting input data. */
-        bool bmi_using_forcing_file;
-        std::string forcing_file_path;
         bool model_initialized = false;
 
         std::vector<std::string> OPTIONAL_PARAMETERS = {
+                BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS
                 BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE,
                 BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES,
                 BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS,
@@ -474,7 +454,6 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG,
                 BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR,
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
-                BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS
         };
 
     };
@@ -498,9 +477,7 @@ namespace realization {
         // Required parameters first
         set_bmi_init_config(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG).as_string());
         set_bmi_main_output_var(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR).as_string());
-        set_forcing_file_path(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__FORCING_FILE).as_string());
         set_model_type_name(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE).as_string());
-        set_bmi_using_forcing_file(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS).as_boolean());
 
         // Then optional ...
 

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -440,7 +440,7 @@ namespace realization {
         bool model_initialized = false;
 
         std::vector<std::string> OPTIONAL_PARAMETERS = {
-                BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS
+                BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS
                 BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE,
                 BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES,
                 BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS,

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -208,8 +208,6 @@ namespace realization {
                                                            const std::shared_ptr<Bmi_Formulation>& out_module,
                                                            const std::shared_ptr<Bmi_Formulation>& in_module);
 
-        const std::string &get_forcing_file_path() const override;
-
         /**
          * Get the inclusive beginning of the period of time over which this instance can provide data for this forcing.
          *
@@ -424,8 +422,6 @@ namespace realization {
         bool is_bmi_model_time_step_fixed() override;
 
         bool is_bmi_output_variable(const std::string &var_name) override;
-
-        bool is_bmi_using_forcing_file() const override;
 
         /**
          * Test whether all backing models have been initialize using the BMI standard ``Initialize`` function.

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -12,7 +12,6 @@ AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
     const std::string& type_name,
     std::string library_file_path,
     std::string bmi_init_config,
-    std::string forcing_file_path,
     bool allow_exceed_end,
     bool has_fixed_time_step,
     std::string registration_func,
@@ -21,7 +20,6 @@ AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
     : Bmi_Adapter(
           type_name,
           std::move(bmi_init_config),
-          std::move(forcing_file_path),
           allow_exceed_end,
           has_fixed_time_step,
           output

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -8,15 +8,12 @@ namespace bmi {
 Bmi_Adapter::Bmi_Adapter(
     std::string model_name,
     std::string bmi_init_config,
-    std::string forcing_file_path,
     bool allow_exceed_end,
     bool has_fixed_time_step,
     utils::StreamHandler output
 )
     : model_name(std::move(model_name))
     , bmi_init_config(std::move(bmi_init_config))
-    , bmi_model_uses_forcing_file(!forcing_file_path.empty())
-    , forcing_file_path(std::move(forcing_file_path))
     , bmi_model_has_fixed_time_step(has_fixed_time_step)
     , allow_model_exceed_end_time(allow_exceed_end)
     , output(std::move(output))

--- a/src/bmi/Bmi_C_Adapter.cpp
+++ b/src/bmi/Bmi_C_Adapter.cpp
@@ -10,17 +10,15 @@ using namespace models::bmi;
  *
  * @param type_name The name of the backing BMI module/model type.
  * @param library_file_path The string path to the shared library file for external module.
- * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
- *                          use one directly.
  * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
  * @param output The output stream handler.
  */
-Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string forcing_file_path,
+Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path,
                              bool allow_exceed_end, bool has_fixed_time_step,
                              const std::string& registration_func, utils::StreamHandler output)
-        : Bmi_C_Adapter(type_name, std::move(library_file_path), "", std::move(forcing_file_path),
+        : Bmi_C_Adapter(type_name, std::move(library_file_path), "",
                         allow_exceed_end, has_fixed_time_step, registration_func, output) { }
 
 /**
@@ -29,18 +27,16 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param type_name The name of the backing BMI module/model type.
  * @param library_file_path The string path to the shared library file for external module.
  * @param bmi_init_config The string path to the BMI initialization config file for the module.
- * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
- *                          use one directly.
  * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
  * @param output The output stream handler.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                             std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                             bool allow_exceed_end, bool has_fixed_time_step,
                              std::string registration_func, utils::StreamHandler output)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
-                        std::move(forcing_file_path), allow_exceed_end, has_fixed_time_step,
+                        allow_exceed_end, has_fixed_time_step,
                         std::move(registration_func), output, true) { }
 
 /**
@@ -57,8 +53,6 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param type_name The name of the backing BMI module/model type.
  * @param library_file_path The string path to the shared library file for external module.
  * @param bmi_init_config The string path to the BMI initialization config file for the module.
- * @param forcing_file_path The string path for the forcing file the module should use, empty if it does not
- *                          use one directly.
  * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
@@ -66,9 +60,9 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param do_initialization Whether initialization should be performed during construction or deferred.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                             std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                             bool allow_exceed_end, bool has_fixed_time_step,
                              std::string registration_func, utils::StreamHandler output, bool do_initialization)
-                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), std::move(forcing_file_path), allow_exceed_end,
+                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), allow_exceed_end,
                              has_fixed_time_step, registration_func, output)
 {
     if (do_initialization) {
@@ -115,9 +109,7 @@ Bmi_C_Adapter::Bmi_C_Adapter(Bmi_C_Adapter &adapter) : model_name(adapter.model_
                                                                adapter.bmi_model_has_fixed_time_step),
                                                        bmi_model_time_convert_factor(
                                                                adapter.bmi_model_time_convert_factor),
-                                                       bmi_model_uses_forcing_file(adapter.bmi_model_uses_forcing_file),
                                                        bmi_registration_function(adapter.bmi_registration_function),
-                                                       forcing_file_path(adapter.forcing_file_path),
                                                        init_exception_msg(adapter.init_exception_msg),
                                                        input_var_names(adapter.input_var_names),
                                                        model_initialized(adapter.model_initialized),

--- a/src/bmi/Bmi_Cpp_Adapter.cpp
+++ b/src/bmi/Bmi_Cpp_Adapter.cpp
@@ -6,26 +6,26 @@
 
 using namespace models::bmi;
 
-Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string forcing_file_path,
+Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path,
                              bool allow_exceed_end, bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func,
                              utils::StreamHandler output)
-        : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), "", std::move(forcing_file_path),
+        : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), "",
                         allow_exceed_end, has_fixed_time_step, creator_func, destroyer_func, output) { }
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                             std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                             bool allow_exceed_end, bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func,
                              utils::StreamHandler output)
         : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
-                        std::move(forcing_file_path), allow_exceed_end, has_fixed_time_step,
+                        allow_exceed_end, has_fixed_time_step,
                         std::move(creator_func), std::move(destroyer_func), output, true) { }
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                             std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                             bool allow_exceed_end, bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func,
                              utils::StreamHandler output, bool do_initialization)
-                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), std::move(forcing_file_path), allow_exceed_end,
+                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), allow_exceed_end,
                              has_fixed_time_step, creator_func, output),
                              model_create_fname(std::move(creator_func)),
                              model_destroy_fname(std::move(destroyer_func))
@@ -67,9 +67,7 @@ Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(Bmi_Cpp_Adapter &adapter) :
                                                                adapter.bmi_model_has_fixed_time_step),
                                                        bmi_model_time_convert_factor(
                                                                adapter.bmi_model_time_convert_factor),
-                                                       bmi_model_uses_forcing_file(adapter.bmi_model_uses_forcing_file),
                                                        bmi_registration_function(adapter.bmi_registration_function),
-                                                       forcing_file_path(adapter.forcing_file_path),
                                                        init_exception_msg(adapter.init_exception_msg),
                                                        input_var_names(adapter.input_var_names),
                                                        model_initialized(adapter.model_initialized),

--- a/src/bmi/Bmi_Py_Adapter.cpp
+++ b/src/bmi/Bmi_Py_Adapter.cpp
@@ -11,15 +11,10 @@ using namespace models::bmi;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality
 
 Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                               bool allow_exceed_end, bool has_fixed_time_step, utils::StreamHandler output)
-        : Bmi_Py_Adapter(type_name, std::move(bmi_init_config), bmi_python_type, "", allow_exceed_end, has_fixed_time_step,
-                         std::move(output)) {}
-
-Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                               std::string forcing_file_path, bool allow_exceed_end, bool has_fixed_time_step,
+                               bool allow_exceed_end, bool has_fixed_time_step,
                                utils::StreamHandler output)
         : Bmi_Adapter(type_name + " (BMI Py)", std::move(bmi_init_config),
-                                  std::move(forcing_file_path), allow_exceed_end, has_fixed_time_step,
+                                  allow_exceed_end, has_fixed_time_step,
                                   output),
           bmi_type_py_full_name(bmi_python_type),
           np(utils::ngenPy::InterpreterUtil::getPyModule("numpy")) /* like 'import numpy as np' */

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -28,7 +28,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_C_Formulation::construct_model(const geojson::P
                     get_model_type_name(),
                     lib_file,
                     get_bmi_init_config(),
-                    (is_bmi_using_forcing_file() ? get_forcing_file_path() : ""),
                     get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed(),
                     reg_func,

--- a/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
@@ -37,7 +37,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_Cpp_Formulation::construct_model(const geojson:
                     get_model_type_name(),
                     lib_file,
                     get_bmi_init_config(),
-                    (is_bmi_using_forcing_file() ? get_forcing_file_path() : ""),
                     get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed(),
                     model_create_fname,

--- a/src/realizations/catchment/Bmi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Formulation.cpp
@@ -3,6 +3,7 @@
 namespace realization
 {
     const std::vector<std::string> Bmi_Formulation::OPTIONAL_PARAMETERS = {
+                BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS
                 BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE,
                 BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES,
                 BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS,
@@ -15,6 +16,5 @@ namespace realization
                 BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG,
                 BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR,
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
-                BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS
         };
 }

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -36,7 +36,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_Fortran_Formulation::construct_model(const geoj
             get_model_type_name(),
             lib_file,
             get_bmi_init_config(),
-            (is_bmi_using_forcing_file() ? get_forcing_file_path() : ""),
             get_allow_model_exceed_end_time(),
             is_bmi_model_time_step_fixed(),
             reg_func,

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -289,10 +289,6 @@ namespace realization {
             return bmi_model;
         }
 
-        const std::string& Bmi_Module_Formulation::get_forcing_file_path() const {
-            return forcing_file_path;
-        }
-
         const time_t& Bmi_Module_Formulation::get_bmi_model_start_time_forcing_offset_s() {
             return bmi_model_start_time_forcing_offset_s;
         }
@@ -305,15 +301,18 @@ namespace realization {
             set_bmi_init_config(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG).as_string());
             set_bmi_main_output_var(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR).as_string());
             set_model_type_name(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE).as_string());
-            set_bmi_using_forcing_file(properties.at(BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS).as_boolean());
 
             // Then optional ...
 
-            // Note that this must be present if bmi_using_forcing_file is true
-            if (properties.find(BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE) != properties.end())
-                set_forcing_file_path(properties.at(BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE).as_string());
-            else if (is_bmi_using_forcing_file())
-                throw std::runtime_error("Can't create BMI formulation: using_forcing_file true but no file path set");
+            auto uses_forcings_it = properties.find(BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS);
+            if (uses_forcings_it != properties.end() && uses_forcings_it->second.as_boolean()) {
+                throw std::runtime_error("The '" BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS "' parameter was removed and cannot be set");
+            }
+
+            auto forcing_file_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE);
+            if (forcing_file_it != properties.end() && forcing_file_it->second.as_string() != "") {
+                throw std::runtime_error("The '" BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE "' parameter was removed and cannot be set " + forcing_file_it->second.as_string());
+            }
 
             if (properties.find(BMI_REALIZATION_CFG_PARAM_OPT__ALLOW_EXCEED_END) != properties.end()) {
                 set_allow_model_exceed_end_time(
@@ -556,10 +555,6 @@ namespace realization {
             return bmi_model_time_step_fixed;
         }
 
-        bool Bmi_Module_Formulation::is_bmi_using_forcing_file() const {
-            return bmi_using_forcing_file;
-        }
-
         bool Bmi_Module_Formulation::is_model_initialized() {
             return model_initialized;
         }
@@ -581,14 +576,6 @@ namespace realization {
 
         void Bmi_Module_Formulation::set_bmi_model_time_step_fixed(bool is_fix_time_step) {
             bmi_model_time_step_fixed = is_fix_time_step;
-        }
-
-        void Bmi_Module_Formulation::set_bmi_using_forcing_file(bool uses_forcing_file) {
-            bmi_using_forcing_file = uses_forcing_file;
-        }
-
-        void Bmi_Module_Formulation::set_forcing_file_path(const std::string &forcing_path) {
-            forcing_file_path = forcing_path;
         }
 
         void Bmi_Module_Formulation::set_model_initialized(bool is_initialized) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -304,9 +304,9 @@ namespace realization {
 
             // Then optional ...
 
-            auto uses_forcings_it = properties.find(BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS);
+            auto uses_forcings_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS);
             if (uses_forcings_it != properties.end() && uses_forcings_it->second.as_boolean()) {
-                throw std::runtime_error("The '" BMI_REALIZATION_CFG_PARAM_REQ__USES_FORCINGS "' parameter was removed and cannot be set");
+                throw std::runtime_error("The '" BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS "' parameter was removed and cannot be set");
             }
 
             auto forcing_file_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE);

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -286,11 +286,6 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
     return output_var_name;
 }
 
-// TODO: remove from this level - it belongs (perhaps) as part of the ForcingProvider interface, but is general to it
-const std::string &Bmi_Multi_Formulation::get_forcing_file_path() const {
-    return modules[0]->get_forcing_file_path();
-}
-
 std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
     // TODO: have to do some figuring out to make sure this isn't ambiguous (i.e., same output var name from two modules)
     // TODO: need to verify that output variable names are valid, or else warn and return default
@@ -405,11 +400,6 @@ bool Bmi_Multi_Formulation::is_bmi_model_time_step_fixed() {
 
 bool Bmi_Multi_Formulation::is_bmi_output_variable(const std::string &var_name) {
     return modules.back()->is_bmi_output_variable(var_name);
-}
-
-bool Bmi_Multi_Formulation::is_bmi_using_forcing_file() const {
-    return std::any_of(modules.cbegin(), modules.cend(),
-                       [](const std::shared_ptr<Bmi_Formulation>& m) { return m->is_bmi_using_forcing_file(); });
 }
 
 bool Bmi_Multi_Formulation::is_model_initialized() {

--- a/test/bmi/Bmi_C_Adapter_Test.cpp
+++ b/test/bmi/Bmi_C_Adapter_Test.cpp
@@ -55,7 +55,6 @@ protected:
 
     std::string config_file_name_0;
     std::string lib_file_name_0;
-    std::string forcing_file_name_0;
     std::string bmi_module_type_name_0;
     std::unique_ptr<Bmi_C_Adapter> adapter;
 
@@ -81,9 +80,6 @@ void Bmi_C_Adapter_Test::SetUp() {
     std::string config_basename_0 = "test_bmi_c_config_0.txt";
     config_file_name_0 = file_search(config_path_options, config_basename_0);
 
-    std::vector<std::string> forcing_dir_opts = {"./data/forcing/", "../data/forcing/", "../../data/forcing/"};
-    forcing_file_name_0 = file_search(forcing_dir_opts, "cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv");
-
     std::vector<std::string> lib_dir_opts = {
             "./extern/test_bmi_c/cmake_build/",
             "../extern/test_bmi_c/cmake_build/",
@@ -92,7 +88,7 @@ void Bmi_C_Adapter_Test::SetUp() {
     lib_file_name_0 = file_search(lib_dir_opts, BMI_TEST_C_LOCAL_LIB_NAME);
     bmi_module_type_name_0 = "test_bmi_c";
     adapter = std::make_unique<Bmi_C_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                              forcing_file_name_0, false, true, REGISTRATION_FUNC,
+                                              false, true, REGISTRATION_FUNC,
                                               utils::StreamHandler());
 }
 

--- a/test/bmi/Bmi_Cpp_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Cpp_Adapter_Test.cpp
@@ -45,7 +45,6 @@ protected:
 
     std::string config_file_name_0;
     std::string lib_file_name_0;
-    std::string forcing_file_name_0;
     std::string bmi_module_type_name_0;
     std::unique_ptr<Bmi_Cpp_Adapter> adapter;
 
@@ -72,9 +71,6 @@ void Bmi_Cpp_Adapter_Test::SetUp() {
     std::string config_basename_0 = "test_bmi_c_config_0.txt";
     config_file_name_0 = file_search(config_path_options, config_basename_0);
 
-    std::vector<std::string> forcing_dir_opts = {"./data/forcing/", "../data/forcing/", "../../data/forcing/"};
-    forcing_file_name_0 = file_search(forcing_dir_opts, "cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv");
-
     std::vector<std::string> lib_dir_opts = {
             "./extern/test_bmi_cpp/cmake_build/",
             "../extern/test_bmi_cpp/cmake_build/",
@@ -84,7 +80,7 @@ void Bmi_Cpp_Adapter_Test::SetUp() {
     bmi_module_type_name_0 = "test_bmi_cpp";
     try {
         adapter = std::make_unique<Bmi_Cpp_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                                forcing_file_name_0, false, true, CREATOR_FUNC, DESTROYER_FUNC,
+                                                false, true, CREATOR_FUNC, DESTROYER_FUNC,
                                                 utils::StreamHandler());
     }
     catch (const std::exception &e) {

--- a/test/bmi/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Fortran_Adapter_Test.cpp
@@ -43,7 +43,6 @@ protected:
 
     std::string config_file_name_0;
     std::string lib_file_name_0;
-    std::string forcing_file_name_0;
     std::string bmi_module_type_name_0;
     std::unique_ptr<Bmi_Fortran_Adapter> adapter;
 
@@ -88,9 +87,6 @@ void Bmi_Fortran_Adapter_Test::SetUp() {
     std::string config_basename_0 = "test_bmi_fortran_config_0.txt";
     config_file_name_0 = file_search(config_path_options, config_basename_0);
 
-    std::vector<std::string> forcing_dir_opts = {"./data/forcing/", "../data/forcing/", "../../data/forcing/"};
-    forcing_file_name_0 = file_search(forcing_dir_opts, "cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv");
-
     std::vector<std::string> lib_dir_opts = {
             "./extern/test_bmi_fortran/cmake_build/",
             "../extern/test_bmi_fortran/cmake_build/",
@@ -99,7 +95,7 @@ void Bmi_Fortran_Adapter_Test::SetUp() {
     lib_file_name_0 = file_search(lib_dir_opts, BMI_TEST_FORTRAN_LOCAL_LIB_NAME);
     bmi_module_type_name_0 = "test_bmi_fortran";
     adapter = std::make_unique<Bmi_Fortran_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                              forcing_file_name_0, false, true, REGISTRATION_FUNC,
+                                              false, true, REGISTRATION_FUNC,
                                               utils::StreamHandler());
 }
 

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -20,7 +20,6 @@ typedef struct example_scenario {
     std::string bmi_init_config;
     // TODO: probably need to change to package name
     std::string module_directory;
-    std::string forcing_file;
     std::string module_name;
     std::shared_ptr<Bmi_Py_Adapter> adapter;
 } example_scenario;
@@ -132,8 +131,6 @@ void Bmi_Py_Adapter_Test::SetUp() {
     for (size_t i = 0; i < num_example_scenarios; ++i) {
         examples[i] = template_ex_struct;
     }
-
-    examples[0].forcing_file = "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv";
 
     // We can handle setting the right init config and initializing the adapter in a loop
     for (int i = 0; i < examples.size(); ++i) {

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -57,16 +57,8 @@ protected:
         return formulation.get_bmi_model_start_time_forcing_offset_s();
     }
 
-    static std::string get_friend_forcing_file_path(const Bmi_C_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
     static time_t get_friend_forcing_start_time(Bmi_C_Formulation& formulation) {
         return formulation.forcing->get_data_start_time();
-    }
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_C_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
     }
 
     static std::string get_friend_model_type_name(Bmi_C_Formulation& formulation) {
@@ -195,7 +187,6 @@ void Bmi_C_Formulation_Test::SetUp() {
                          "            \"bmi_c\": {"
                          "                \"model_type_name\": \"" + model_type_name[i] + "\","
                          "                \"library_file\": \"" + lib_file[i] + "\","
-                         "                \"forcing_file\": \"" + forcing_file[i] + "\","
                          "                \"init_config\": \"" + init_config[i] + "\","
                          "                \"main_output_variable\": \"" + main_output_variable[i] + "\","
                          "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
@@ -234,10 +225,8 @@ TEST_F(Bmi_C_Formulation_Test, Initialize_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     ASSERT_EQ(get_friend_model_type_name(formulation), model_type_name[ex_index]);
-    ASSERT_EQ(get_friend_forcing_file_path(formulation), forcing_file[ex_index]);
     ASSERT_EQ(get_friend_bmi_init_config(formulation), init_config[ex_index]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variable[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure we can initialize multiple model instances with dynamic loading. */

--- a/test/realizations/catchments/Bmi_C_Pet_IT.cpp
+++ b/test/realizations/catchments/Bmi_C_Pet_IT.cpp
@@ -43,14 +43,6 @@ protected:
         return formulation.get_bmi_main_output_var();
     }
 
-    static std::string get_friend_forcing_file_path(const Bmi_C_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_C_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
-    }
-
     static std::string get_friend_model_type_name(Bmi_C_Formulation& formulation) {
         return formulation.get_model_type_name();
     }
@@ -113,7 +105,7 @@ void Bmi_C_Pet_IT::SetUp() {
     registration_functions[0] = "register_bmi_pet";
     init_config[0] = find_file(bmi_init_cfg_dir_opts, "cat-27_bmi_config.ini");
     main_output_variable[0] = "water_potential_evaporation_flux";
-    uses_forcing_file[0] = true;
+    uses_forcing_file[0] = false;
 
     catchment_ids[1] = "cat-67";
     model_type_name[1] = "bmi_c_pet";
@@ -122,7 +114,7 @@ void Bmi_C_Pet_IT::SetUp() {
     registration_functions[1] = "register_bmi_pet";
     init_config[1] = find_file(bmi_init_cfg_dir_opts, "cat-67_bmi_config.ini");
     main_output_variable[1] = "water_potential_evaporation_flux";
-    uses_forcing_file[1] = true;
+    uses_forcing_file[1] = false;
 
     std::string output_variables = "                \"output_variables\": [\"water_potential_evaporation_flux\"],\n";
 
@@ -140,7 +132,6 @@ void Bmi_C_Pet_IT::SetUp() {
                          "            \"bmi_c\": {"
                          "                \"model_type_name\": \"" + model_type_name[i] + "\","
                          "                \"library_file\": \"" + lib_file[i] + "\","
-                         "                \"forcing_file\": \"" + forcing_file[i] + "\","
                          "                \"init_config\": \"" + init_config[i] + "\","
                          "                \"main_output_variable\": \"" + main_output_variable[i] + "\","
                          "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 9, "
@@ -181,10 +172,8 @@ TEST_F(Bmi_C_Pet_IT, Test_InitModel) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     ASSERT_EQ(get_friend_model_type_name(formulation), model_type_name[ex_index]);
-    ASSERT_EQ(get_friend_forcing_file_path(formulation), forcing_file[ex_index]);
     ASSERT_EQ(get_friend_bmi_init_config(formulation), init_config[ex_index]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variable[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test of get response. */

--- a/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
@@ -55,16 +55,8 @@ protected:
         return formulation.get_bmi_model_start_time_forcing_offset_s();
     }
 
-    static std::string get_friend_forcing_file_path(const Bmi_Cpp_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
     static time_t get_friend_forcing_start_time(Bmi_Cpp_Formulation& formulation) {
         return formulation.forcing->get_data_start_time();
-    }
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_Cpp_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
     }
 
     static std::string get_friend_model_type_name(Bmi_Cpp_Formulation& formulation) {
@@ -194,7 +186,6 @@ void Bmi_Cpp_Formulation_Test::SetUp() {
                          "            \"bmi_c++\": {"
                          "                \"model_type_name\": \"" + model_type_name[i] + "\","
                          "                \"library_file\": \"" + lib_file[i] + "\","
-                         "                \"forcing_file\": \"" + forcing_file[i] + "\","
                          "                \"init_config\": \"" + init_config[i] + "\","
                          "                \"main_output_variable\": \"" + main_output_variable[i] + "\","
                          "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES + "\": { "
@@ -230,10 +221,8 @@ TEST_F(Bmi_Cpp_Formulation_Test, Initialize_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     ASSERT_EQ(get_friend_model_type_name(formulation), model_type_name[ex_index]);
-    ASSERT_EQ(get_friend_forcing_file_path(formulation), forcing_file[ex_index]);
     ASSERT_EQ(get_friend_bmi_init_config(formulation), init_config[ex_index]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variable[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure we can initialize multiple model instances with dynamic loading. */

--- a/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
@@ -74,14 +74,6 @@ protected:
         return formulation.get_bmi_model_start_time_forcing_offset_s();
     }
 
-    static std::string get_friend_forcing_file_path(const Bmi_Multi_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_Multi_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
-    }
-
     static std::string get_friend_nested_module_model_type_name(Bmi_Multi_Formulation& formulation,
                                                                 const int nested_index) {
         return formulation.modules[nested_index]->get_model_type_name();
@@ -319,7 +311,6 @@ TEST_F(Bmi_Cpp_Multi_Array_Test, Initialize_0_a) {
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 0), nested_module_main_output_variables[ex_index][0]);
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure the model config from example 0 initializes no deferred providers. */

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -55,16 +55,8 @@ protected:
         return formulation.get_bmi_model_start_time_forcing_offset_s();
     }
 
-    static std::string get_friend_forcing_file_path(const Bmi_Fortran_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
     static time_t get_friend_forcing_start_time(Bmi_Fortran_Formulation& formulation) {
         return formulation.forcing->get_data_start_time();
-    }
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_Fortran_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
     }
 
     static std::string get_friend_model_type_name(Bmi_Fortran_Formulation& formulation) {
@@ -201,7 +193,6 @@ void Bmi_Fortran_Formulation_Test::SetUp() {
                          "            \"bmi_fortran\": {"
                          "                \"model_type_name\": \"" + model_type_name[i] + "\","
                          "                \"library_file\": \"" + lib_file[i] + "\","
-                         "                \"forcing_file\": \"" + forcing_file[i] + "\","
                          "                \"init_config\": \"" + init_config[i] + "\","
                          "                \"main_output_variable\": \"" + main_output_variable[i] + "\","
                          "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
@@ -243,10 +234,8 @@ TEST_F(Bmi_Fortran_Formulation_Test, Initialize_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     ASSERT_EQ(get_friend_model_type_name(formulation), model_type_name[ex_index]);
-    ASSERT_EQ(get_friend_forcing_file_path(formulation), forcing_file[ex_index]);
     ASSERT_EQ(get_friend_bmi_init_config(formulation), init_config[ex_index]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variable[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure we can initialize multiple model instances with dynamic loading. */

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -100,19 +100,11 @@ protected:
         return formulation.get_bmi_model_start_time_forcing_offset_s();
     }
 
-    static std::string get_friend_forcing_file_path(const Bmi_Multi_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
     /*
     static time_t get_friend_forcing_start_time(Bmi_Multi_Formulation& formulation) {
         return formulation.forcing->get_forcing_output_time_begin("");
     }
     */
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_Multi_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
-    }
 
     static std::string get_friend_nested_module_model_type_name(Bmi_Multi_Formulation& formulation,
                                                                 const int nested_index) {
@@ -514,7 +506,6 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_0_a) {
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 0), nested_module_main_output_variables[ex_index][0]);
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure the model config from example 0 initializes no deferred providers. */
@@ -539,7 +530,6 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_1_a) {
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 0), nested_module_main_output_variables[ex_index][0]);
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure the model config from example 1 initializes no deferred providers. */
@@ -571,7 +561,6 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_3_a) {
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 0), nested_module_main_output_variables[ex_index][0]);
     ASSERT_EQ(get_friend_nested_module_main_output_variable(formulation, 1), nested_module_main_output_variables[ex_index][1]);
     ASSERT_EQ(get_friend_bmi_main_output_var(formulation), main_output_variables[ex_index]);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(formulation), uses_forcing_file[ex_index]);
 }
 
 /** Test to make sure the model config from example 3 initializes expected number of deferred providers. */

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -62,16 +62,8 @@ protected:
     //    return formulation.forcing.get_value_for_param_name(param_name);
     //}
 
-    static std::string get_friend_forcing_file_path(const Bmi_Py_Formulation& formulation) {
-        return formulation.get_forcing_file_path();
-    }
-
     static time_t get_friend_forcing_start_time(Bmi_Py_Formulation& formulation) {
         return formulation.forcing->get_data_start_time();
-    }
-
-    static bool get_friend_is_bmi_using_forcing_file(const Bmi_Py_Formulation& formulation) {
-        return formulation.is_bmi_using_forcing_file();
     }
 
     static std::string get_friend_model_type_name(Bmi_Py_Formulation& formulation) {
@@ -250,7 +242,6 @@ void Bmi_Py_Formulation_Test::generate_realization_config(int ex_idx) {
               "            \"bmi_python\": {"
               "                \"model_type_name\": \"" + examples[ex_idx].module_name + "\","
               "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__PYTHON_TYPE_NAME + "\": \"" + examples[ex_idx].module_name + "\","
-              "                \"forcing_file\": \"" + examples[ex_idx].forcing_params->path + "\","
               "                \"init_config\": \"" + examples[ex_idx].bmi_init_config + "\","
               "                \"main_output_variable\": \"" + examples[ex_idx].main_output_variable + "\","
               "                \"" + BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION + "\": 6, "
@@ -356,10 +347,8 @@ TEST_F(Bmi_Py_Formulation_Test, Initialize_0_a) {
     int ex_index = 0;
 
     ASSERT_EQ(get_friend_model_type_name(*examples[ex_index].formulation), examples[ex_index].module_name);
-    ASSERT_EQ(get_friend_forcing_file_path(*examples[ex_index].formulation), examples[ex_index].forcing_params->path);
     ASSERT_EQ(get_friend_bmi_init_config(*examples[ex_index].formulation), examples[ex_index].bmi_init_config);
     ASSERT_EQ(get_friend_bmi_main_output_var(*examples[ex_index].formulation), examples[ex_index].main_output_variable);
-    ASSERT_EQ(get_friend_is_bmi_using_forcing_file(*examples[ex_index].formulation), examples[ex_index].uses_forcing_file);
 }
 
 /**


### PR DESCRIPTION
Fix #570 by removing support for unimplemented legacy parameters used to configure forcings inputs.

## Removals

- `Bmi_Adapter`: delete `uses_forcing_file` and `forcing_file` (path) members, construction arguments, and accessors
- BMI Formulation classes: stop passing `forcing_file` arguments through to BMI Adapter classes

## Changes

- Delete all `forcing_file` keys in JSON built in test fixtures
- Throw errors on affirmative use of the never-active and now-removed configuration options

## Testing

1. `ctest`
2. CI

## Notes

- There may be documentation that should evolve in tandem
- Users with legacy realization configs may start to see errors related to this. They've already almost certainly added the right options, since otherwise their runs just wouldn't work. So, fixing things is just a matter of removing the old bits from their files.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: