### PR TITLE
ci: fix troute build

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -119,14 +119,10 @@ jobs:
             export LIBRARY_PATH=/usr/local/lib/gcc/11/
             export LD_LIBRARY_PATH=/usr/local/lib/gcc/11/
           fi
-          sed -i.bak 's/NETCDF}"/NETCDF}\/include"/' compiler.sh
+          export NETCDFALTERNATIVE=${NETCDF}/include
           export FC=gfortran
           export F90=gfortran 
-          ./compiler.sh
-          cd src
-          pip install troute-nwm/
-          pip install --install-option="--use-cython" troute-network/
-          pip install --install-option="--use-cython" troute-routing/
+          ./compiler.sh no-e
           
           deactivate
 


### PR DESCRIPTION
Fix `t-route` CI builds after changes introduced in https://github.com/NOAA-OWP/t-route/pull/780. https://github.com/NOAA-OWP/t-route/pull/780 at its core addressed the need for the python `wheel` package as a build time dependency. `wheel` was not installed in CI before attempting to build `t-route`. This addresses that.