### PR TITLE
Fix warnings about non-virtual destructors for non-BMI classes with virtual methods

### DIFF
--- a/include/geojson/FeatureVisitor.hpp
+++ b/include/geojson/FeatureVisitor.hpp
@@ -27,6 +27,8 @@ namespace geojson {
             virtual void visit(MultiLineStringFeature *feature) = 0;
             virtual void visit(MultiPolygonFeature *feature) = 0;
             virtual void visit(CollectionFeature* feature) = 0;
+
+            virtual ~FeatureVisitor() = default;
     };
 }
 #endif

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -47,7 +47,7 @@ namespace realization {
 
             ~Formulation_Manager() = default;
 
-            virtual void read(geojson::GeoJSON fabric, utils::StreamHandler output_stream) {
+            void read(geojson::GeoJSON fabric, utils::StreamHandler output_stream) {
                 //TODO seperate the parsing of configuration options like time
                 //and routing and other non feature specific tasks from this main function
                 //which has to iterate the entire hydrofabric.
@@ -180,46 +180,46 @@ namespace realization {
                 }
             }
 
-            virtual void add_formulation(std::shared_ptr<Catchment_Formulation> formulation) {
+            void add_formulation(std::shared_ptr<Catchment_Formulation> formulation) {
                 this->formulations.emplace(formulation->get_id(), formulation);
             }
 
-            virtual std::shared_ptr<Catchment_Formulation> get_formulation(std::string id) const {
+            std::shared_ptr<Catchment_Formulation> get_formulation(std::string id) const {
                 // TODO: Implement on-the-fly formulation creation using global parameters
                 return this->formulations.at(id);
             }
 
-            virtual std::shared_ptr<Catchment_Formulation> get_domain_formulation(long id) const {
+            std::shared_ptr<Catchment_Formulation> get_domain_formulation(long id) const {
                 return this->domain_formulations.at(id);
             }
 
-            virtual bool has_domain_formulation(int id) const {
+            bool has_domain_formulation(int id) const {
                 return this->domain_formulations.count( id ) > 0;
             }
 
-            virtual bool contains(std::string identifier) const {
+            bool contains(std::string identifier) const {
                 return this->formulations.count(identifier) > 0;
             }
 
             /**
              * @return The number of elements within the collection
              */
-            virtual int get_size() {
+            int get_size() {
                 return this->formulations.size();
             }
 
             /**
              * @return Whether or not the collection is empty
              */
-            virtual bool is_empty() {
+            bool is_empty() {
                 return this->formulations.empty();
             }
 
-            virtual typename std::map<std::string, std::shared_ptr<Catchment_Formulation>>::const_iterator begin() const {
+            typename std::map<std::string, std::shared_ptr<Catchment_Formulation>>::const_iterator begin() const {
                 return this->formulations.cbegin();
             }
 
-            virtual typename std::map<std::string, std::shared_ptr<Catchment_Formulation>>::const_iterator end() const {
+            typename std::map<std::string, std::shared_ptr<Catchment_Formulation>>::const_iterator end() const {
                 return this->formulations.cend();
             }
 

--- a/include/utilities/python/HydrofabricSubsetter.hpp
+++ b/include/utilities/python/HydrofabricSubsetter.hpp
@@ -89,7 +89,7 @@ namespace utils {
                                                              py_cli(std::move(p.py_cli)),
                                                              partitionsConfigFile(std::move(p.partitionsConfigFile)) { }
 
-            virtual bool execSubdivision() {
+            bool execSubdivision() {
                 bool result;
                 try {
                     py::bool_ bool_result = py_cli.attr("divide_hydrofabric")();
@@ -102,7 +102,7 @@ namespace utils {
                 return result;
             }
 
-            virtual bool execSubdivision(int index) {
+            bool execSubdivision(int index) {
                 bool result;
                 try {
                     py::bool_ bool_result = py_cli.attr("divide_hydrofabric")(index);


### PR DESCRIPTION
We want to build warning-clean, and `-Wnon-virtual-dtor` can signal some serious potential errors. This PR fixes internal cases that trigger the warning.

## Changes

- `Formulation_Manager` and HydrofabricSubsetter: remove `virtual` marking on member functions, since the classes don't have descendants that need virtual dispatch
- `geojson::FeatureVisitor`: add virtual destructor

## Testing

1. CI

## Notes

- BMI module class change will come in a separate PR, that changes both our copies and external git submodules together

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: