### PR TITLE
Forcings Engine Data Provider Base Interface

### DIFF
--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <NGenConfig.h>
+
+#if NGEN_WITH_PYTHON
+
 #include <cmath>
 #include <chrono>
 #include <memory>
@@ -211,3 +215,5 @@ struct ForcingsEngineDataProvider
 };
 
 } // namespace data_access
+
+#endif // NGEN_WITH_PYTHON

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -60,7 +60,7 @@ struct ForcingsEngineStorage {
     }
 
     //! Associate a Forcings Engine instance to a file path.
-    //! @param key Initiailiation file path for Forcings Engine instance.
+    //! @param key Initialization file path for Forcings Engine instance.
     //! @param value Shared pointer to a Forcings Engine BMI instance.
     void set(const key_type& key, value_type value)
     {

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -178,7 +178,6 @@ struct ForcingsEngineDataProvider
                 "ForcingsEngine",
                 init,
                 forcings_engine_python_classpath,
-                /*allow_exceed_end=*/true,
                 /*has_fixed_time_step=*/true
             );
 

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
-#include <memory>
-#include <unordered_map>
+#include <cmath>
 #include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "DataProvider.hpp"
 #include "bmi/Bmi_Py_Adapter.hpp"
-#include "utilities/StreamHandler.hpp"
 
 namespace data_access {
 
@@ -158,7 +161,7 @@ struct ForcingsEngineDataProvider
     //! @note Derived implementations should delegate to this constructor
     //!       to acquire a shared forcings engine instance.
     ForcingsEngineDataProvider(
-        std::string init,
+        const std::string& init,
         std::size_t time_begin_seconds,
         std::size_t time_end_seconds
     )

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -6,6 +6,7 @@
 
 #include "DataProvider.hpp"
 #include "bmi/Bmi_Py_Adapter.hpp"
+#include "utilities/StreamHandler.hpp"
 
 namespace data_access {
 

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -176,8 +176,7 @@ struct ForcingsEngineDataProvider
                 init,
                 forcings_engine_python_classpath,
                 /*allow_exceed_end=*/true,
-                /*has_fixed_time_step=*/true,
-                utils::getStdOut()
+                /*has_fixed_time_step=*/true
             );
 
             storage_type::instances.set(init, bmi_);

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <chrono>
+
+#include "DataProvider.hpp"
+#include "bmi/Bmi_Py_Adapter.hpp"
+
+namespace data_access {
+
+//! Python module name for NextGen Forcings Engine
+static constexpr auto forcings_engine_python_module = "NextGen_Forcings_Engine";
+
+//! Python classname for NextGen Forcings Engine BMI class
+static constexpr auto forcings_engine_python_class  = "NWMv3_Forcing_Engine_BMI_model";
+
+//! Full Python classpath for Forcings Engine BMI class
+static constexpr auto forcings_engine_python_classpath = "NextGen_Forcings_Engine.NWMv3_Forcing_Engine_BMI_model";
+
+//! Default time format used for parsing timestamp strings
+static constexpr auto default_time_format = "%Y-%m-%d %H:%M:%S";
+
+namespace detail {
+
+//! Parse time string from format.
+//! Utility function for ForcingsEngineLumpedDataProvider constructor.
+time_t parse_time(const std::string& time, const std::string& fmt);
+
+//! Check that requirements for running the forcings engine
+//! are available at runtime. If requirements are not available,
+//! then this function throws.
+void assert_forcings_engine_requirements();
+
+//! Storage for Forcings Engine-specific BMI instances.
+struct ForcingsEngineStorage {
+    using key_type   = std::string;
+    using bmi_type   = models::bmi::Bmi_Py_Adapter;
+    using value_type = std::shared_ptr<bmi_type>;
+
+    static ForcingsEngineStorage instances;
+
+    value_type get(const key_type& key)
+    {
+        auto pos = data_.find(key);
+        if (pos == data_.end()) {
+          return nullptr;
+        }
+
+        return pos->second;
+    }
+
+    void set(const key_type& key, value_type value)
+    {
+        data_[key] = value;
+    }
+
+    void clear()
+    {
+        data_.clear();
+    }
+
+  private:
+    //! Instance map of underlying BMI models.
+    std::unordered_map<key_type, value_type> data_;
+};
+
+} // namespace detail
+
+
+//! Forcings Engine Data Provider
+//! @tparam DataType Data type for values returned from derived classes
+//! @tparam SelectionType Selector type for querying data from derived classes
+template<typename DataType, typename SelectionType>
+struct ForcingsEngineDataProvider
+  : public DataProvider<DataType, SelectionType>
+{
+    using data_type = DataType;
+    using selection_type = SelectionType;
+    using clock_type = std::chrono::system_clock;
+
+    ~ForcingsEngineDataProvider() override = default;
+
+    boost::span<const std::string> get_available_variable_names() override
+    {
+        return var_output_names_;
+    }
+
+    long get_data_start_time() override
+    {
+        return clock_type::to_time_t(time_begin_);
+    }
+
+    long get_data_stop_time() override
+    {
+        return clock_type::to_time_t(time_end_);
+    }
+
+    long record_duration() override
+    {
+        return std::chrono::duration_cast<std::chrono::seconds>(time_step_).count();
+    }
+
+    size_t get_ts_index_for_time(const time_t& epoch_time) override
+    {
+        const auto epoch = clock_type::from_time_t(epoch_time);
+
+        if (epoch < time_begin_ || epoch > time_end_) {
+          throw std::out_of_range{
+            "epoch " + std::to_string(epoch.time_since_epoch().count()) +
+            " out of range of " + std::to_string(time_begin_.time_since_epoch().count()) + ", "
+            + std::to_string(time_end_.time_since_epoch().count())
+          };
+        }
+
+        return (epoch - time_begin_) / time_step_;
+    }
+
+    std::shared_ptr<models::bmi::Bmi_Py_Adapter> model() noexcept
+    {
+        return bmi_;
+    }
+
+    /* Remaining virtual member functions from DataProvider must be implemented
+       by derived classes. */
+
+    data_type get_value(
+      const selection_type& selector,
+      data_access::ReSampleMethod m
+    ) override = 0;
+
+    std::vector<data_type> get_values(
+      const selection_type& selector,
+      data_access::ReSampleMethod m
+    ) override = 0;
+
+  protected:
+    using storage_type = detail::ForcingsEngineStorage;
+
+    ForcingsEngineDataProvider(
+        std::string init,
+        std::size_t time_begin_seconds,
+        std::size_t time_end_seconds
+    )
+      : time_begin_(std::chrono::seconds{time_begin_seconds})
+      , time_end_(std::chrono::seconds{time_end_seconds})
+      , bmi_(storage_type::instances.get(init))
+      , time_step_(std::chrono::seconds{static_cast<int64_t>(bmi_->GetTimeStep())})
+      , time_current_index_(std::chrono::seconds{static_cast<int64_t>(bmi_->GetCurrentTime())} / time_step_)
+      , var_output_names_(bmi_->GetOutputVarNames())
+    {}
+
+    
+    //! Update the Forcings Engine instance to the next timestep.
+    void next()
+    {
+        bmi_->Update();
+        time_current_index_++;
+    }
+
+    //! Update the Forcings Engine instance to the next timestep before `time`.
+    //! @param time Time in seconds to update to.
+    //!             i.e. A value of 14401 will update
+    //!                  the instance to the 5th time index,
+    //!                  since 3600 * 4 = 14400 but 14400 < 14401.
+    void next(double time)
+    {
+      const auto start = bmi_->GetCurrentTime();
+      bmi_->UpdateUntil(time);
+      const auto end = bmi_->GetCurrentTime();
+      time_current_index_ += static_cast<int64_t>(
+        (end - start) / bmi_->GetTimeStep()
+      );
+    }
+
+    //! Forcings Engine instance
+    std::shared_ptr<models::bmi::Bmi_Py_Adapter> bmi_ = nullptr;
+
+    //! Output variable names
+    std::vector<std::string> var_output_names_{};
+
+  private:
+    //! Initialization config file path
+    std::string init_;
+
+    clock_type::time_point time_begin_{};
+    clock_type::time_point time_end_{};
+    clock_type::duration   time_step_{};
+    std::size_t            time_current_index_{};
+};
+
+
+//! Forcings Engine factory constructor function
+//! @param init File path to instance initialization file.
+//! @param time_begin Beginning time of simulation in timestamp form.
+//! @param time_end End time of simulation in timestamp form.
+//! @param time_fmt Parse format for timestamp strings.
+//! @param args Additional arguments passed to derived constructor.
+//! @tparam Tp Derived Forcings Engine Type.
+//! @tparam Args Additional argument types passed to derived constructor.
+//! @note This function requires that @c Tp must derive from
+//!       type @c ForcingsEngineDataProvider<Tp::data_type, Tp::selection_type>.
+template<
+  typename Tp,
+  typename... Args,
+  std::enable_if_t<
+    std::is_base_of<
+      ForcingsEngineDataProvider<
+        typename Tp::data_type,
+        typename Tp::selection_type
+      >,
+      Tp
+    >::value,
+    bool
+  > = true
+>
+std::unique_ptr<typename Tp::base_type> make_forcings_engine(
+  const std::string& init,
+  const std::string& time_begin,
+  const std::string& time_end,
+  const std::string& time_fmt = default_time_format,
+  Args&&...          args
+)
+{
+    using storage_type = detail::ForcingsEngineStorage;
+
+    // Ensure python and other requirements are met to use
+    // the python forcings engine.
+    // TODO: Move this to a place where it only runs once,
+    //       possibly in NGen.cpp?
+    detail::assert_forcings_engine_requirements();
+
+    // Get or create a BMI instance based on the init config path
+    auto instance = storage_type::instances.get(init);
+    if (instance == nullptr) {
+        instance = std::make_shared<models::bmi::Bmi_Py_Adapter>(
+            "ForcingsEngine",
+            init,
+            forcings_engine_python_classpath,
+            /*allow_exceed_end=*/true,
+            /*has_fixed_time_step=*/true,
+            utils::getStdOut()
+        );
+
+        storage_type::instances.set(init, instance);
+    }
+
+    // Create the derived instance
+    return std::make_unique<Tp>(
+        init,
+        detail::parse_time(time_begin, time_fmt),
+        detail::parse_time(time_end, time_fmt),
+        std::forward<Args>(args)...
+    );
+}
+
+
+} // namespace data_access

--- a/include/forcing/GenericDataProvider.hpp
+++ b/include/forcing/GenericDataProvider.hpp
@@ -6,12 +6,7 @@
 
 namespace data_access
 {
-    class GenericDataProvider : public DataProvider<double, CatchmentAggrDataSelector>
-    {
-        public:
-
-        private:
-    };
+    using GenericDataProvider = DataProvider<double, CatchmentAggrDataSelector>;
 }
 
 #endif

--- a/include/forcing/NullForcingProvider.hpp
+++ b/include/forcing/NullForcingProvider.hpp
@@ -3,8 +3,6 @@
 
 #include <vector>
 #include <string>
-#include <stdexcept>
-#include <limits>
 #include "GenericDataProvider.hpp"
 
 /**
@@ -14,43 +12,25 @@ class NullForcingProvider : public data_access::GenericDataProvider
 {
     public:
 
-    NullForcingProvider(){}
+    NullForcingProvider();
 
     // BEGIN DataProvider interface methods
 
-    long get_data_start_time() override {
-        return 0;
-    }
+    long get_data_start_time() override;
 
-    long get_data_stop_time() override {
-        return LONG_MAX;
-    }
+    long get_data_stop_time() override;
 
-    long record_duration() override {
-        return 1;
-    }
+    long record_duration() override;
 
-    size_t get_ts_index_for_time(const time_t &epoch_time) override {
-        return 0;
-    }
+    size_t get_ts_index_for_time(const time_t &epoch_time) override;
 
-    double get_value(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
-    {
-        throw std::runtime_error("Called get_value function in NullDataProvider");
-    }
+    double get_value(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override;
 
-    virtual std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override
-    {
-        throw std::runtime_error("Called get_values function in NullDataProvider");
-    }
+    std::vector<double> get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m) override;
 
-    inline bool is_property_sum_over_time_step(const std::string& name) override {
-        throw std::runtime_error("Got request for variable " + name + " but no such variable is provided by NullForcingProvider." + SOURCE_LOC);
-    }
+    inline bool is_property_sum_over_time_step(const std::string& name) override;
 
-    boost::span<const std::string> get_available_variable_names() override {
-        return {};
-    }
+    boost::span<const std::string> get_available_variable_names() override;
 };
 
 #endif // NGEN_NULLFORCING_H

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -27,4 +27,12 @@ if(NGEN_WITH_NETCDF)
     target_link_libraries(forcing PUBLIC NetCDF)
 endif()
 
+if(NGEN_WITH_PYTHON)
+    target_sources(forcing
+      PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/ForcingsEngineDataProvider.cpp"
+    )
+    target_link_libraries(forcing PUBLIC pybind11::embed NGen::ngen_bmi)
+endif()
+
 #target_compile_options(forcing PUBLIC -std=c++14 -Wall)

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -1,7 +1,6 @@
-include(${PROJECT_SOURCE_DIR}/cmake/dynamic_sourced_library.cmake)
-dynamic_sourced_cxx_library(forcing "${CMAKE_CURRENT_SOURCE_DIR}")
-
+add_library(forcing)
 add_library(NGen::forcing ALIAS forcing)
+
 
 find_package(Threads REQUIRED)
 
@@ -14,12 +13,17 @@ target_include_directories(forcing PUBLIC
         )
 
 target_link_libraries(forcing PUBLIC
+        NGen::config_header
+        NGen::core
         Boost::boost                # Headers-only Boost
         NGen::config_header
         Threads::Threads
 )
 
+target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/NullForcingProvider.cpp")
+
 if(NGEN_WITH_NETCDF)
+    target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/NetCDFPerFeatureDataProvider.cpp")
     target_link_libraries(forcing PUBLIC NetCDF)
 endif()
 

--- a/src/forcing/ForcingsEngineDataProvider.cpp
+++ b/src/forcing/ForcingsEngineDataProvider.cpp
@@ -1,6 +1,7 @@
 #include <forcing/ForcingsEngineDataProvider.hpp>
 #include <utilities/python/InterpreterUtil.hpp>
 
+#include <ctime> // timegm
 #include <iomanip> // std::get_time
 
 namespace data_access {
@@ -15,7 +16,7 @@ time_t parse_time(const std::string& time, const std::string& fmt)
     std::stringstream tmstr{time};
     tmstr >> std::get_time(&tm_, fmt.c_str());
 
-    // Note: `timegm` is available for Linux and BSD (aka macOS) via time.h, but not Windows.
+    // Note: `timegm` is available for Linux and macOS via time.h, but not Windows.
     return timegm(&tm_);
 }
 

--- a/src/forcing/ForcingsEngineDataProvider.cpp
+++ b/src/forcing/ForcingsEngineDataProvider.cpp
@@ -1,0 +1,47 @@
+#include <forcing/ForcingsEngineDataProvider.hpp>
+#include <utilities/python/InterpreterUtil.hpp>
+
+#include <iomanip> // std::get_time
+
+namespace data_access {
+namespace detail {
+
+// Initialize instance storage
+ForcingsEngineStorage ForcingsEngineStorage::instances{};
+
+time_t parse_time(const std::string& time, const std::string& fmt)
+{
+    std::tm tm_ = {};
+    std::stringstream tmstr{time};
+    tmstr >> std::get_time(&tm_, fmt.c_str());
+
+    // Note: `timegm` is available for Linux and BSD (aka macOS) via time.h, but not Windows.
+    return timegm(&tm_);
+}
+
+void assert_forcings_engine_requirements()
+{
+    // Check that the python module is installed.
+    {
+        auto interpreter_ = utils::ngenPy::InterpreterUtil::getInstance();
+        try {
+            auto mod = interpreter_->getModule(forcings_engine_python_module);
+            auto cls = mod.attr(forcings_engine_python_class).cast<py::object>();
+        } catch(std::exception& e) {
+            throw std::runtime_error{
+                "Failed to initialize ForcingsEngine: ForcingsEngine python module is not installed or is not properly configured. (" + std::string{e.what()} + ")"
+            };
+        }
+    }
+
+    // Check that the WGRIB2 environment variable is defined
+    {
+        const auto* wgrib2_exec = std::getenv("WGRIB2");
+        if (wgrib2_exec == nullptr) {
+            throw std::runtime_error{"Failed to initialize ForcingsEngine: $WGRIB2 is not defined"};
+        }
+    }
+}
+
+} // namespace detail
+} // namespace data_access

--- a/src/forcing/NullForcingProvider.cpp
+++ b/src/forcing/NullForcingProvider.cpp
@@ -1,0 +1,43 @@
+#include "NullForcingProvider.hpp"
+
+#include <stdexcept>
+#include <limits>
+
+#include <all.h>
+
+NullForcingProvider::NullForcingProvider() = default;
+
+long NullForcingProvider::get_data_start_time()
+{
+    return 0;
+}
+
+long NullForcingProvider::get_data_stop_time() {
+    return std::numeric_limits<long>::max();
+}
+
+long NullForcingProvider::record_duration() {
+    return 1;
+}
+
+size_t NullForcingProvider::get_ts_index_for_time(const time_t &epoch_time) {
+    return 0;
+}
+
+double NullForcingProvider::get_value(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
+{
+    throw std::runtime_error("Called get_value function in NullDataProvider");
+}
+
+std::vector<double> NullForcingProvider::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
+{
+    throw std::runtime_error("Called get_values function in NullDataProvider");
+}
+
+inline bool NullForcingProvider::is_property_sum_over_time_step(const std::string& name) {
+    throw std::runtime_error("Got request for variable " + name + " but no such variable is provided by NullForcingProvider." + SOURCE_LOC);
+}
+
+boost::span<const std::string> NullForcingProvider::get_available_variable_names() {
+    return {};
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -183,6 +183,16 @@ ngen_add_test(
         NGen::geojson
 )
 
+ngen_add_test(
+    test_forcings_engine
+    OBJECTS
+        forcing/ForcingsEngineDataProvider_Test.cpp
+    LIBRARIES
+        NGen::forcing
+    REQUIRES
+        NGEN_WITH_PYTHON
+)
+
 ########################## Series Unit Tests
 ngen_add_test(
     test_mdarray

--- a/test/forcing/ForcingsEngineDataProvider_Test.cpp
+++ b/test/forcing/ForcingsEngineDataProvider_Test.cpp
@@ -1,0 +1,5 @@
+#include <forcing/ForcingsEngineDataProvider.hpp>
+
+#include "DataProviderSelectors.hpp"
+
+template struct data_access::ForcingsEngineDataProvider<double, CatchmentAggrDataSelector>;


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR replaces #720.**

This PR adds the **`ForcingsEngineDataProvider<DataType, SelectionType>`** class. This class is intended to serve as the base class for Lumped, Gridded, and Unstructured forcings engine data providers. The base class handles timing and updating the underlying BMI instance, so derived classes need only implement the value querying requirements.

Internally, this PR also adds the **`detail::ForcingsEngineStorage`** class, which composes a map of initialization file names to Python BMI Adapter shared pointers. The design of this is to allow the Forcings Engine data providers to store a mask of some sort to simplify querying from the forcings engine, i.e. for a Gridded instance, the mask may be a bounding box. This need is due to the implementation of the forcings engine, and should simplify the external requirements for a NGen run using the Python Forcings Engine.

Additionally, this PR includes some minor changes to the `forcings` library. Namely, the `GenericDataProvider` class is refactored into a type alias, and the `NullForcingProvider` implementation is split into header/source files rather than being header-only. The latter change is to ensure the `forcings` CMake target is always build-able.

## Additions

- `ForcingsEngineDataProvider`: templated base class.
- `detail::ForcingsEngineStorage`: shared storage between data providers.
- `detail::assert_forcings_engine_requirements`: helper for ensuring runtime dependencies are available.
- `detail::parse_time`: helper for parsing timestamp strings.
-  `constexpr` constants for default time format string and forcings engine python information.

## Changes

- `NullForcingProvider`: split implementation into header/source file.
- `GenericDataProvider`: converted into type alias. 

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: