### PR TITLE
Fix warnings from -Wsuggest-override

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -182,7 +182,7 @@ runs:
           run: |
             export BOOST_ROOT="$(pwd)/boost_1_79_0"
             export CFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -Werror"
-            export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -pedantic-errors -Werror -Wpessimizing-move -Wparentheses -Wrange-loop-construct"
+            export CXXFLAGS="-fsanitize=address -O1 -g -fno-omit-frame-pointer -pedantic-errors -Werror -Wpessimizing-move -Wparentheses -Wrange-loop-construct -Wsuggest-override"
             . .venv/bin/activate
             [ ! -d "$BOOST_ROOT" ] && echo "Error: no Boost root found at $BOOST_ROOT" && exit 1
             cmake -B ${{ inputs.build-dir }} \

--- a/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
+++ b/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
@@ -41,62 +41,62 @@ class TestBmiCpp : public bmi::Bmi {
             set_usage(input_array, output_array, model_params);
         };
 
-        virtual void Initialize(std::string config_file);
-        virtual void Update();
-        virtual void UpdateUntil(double time);
-        virtual void Finalize();
+        virtual void Initialize(std::string config_file) override;
+        virtual void Update() override;
+        virtual void UpdateUntil(double time) override;
+        virtual void Finalize() override;
 
         // Model information functions.
-        virtual std::string GetComponentName();
-        virtual int GetInputItemCount();
-        virtual int GetOutputItemCount();
-        virtual std::vector<std::string> GetInputVarNames();
-        virtual std::vector<std::string> GetOutputVarNames();
+        virtual std::string GetComponentName() override;
+        virtual int GetInputItemCount() override;
+        virtual int GetOutputItemCount() override;
+        virtual std::vector<std::string> GetInputVarNames() override;
+        virtual std::vector<std::string> GetOutputVarNames() override;
 
         // Variable information functions
-        virtual int GetVarGrid(std::string name);
-        virtual std::string GetVarType(std::string name);
-        virtual std::string GetVarUnits(std::string name);
-        virtual int GetVarItemsize(std::string name);
-        virtual int GetVarNbytes(std::string name);
-        virtual std::string GetVarLocation(std::string name);
+        virtual int GetVarGrid(std::string name) override;
+        virtual std::string GetVarType(std::string name) override;
+        virtual std::string GetVarUnits(std::string name) override;
+        virtual int GetVarItemsize(std::string name) override;
+        virtual int GetVarNbytes(std::string name) override;
+        virtual std::string GetVarLocation(std::string name) override;
 
-        virtual double GetCurrentTime();
-        virtual double GetStartTime();
-        virtual double GetEndTime();
-        virtual std::string GetTimeUnits();
-        virtual double GetTimeStep();
+        virtual double GetCurrentTime() override;
+        virtual double GetStartTime() override;
+        virtual double GetEndTime() override;
+        virtual std::string GetTimeUnits() override;
+        virtual double GetTimeStep() override;
 
         // Variable getters
-        virtual void GetValue(std::string name, void *dest);
-        virtual void *GetValuePtr(std::string name);
-        virtual void GetValueAtIndices(std::string name, void *dest, int *inds, int count);
+        virtual void GetValue(std::string name, void *dest) override;
+        virtual void *GetValuePtr(std::string name) override;
+        virtual void GetValueAtIndices(std::string name, void *dest, int *inds, int count) override;
 
         // Variable setters
-        virtual void SetValue(std::string name, void *src);
-        virtual void SetValueAtIndices(std::string name, int *inds, int count, void *src);
+        virtual void SetValue(std::string name, void *src) override;
+        virtual void SetValueAtIndices(std::string name, int *inds, int count, void *src) override;
 
         // Grid information functions
-        virtual int GetGridRank(const int grid);
-        virtual int GetGridSize(const int grid);
-        virtual std::string GetGridType(const int grid);
+        virtual int GetGridRank(const int grid) override;
+        virtual int GetGridSize(const int grid) override;
+        virtual std::string GetGridType(const int grid) override;
 
-        virtual void GetGridShape(const int grid, int *shape);
-        virtual void GetGridSpacing(const int grid, double *spacing);
-        virtual void GetGridOrigin(const int grid, double *origin);
+        virtual void GetGridShape(const int grid, int *shape) override;
+        virtual void GetGridSpacing(const int grid, double *spacing) override;
+        virtual void GetGridOrigin(const int grid, double *origin) override;
 
-        virtual void GetGridX(int grid, double *x);
-        virtual void GetGridY(const int grid, double *y);
-        virtual void GetGridZ(const int grid, double *z);
+        virtual void GetGridX(int grid, double *x) override;
+        virtual void GetGridY(const int grid, double *y) override;
+        virtual void GetGridZ(const int grid, double *z) override;
 
-        virtual int GetGridNodeCount(const int grid);
-        virtual int GetGridEdgeCount(const int grid);
-        virtual int GetGridFaceCount(const int grid);
+        virtual int GetGridNodeCount(const int grid) override;
+        virtual int GetGridEdgeCount(const int grid) override;
+        virtual int GetGridFaceCount(const int grid) override;
 
-        virtual void GetGridEdgeNodes(const int grid, int *edge_nodes);
-        virtual void GetGridFaceEdges(const int grid, int *face_edges);
-        virtual void GetGridFaceNodes(const int grid, int *face_nodes);
-        virtual void GetGridNodesPerFace(const int grid, int *nodes_per_face);
+        virtual void GetGridEdgeNodes(const int grid, int *edge_nodes) override;
+        virtual void GetGridFaceEdges(const int grid, int *face_edges) override;
+        virtual void GetGridFaceNodes(const int grid, int *face_nodes) override;
+        virtual void GetGridNodesPerFace(const int grid, int *nodes_per_face) override;
 
 
 

--- a/include/bmi/State_Exception.hpp
+++ b/include/bmi/State_Exception.hpp
@@ -29,7 +29,7 @@ namespace models {
             State_Exception(State_Exception &&exception) noexcept
                     : State_Exception(std::move(exception.what_message)) {}
 
-            virtual char const *what() const noexcept {
+            virtual char const *what() const noexcept override {
                 return what_message.c_str();
             }
 

--- a/include/core/nexus/HY_PointHydroNexus.hpp
+++ b/include/core/nexus/HY_PointHydroNexus.hpp
@@ -14,19 +14,19 @@ class HY_PointHydroNexus : public HY_HydroNexus
         virtual ~HY_PointHydroNexus();
 
         /** get the request percentage of downstream flow through this nexus at timestep t. */
-        double get_downstream_flow(std::string catchment_id, time_step_t t, double percent_flow);
+        double get_downstream_flow(std::string catchment_id, time_step_t t, double percent_flow) override;
 
         /** add flow to this nexus for timestep t. */
-        void add_upstream_flow(double val, std::string catchment_id, time_step_t t);
+        void add_upstream_flow(double val, std::string catchment_id, time_step_t t) override;
 
         /** inspect a nexus to see what flows are recorded at a time step. */
-        std::pair<double, int> inspect_upstream_flows(time_step_t t);
+        std::pair<double, int> inspect_upstream_flows(time_step_t t) override;
 
         /** inspect a nexus to see what requests are recorded at a time step. */
-        virtual std::pair<double, int> inspect_downstream_requests(time_step_t t);
+        virtual std::pair<double, int> inspect_downstream_requests(time_step_t t) override;
 
         /** get the units that flows are represented in. */
-        std::string get_flow_units();
+        std::string get_flow_units() override;
 
         void set_mintime(time_step_t);
 

--- a/include/core/nexus/HY_PointHydroNexusRemote.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemote.hpp
@@ -36,10 +36,10 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
 
         /** get the request percentage of downstream flow through this nexus at timestep t. If the indicated catchment is not local a async send will be
             created. Will attempt to process all async receives currently queued before processing flows*/
-        double get_downstream_flow(std::string catchment_id, time_step_t t, double percent_flow);
+        double get_downstream_flow(std::string catchment_id, time_step_t t, double percent_flow) override;
 
         /** add flow to this nexus for timestep t. If the indicated catchment is not local an async receive will be started*/
-        void add_upstream_flow(double val, std::string catchment_id, time_step_t t);
+        void add_upstream_flow(double val, std::string catchment_id, time_step_t t) override;
 
         /** extract a numeric id from the catchment id for use as a mpi tag */
         static long extract(std::string s) {  return std::stoi( s.substr( s.find(hy_features::identifiers::seperator)+1 ) ); }

--- a/include/geojson/features/CollectionFeature.hpp
+++ b/include/geojson/features/CollectionFeature.hpp
@@ -209,7 +209,7 @@ namespace geojson {
                 return this->geometry_collection.cend();
             }
 
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/geojson/features/LineStringFeature.hpp
+++ b/include/geojson/features/LineStringFeature.hpp
@@ -37,7 +37,7 @@ namespace geojson {
                 return boost::get<linestring_t>(this->geom);
             }
 
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/geojson/features/MultiLineStringFeature.hpp
+++ b/include/geojson/features/MultiLineStringFeature.hpp
@@ -37,7 +37,7 @@ namespace geojson {
                 return boost::get<multilinestring_t>(this->geom);
             }
 
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/geojson/features/MultiPointFeature.hpp
+++ b/include/geojson/features/MultiPointFeature.hpp
@@ -37,7 +37,7 @@ namespace geojson {
                 return boost::get<multipoint_t>(this->geom);
             }
 
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/geojson/features/MultiPolygonFeature.hpp
+++ b/include/geojson/features/MultiPolygonFeature.hpp
@@ -37,7 +37,7 @@ namespace geojson {
                 return boost::get<multipolygon_t>(this->geom);
             }
 
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/geojson/features/PointFeature.hpp
+++ b/include/geojson/features/PointFeature.hpp
@@ -38,7 +38,7 @@ namespace geojson {
                 return boost::get<coordinate_t>(this->geom);
             }
 
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/geojson/features/PolygonFeature.hpp
+++ b/include/geojson/features/PolygonFeature.hpp
@@ -58,7 +58,7 @@ namespace geojson {
             /**
              * Runs a visitor function on this feature
              */
-            void visit(FeatureVisitor& visitor) {
+            void visit(FeatureVisitor& visitor) override {
                 visitor.visit(this);
             }
     };

--- a/include/utilities/ConfigurationException.hpp
+++ b/include/utilities/ConfigurationException.hpp
@@ -23,7 +23,7 @@ namespace realization {
         ConfigurationException(ConfigurationException &&exception) noexcept
                 : ConfigurationException(std::move(exception.what_message)) {}
 
-        virtual char const *what() const noexcept {
+        char const *what() const noexcept override {
             return what_message.c_str();
         }
 

--- a/include/utilities/ExternalIntegrationException.hpp
+++ b/include/utilities/ExternalIntegrationException.hpp
@@ -24,7 +24,7 @@ namespace external {
         ExternalIntegrationException(ExternalIntegrationException &&exception) noexcept
         : ExternalIntegrationException(std::move(exception.what_message)) {}
 
-        virtual char const *what() const noexcept {
+        char const *what() const noexcept override {
             return what_message.c_str();
         }
 

--- a/src/core/nexus/HY_PointHydroNexus.cpp
+++ b/src/core/nexus/HY_PointHydroNexus.cpp
@@ -6,27 +6,27 @@ typedef boost::error_info<struct tag_errmsg, std::string> errmsg_info;
 
 struct invalid_downstream_request : public boost::exception, public std::exception
 {
-  const char *what() const noexcept { return "All downstream catchments can not request more than 100% of flux in total"; }
+  const char *what() const noexcept override { return "All downstream catchments can not request more than 100% of flux in total"; }
 };
 
 struct add_to_summed_nexus : public boost::exception, public std::exception
 {
-  const char *what() const noexcept { return "Can not add water to a summed point nexus"; }
+  const char *what() const noexcept override { return "Can not add water to a summed point nexus"; }
 };
 
 struct request_from_empty_nexus : public boost::exception, public std::exception
 {
-  const char *what() const noexcept { return "Can not release water from an empty nexus"; }
+  const char *what() const noexcept override { return "Can not release water from an empty nexus"; }
 };
 
 struct completed_time_step : public boost::exception, public std::exception
 {
-  const char *what() const noexcept { return "Can not operate on a completed time step"; }
+  const char *what() const noexcept override { return "Can not operate on a completed time step"; }
 };
 
 struct invalid_time_step : public boost::exception, public std::exception
 {
-  const char *what() const noexcept { return "Time step before minimum time step requested"; }
+  const char *what() const noexcept override { return "Time step before minimum time step requested"; }
 };
 
 HY_PointHydroNexus::HY_PointHydroNexus(std::string nexus_id, Catchments receiving_catchments) : HY_HydroNexus( nexus_id, receiving_catchments), upstream_flows()

--- a/test/core/NetworkTests.cpp
+++ b/test/core/NetworkTests.cpp
@@ -133,7 +133,7 @@ public:
 class Network_Test2 : public Network_Test, public ::testing::Test{
 public:
   Network_Test2(){}
-  void SetUp(){
+  void SetUp() override {
     this->add_catchment("cat-0", "nex-0");
     this->add_catchment("cat-1", "nex-0");
     this->add_nexus("nex-0", "cat-2");

--- a/test/geojson/FeatureCollection_Test.cpp
+++ b/test/geojson/FeatureCollection_Test.cpp
@@ -27,31 +27,31 @@ class FeatureCollection_Test : public ::testing::Test {
 
 class Visitor : public geojson::FeatureVisitor {
     public:
-        void visit(geojson::PointFeature *feature) {
+        void visit(geojson::PointFeature *feature) override {
             this->types.push_back("PointFeature");
         }
 
-        void visit(geojson::LineStringFeature *feature) {
+        void visit(geojson::LineStringFeature *feature) override {
             this->types.push_back("LineStringFeature");
         }
 
-        void visit(geojson::PolygonFeature *feature) {
+        void visit(geojson::PolygonFeature *feature) override {
             this->types.push_back("PolygonFeature");
         }
 
-        void visit(geojson::MultiPointFeature *feature) {
+        void visit(geojson::MultiPointFeature *feature) override {
             this->types.push_back("MultiPointFeature");
         }
 
-        void visit(geojson::MultiLineStringFeature *feature) {
+        void visit(geojson::MultiLineStringFeature *feature) override {
             this->types.push_back("MultiLineStringFeature");
         }
 
-        void visit(geojson::MultiPolygonFeature *feature) {
+        void visit(geojson::MultiPolygonFeature *feature) override {
             this->types.push_back("MultiPolygonFeature");
         }
 
-        void visit(geojson::CollectionFeature *feature) {
+        void visit(geojson::CollectionFeature *feature) override {
             this->types.push_back("CollectionFeature");
         }
 


### PR DESCRIPTION
We want to be able to build the code as strictly as possible without compiler warnings. This fixes warnings from `-Wsuggest-override`, which indicates the potential for hidden mistakes relating to dynamic method dispatch, and hence incorrect results.

## Changes

- Add `override` on various member function declarations throughout the code and tests
- Update Sloth with https://github.com/NOAA-OWP/SLoTH/pull/6
- Add `-Wsuggest-override` to CI build with `-Werror` so new instances aren't introduced

## Testing

1. CI passes with no instances of the offending warning

## Notes

- Once https://github.com/Unidata/netcdf-cxx4/pull/152 is merged, we can update our submodule of netcdf-cxx4. In the meanwhile, it's not used in CI, so there's no failure from it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: