### PR TITLE
CMake: update documentation for `ngen_add_test`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,8 @@ target_include_directories(test_all PRIVATE ${CMAKE_CURRENT_LIST_DIR}/bmi)
 #[==[
 ngen_add_test(<test name> OBJECTS <source>...
                           LIBRARIES <library>...
-                          [REQUIRES <varname>...])
+                          [REQUIRES <varname>...]
+                          [DEPENDS <dependency>...])
 
 Adds an executable test (i.e. a target) called <test name>.
 
@@ -83,6 +84,11 @@ Adds an executable test (i.e. a target) called <test name>.
     Variable names that this test's creation is dependent on.
     If a given variable is not defined or is FALSE/OFF/etc. then
     the corresponding <test name> target is not created.
+
+`DEPENDS`
+    Additional targets that a test executable depends on. For each
+    dependent target given, add_dependencies(<test name> <dependency>...)
+    is called.
 #]==]
 function(ngen_add_test TESTNAME)
     set(multiValueArgs OBJECTS LIBRARIES REQUIRES DEPENDS)


### PR DESCRIPTION
This PR updates the inline documentation for `ngen_add_test`. The `DEPENDS` argument wasn't documented.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
