### PR TITLE
Bmi_Adapter: drop 'StreamHandler output'

### DIFF
--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -21,8 +21,7 @@ namespace models {
              * @param output The output stream handler.
              */
             AbstractCLibBmiAdapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                                   bool allow_exceed_end, bool has_fixed_time_step, std::string registration_func,
-                                   utils::StreamHandler output);
+                                   bool allow_exceed_end, bool has_fixed_time_step, std::string registration_func);
 
             /**
              * Class destructor.

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -20,7 +20,7 @@ namespace models {
         public:
 
             Bmi_Adapter(std::string model_name, std::string bmi_init_config, bool allow_exceed_end,
-                        bool has_fixed_time_step, utils::StreamHandler output);
+                        bool has_fixed_time_step);
 
             Bmi_Adapter(Bmi_Adapter const&) = delete;
             Bmi_Adapter(Bmi_Adapter &&) = delete;

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -163,7 +163,6 @@ namespace models {
             /** Whether the backing model has been initialized yet, which is always initially ``false``. */
             bool model_initialized = false;
             std::string model_name;
-            utils::StreamHandler output;
             /** Pointer to collection of output variable names for backing model, used by ``GetOutputVarNames()``. */
             std::shared_ptr<std::vector<std::string>> output_var_names;
 

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -7,8 +7,6 @@
 #include "bmi.hpp"
 
 #include "core/mediator/UnitsHelper.hpp"
-#include "utilities/StreamHandler.hpp"
-
 
 namespace models {
     namespace bmi {

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -7,7 +7,6 @@
 #include "bmi.h"
 #include "AbstractCLibBmiAdapter.hpp"
 #include "State_Exception.hpp"
-#include "utilities/StreamHandler.hpp"
 #include "utilities/ExternalIntegrationException.hpp"
 
 
@@ -35,11 +34,10 @@ namespace models {
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
-             * @param output The output stream handler.
              */
             explicit Bmi_C_Adapter(const std::string &type_name, std::string library_file_path,
                                    bool allow_exceed_end, bool has_fixed_time_step,
-                                   const std::string& registration_func, utils::StreamHandler output);
+                                   const std::string& registration_func);
 
             /**
              * Main public constructor.
@@ -50,11 +48,10 @@ namespace models {
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
-             * @param output The output stream handler.
              */
             Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                           bool allow_exceed_end, bool has_fixed_time_step,
-                          std::string registration_func, utils::StreamHandler output);
+                          std::string registration_func);
 
         protected:
 
@@ -75,12 +72,11 @@ namespace models {
              * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
-             * @param output The output stream handler.
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
             Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                           bool allow_exceed_end, bool has_fixed_time_step,
-                          std::string registration_func, utils::StreamHandler output, bool do_initialization);
+                          std::string registration_func, bool do_initialization);
 
         public:
 

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -6,7 +6,6 @@
 
 #include "bmi.hpp"
 #include "AbstractCLibBmiAdapter.hpp"
-#include "utilities/StreamHandler.hpp"
 #include "utilities/ExternalIntegrationException.hpp"
 
 
@@ -39,12 +38,10 @@ namespace models {
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
-             * @param output The output stream handler.
              */
             explicit Bmi_Cpp_Adapter(const std::string &type_name, std::string library_file_path,
                                    bool allow_exceed_end, bool has_fixed_time_step,
-                                   std::string creator_func, std::string destroyer_func,
-                                   utils::StreamHandler output);
+                                   std::string creator_func, std::string destroyer_func);
 
             /**
              * Main public constructor.
@@ -56,12 +53,10 @@ namespace models {
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
-             * @param output The output stream handler.
              */
             Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
                           bool allow_exceed_end, bool has_fixed_time_step,
-                          std::string creator_func, std::string destroyer_func,
-                          utils::StreamHandler output);
+                          std::string creator_func, std::string destroyer_func);
 
         protected:
 
@@ -83,13 +78,12 @@ namespace models {
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
-             * @param output The output stream handler.
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
             Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
                           bool allow_exceed_end, bool has_fixed_time_step,
                           std::string creator_func, std::string destroyer_func,
-                          utils::StreamHandler output, bool do_initialization);
+                          bool do_initialization);
 
         public:
 

--- a/include/bmi/Bmi_Fortran_Adapter.hpp
+++ b/include/bmi/Bmi_Fortran_Adapter.hpp
@@ -31,21 +31,20 @@ namespace models {
 
             explicit Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path,
                                          bool allow_exceed_end, bool has_fixed_time_step,
-                                         const std::string &registration_func, utils::StreamHandler output)
+                                         const std::string &registration_func)
                     : Bmi_Fortran_Adapter(type_name, library_file_path, "", allow_exceed_end,
                                           has_fixed_time_step,
-                                          registration_func, output) {}
+                                          registration_func) {}
 
             Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                                 bool allow_exceed_end, bool has_fixed_time_step,
-                                std::string registration_func,
-                                utils::StreamHandler output) : AbstractCLibBmiAdapter(type_name,
+                                std::string registration_func) : AbstractCLibBmiAdapter(type_name,
                                                                                       library_file_path,
                                                                                       bmi_init_config,
                                                                                       allow_exceed_end,
                                                                                       has_fixed_time_step,
-                                                                                      registration_func,
-                                                                                      output) {
+                                                                                      registration_func
+                                                                                      ) {
                 try {
                     construct_and_init_backing_model_for_fortran();
                     // Make sure this is set to 'true' after this function call finishes

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -18,7 +18,6 @@
 
 #include "Bmi_Adapter.hpp"
 
-#include "utilities/StreamHandler.hpp"
 #include "utilities/python/InterpreterUtil.hpp"
 
 // Forward declaration to provide access to protected items in testing

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -9,6 +9,7 @@
 #include <exception>
 #include <memory>
 #include <string>
+#include <iostream>
 
 #include "pybind11/pybind11.h"
 #include "pybind11/pytypes.h"

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -40,7 +40,7 @@ namespace models {
         public:
 
             Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                           bool allow_exceed_end, bool has_fixed_time_step, utils::StreamHandler output);
+                           bool allow_exceed_end, bool has_fixed_time_step);
 
             Bmi_Py_Adapter(Bmi_Py_Adapter const&) = delete;
             Bmi_Py_Adapter(Bmi_Py_Adapter&&) = delete;

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -2,6 +2,7 @@
 
 #include "utilities/FileChecker.h"
 #include "utilities/ExternalIntegrationException.hpp"
+#include "utilities/logging_utils.h"
 
 #include <dlfcn.h>
 
@@ -42,10 +43,8 @@ void AbstractCLibBmiAdapter::dynamic_library_load() {
         throw std::runtime_error(this->init_exception_msg);
     }
     if (dyn_lib_handle != nullptr) {
-        this->output.put(
-            "WARNING: ignoring attempt to reload dynamic shared library '" + bmi_lib_file +
-            "' for " + this->model_name
-        );
+        std::string message = "AbstractCLibBmiAdapter::dynamic_library_load: ignoring attempt to reload dynamic shared library '" + bmi_lib_file + "' for " + this->model_name;
+        logging::warning(message.c_str());
         return;
     }
     if (!utils::FileChecker::file_is_readable(bmi_lib_file)) {

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -15,15 +15,13 @@ AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
     std::string bmi_init_config,
     bool allow_exceed_end,
     bool has_fixed_time_step,
-    std::string registration_func,
-    utils::StreamHandler output
+    std::string registration_func
 )
     : Bmi_Adapter(
           type_name,
           std::move(bmi_init_config),
           allow_exceed_end,
-          has_fixed_time_step,
-          output
+          has_fixed_time_step
       )
     , bmi_lib_file(std::move(library_file_path))
     , bmi_registration_function(std::move(registration_func)){}

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -1,6 +1,7 @@
 #include "bmi/Bmi_Adapter.hpp"
 #include "bmi/State_Exception.hpp"
 #include "utilities/FileChecker.h"
+#include "utilities/logging_utils.h"
 
 namespace models {
 namespace bmi {
@@ -16,7 +17,6 @@ Bmi_Adapter::Bmi_Adapter(
     , bmi_init_config(std::move(bmi_init_config))
     , bmi_model_has_fixed_time_step(has_fixed_time_step)
     , allow_model_exceed_end_time(allow_exceed_end)
-    , output(std::move(output))
     , bmi_model_time_convert_factor(1.0) {
     // This replicates a lot of Initialize, but it's necessary to be able to do it separately to
     // support "initializing" on construction, given using Initialize requires use of virtual
@@ -105,10 +105,9 @@ void Bmi_Adapter::Initialize(std::string config_file) {
     }
 
     if (config_file != bmi_init_config && !model_initialized) {
-        output.put(
-            "Warning: initialization call changes model config from " + bmi_init_config + " to " +
-            config_file
-        );
+        std::string message = "Bmi_Adapter::Initialize: initialization call changes model config from " + bmi_init_config + " to " + config_file;
+        logging::warning(message.c_str());
+
         bmi_init_config = config_file;
     }
     try {

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -10,8 +10,7 @@ Bmi_Adapter::Bmi_Adapter(
     std::string model_name,
     std::string bmi_init_config,
     bool allow_exceed_end,
-    bool has_fixed_time_step,
-    utils::StreamHandler output
+    bool has_fixed_time_step
 )
     : model_name(std::move(model_name))
     , bmi_init_config(std::move(bmi_init_config))

--- a/src/bmi/Bmi_C_Adapter.cpp
+++ b/src/bmi/Bmi_C_Adapter.cpp
@@ -13,13 +13,12 @@ using namespace models::bmi;
  * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
- * @param output The output stream handler.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path,
                              bool allow_exceed_end, bool has_fixed_time_step,
-                             const std::string& registration_func, utils::StreamHandler output)
+                             const std::string& registration_func)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), "",
-                        allow_exceed_end, has_fixed_time_step, registration_func, output) { }
+                        allow_exceed_end, has_fixed_time_step, registration_func) { }
 
 /**
  * Main public constructor.
@@ -30,14 +29,13 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
- * @param output The output stream handler.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                              bool allow_exceed_end, bool has_fixed_time_step,
-                             std::string registration_func, utils::StreamHandler output)
+                             std::string registration_func)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
                         allow_exceed_end, has_fixed_time_step,
-                        std::move(registration_func), output, true) { }
+                        std::move(registration_func), true) { }
 
 /**
  * Protected constructor that allows control over whether initialization steps are done during construction.
@@ -56,14 +54,13 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
- * @param output The output stream handler.
  * @param do_initialization Whether initialization should be performed during construction or deferred.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
                              bool allow_exceed_end, bool has_fixed_time_step,
-                             std::string registration_func, utils::StreamHandler output, bool do_initialization)
+                             std::string registration_func, bool do_initialization)
                              : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), allow_exceed_end,
-                             has_fixed_time_step, registration_func, output)
+                             has_fixed_time_step, registration_func)
 {
     if (do_initialization) {
         try {

--- a/src/bmi/Bmi_Cpp_Adapter.cpp
+++ b/src/bmi/Bmi_Cpp_Adapter.cpp
@@ -8,25 +8,23 @@ using namespace models::bmi;
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path,
                              bool allow_exceed_end, bool has_fixed_time_step,
-                             std::string creator_func, std::string destroyer_func,
-                             utils::StreamHandler output)
+                             std::string creator_func, std::string destroyer_func)
         : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), "",
-                        allow_exceed_end, has_fixed_time_step, creator_func, destroyer_func, output) { }
+                        allow_exceed_end, has_fixed_time_step, creator_func, destroyer_func) { }
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
                              bool allow_exceed_end, bool has_fixed_time_step,
-                             std::string creator_func, std::string destroyer_func,
-                             utils::StreamHandler output)
+                             std::string creator_func, std::string destroyer_func)
         : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
                         allow_exceed_end, has_fixed_time_step,
-                        std::move(creator_func), std::move(destroyer_func), output, true) { }
+                        std::move(creator_func), std::move(destroyer_func), true) { }
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
                              bool allow_exceed_end, bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func,
-                             utils::StreamHandler output, bool do_initialization)
+                             bool do_initialization)
                              : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), allow_exceed_end,
-                             has_fixed_time_step, creator_func, output),
+                             has_fixed_time_step, creator_func),
                              model_create_fname(std::move(creator_func)),
                              model_destroy_fname(std::move(destroyer_func))
                              //TODO: We are passing creator_func as registration_func because AbstractCLibBmiAdapter expects it to exist, but are not using it the same way...may be okay but we may want to generalize that assumption out!

--- a/src/bmi/Bmi_Cpp_Adapter.cpp
+++ b/src/bmi/Bmi_Cpp_Adapter.cpp
@@ -2,7 +2,7 @@
 
 #include <exception>
 #include <utility>
-
+#include <iostream>
 
 using namespace models::bmi;
 

--- a/src/bmi/Bmi_Py_Adapter.cpp
+++ b/src/bmi/Bmi_Py_Adapter.cpp
@@ -4,6 +4,7 @@
 
 #include <exception>
 #include <utility>
+#include <iostream>
 
 #include "bmi/Bmi_Py_Adapter.hpp"
 

--- a/src/bmi/Bmi_Py_Adapter.cpp
+++ b/src/bmi/Bmi_Py_Adapter.cpp
@@ -11,11 +11,9 @@ using namespace models::bmi;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality
 
 Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                               bool allow_exceed_end, bool has_fixed_time_step,
-                               utils::StreamHandler output)
+                               bool allow_exceed_end, bool has_fixed_time_step)
         : Bmi_Adapter(type_name + " (BMI Py)", std::move(bmi_init_config),
-                                  allow_exceed_end, has_fixed_time_step,
-                                  output),
+                                  allow_exceed_end, has_fixed_time_step),
           bmi_type_py_full_name(bmi_python_type),
           np(utils::ngenPy::InterpreterUtil::getPyModule("numpy")) /* like 'import numpy as np' */
 {

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -30,8 +30,7 @@ std::shared_ptr<Bmi_Adapter> Bmi_C_Formulation::construct_model(const geojson::P
                     get_bmi_init_config(),
                     get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed(),
-                    reg_func,
-                    output);
+                    reg_func);
 }
 
 double Bmi_C_Formulation::get_var_value_as_double(const int& index, const std::string& var_name) {

--- a/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
@@ -40,8 +40,7 @@ std::shared_ptr<Bmi_Adapter> Bmi_Cpp_Formulation::construct_model(const geojson:
                     get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed(),
                     model_create_fname,
-                    model_destroy_fname,
-                    output);
+                    model_destroy_fname);
 }
 
 double Bmi_Cpp_Formulation::get_var_value_as_double(const int& index, const std::string& var_name) {

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -38,8 +38,7 @@ std::shared_ptr<Bmi_Adapter> Bmi_Fortran_Formulation::construct_model(const geoj
             get_bmi_init_config(),
             get_allow_model_exceed_end_time(),
             is_bmi_model_time_step_fixed(),
-            reg_func,
-            output);
+            reg_func);
 }
 
 std::string Bmi_Fortran_Formulation::get_formulation_type() {

--- a/src/realizations/catchment/Bmi_Py_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Py_Formulation.cpp
@@ -29,8 +29,7 @@ std::shared_ptr<Bmi_Adapter> Bmi_Py_Formulation::construct_model(const geojson::
                     get_bmi_init_config(),
                     python_type_name,
                     get_allow_model_exceed_end_time(),
-                    is_bmi_model_time_step_fixed(),
-                    output);
+                    is_bmi_model_time_step_fixed());
 }
 
 time_t realization::Bmi_Py_Formulation::convert_model_time(const double &model_time) {

--- a/test/bmi/Bmi_C_Adapter_Test.cpp
+++ b/test/bmi/Bmi_C_Adapter_Test.cpp
@@ -88,8 +88,7 @@ void Bmi_C_Adapter_Test::SetUp() {
     lib_file_name_0 = file_search(lib_dir_opts, BMI_TEST_C_LOCAL_LIB_NAME);
     bmi_module_type_name_0 = "test_bmi_c";
     adapter = std::make_unique<Bmi_C_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                              false, true, REGISTRATION_FUNC,
-                                              utils::StreamHandler());
+                                              false, true, REGISTRATION_FUNC);
 }
 
 void Bmi_C_Adapter_Test::TearDown() {

--- a/test/bmi/Bmi_Cpp_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Cpp_Adapter_Test.cpp
@@ -80,8 +80,7 @@ void Bmi_Cpp_Adapter_Test::SetUp() {
     bmi_module_type_name_0 = "test_bmi_cpp";
     try {
         adapter = std::make_unique<Bmi_Cpp_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                                false, true, CREATOR_FUNC, DESTROYER_FUNC,
-                                                utils::StreamHandler());
+                                                false, true, CREATOR_FUNC, DESTROYER_FUNC);
     }
     catch (const std::exception &e) {
         std::clog << e.what() << std::endl;

--- a/test/bmi/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Fortran_Adapter_Test.cpp
@@ -95,8 +95,7 @@ void Bmi_Fortran_Adapter_Test::SetUp() {
     lib_file_name_0 = file_search(lib_dir_opts, BMI_TEST_FORTRAN_LOCAL_LIB_NAME);
     bmi_module_type_name_0 = "test_bmi_fortran";
     adapter = std::make_unique<Bmi_Fortran_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                              false, true, REGISTRATION_FUNC,
-                                              utils::StreamHandler());
+                                              false, true, REGISTRATION_FUNC);
 }
 
 void Bmi_Fortran_Adapter_Test::TearDown() {

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -138,8 +138,7 @@ void Bmi_Py_Adapter_Test::SetUp() {
                 + std::to_string(i) + ".yml";
 
         examples[i].adapter = std::make_shared<Bmi_Py_Adapter>(examples[i].module_name, examples[i].bmi_init_config,
-                                                               examples[i].module_name, false, true,
-                                                               utils::StreamHandler());
+                                                               examples[i].module_name, false, true);
     }
 }
 


### PR DESCRIPTION
The entire hierarchy of classes below `Bmi_Adapter` takes `StreamHandler output` as a constructor argument, and just passes it up the chain. The only places it was actually used was in a pair of re-initialization warnings.

## Changes

- Change the warnings to use `logging::warning` instead
- Drop the `Bmi_Adapter::output` member that was otherwise unused
- Drop the `StreamHandler output` parameter from all class constructors in the hierarchy
- Remove `output` arguments used to fill those parameters in adapter construction calls


## Testing

1. ctest
2. CI

## Notes

- The Formulation classes are minimally changed, and particularly did not get into modifying their interfaces

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: