### PR TITLE
Bmi_Adapter: drop unused 'allow_exceed_end_time' member

### DIFF
--- a/include/bmi/AbstractCLibBmiAdapter.hpp
+++ b/include/bmi/AbstractCLibBmiAdapter.hpp
@@ -15,13 +15,12 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              * @param output The output stream handler.
              */
             AbstractCLibBmiAdapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                                   bool allow_exceed_end, bool has_fixed_time_step, std::string registration_func);
+                                   bool has_fixed_time_step, std::string registration_func);
 
             /**
              * Class destructor.

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -17,8 +17,7 @@ namespace models {
         class Bmi_Adapter : public ::bmi::Bmi {
         public:
 
-            Bmi_Adapter(std::string model_name, std::string bmi_init_config, bool allow_exceed_end,
-                        bool has_fixed_time_step);
+            Bmi_Adapter(std::string model_name, std::string bmi_init_config, bool has_fixed_time_step);
 
             Bmi_Adapter(Bmi_Adapter const&) = delete;
             Bmi_Adapter(Bmi_Adapter &&) = delete;

--- a/include/bmi/Bmi_Adapter.hpp
+++ b/include/bmi/Bmi_Adapter.hpp
@@ -144,8 +144,6 @@ namespace models {
             std::string get_model_name();
 
         protected:
-            /** Whether model ``Update`` calls are allowed and handled in some way by the backing model. */
-            bool allow_model_exceed_end_time = false;
             /** Path (as a string) to the BMI config file for initializing the backing model (empty if none). */
             std::string bmi_init_config;
             /** Whether this particular model has a time step size that cannot be changed internally or externally. */

--- a/include/bmi/Bmi_C_Adapter.hpp
+++ b/include/bmi/Bmi_C_Adapter.hpp
@@ -31,12 +31,11 @@ namespace models {
              *
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              */
             explicit Bmi_C_Adapter(const std::string &type_name, std::string library_file_path,
-                                   bool allow_exceed_end, bool has_fixed_time_step,
+                                   bool has_fixed_time_step,
                                    const std::string& registration_func);
 
             /**
@@ -45,12 +44,11 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              */
             Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                          bool allow_exceed_end, bool has_fixed_time_step,
+                          bool has_fixed_time_step,
                           std::string registration_func);
 
         protected:
@@ -69,13 +67,12 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param registration_func The name for the @see bmi_registration_function.
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
             Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                          bool allow_exceed_end, bool has_fixed_time_step,
+                          bool has_fixed_time_step,
                           std::string registration_func, bool do_initialization);
 
         public:

--- a/include/bmi/Bmi_Cpp_Adapter.hpp
+++ b/include/bmi/Bmi_Cpp_Adapter.hpp
@@ -34,13 +34,12 @@ namespace models {
              *
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
              */
             explicit Bmi_Cpp_Adapter(const std::string &type_name, std::string library_file_path,
-                                   bool allow_exceed_end, bool has_fixed_time_step,
+                                   bool has_fixed_time_step,
                                    std::string creator_func, std::string destroyer_func);
 
             /**
@@ -49,13 +48,12 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
              */
             Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                          bool allow_exceed_end, bool has_fixed_time_step,
+                          bool has_fixed_time_step,
                           std::string creator_func, std::string destroyer_func);
 
         protected:
@@ -74,14 +72,13 @@ namespace models {
              * @param type_name The name of the backing BMI module/model type.
              * @param library_file_path The string path to the shared library file for external module.
              * @param bmi_init_config The string path to the BMI initialization config file for the module.
-             * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
              * @param has_fixed_time_step Whether the model has a fixed time step size.
              * @param creator_func The name for the @see creator_function .
              * @param destoryer_func The name for the @see destroyer_function .
              * @param do_initialization Whether initialization should be performed during construction or deferred.
              */
             Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                          bool allow_exceed_end, bool has_fixed_time_step,
+                          bool has_fixed_time_step,
                           std::string creator_func, std::string destroyer_func,
                           bool do_initialization);
 

--- a/include/bmi/Bmi_Fortran_Adapter.hpp
+++ b/include/bmi/Bmi_Fortran_Adapter.hpp
@@ -30,18 +30,17 @@ namespace models {
         public:
 
             explicit Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path,
-                                         bool allow_exceed_end, bool has_fixed_time_step,
+                                         bool has_fixed_time_step,
                                          const std::string &registration_func)
-                    : Bmi_Fortran_Adapter(type_name, library_file_path, "", allow_exceed_end,
+                    : Bmi_Fortran_Adapter(type_name, library_file_path, "",
                                           has_fixed_time_step,
                                           registration_func) {}
 
             Bmi_Fortran_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                                bool allow_exceed_end, bool has_fixed_time_step,
+                                bool has_fixed_time_step,
                                 std::string registration_func) : AbstractCLibBmiAdapter(type_name,
                                                                                       library_file_path,
                                                                                       bmi_init_config,
-                                                                                      allow_exceed_end,
                                                                                       has_fixed_time_step,
                                                                                       registration_func
                                                                                       ) {

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -40,7 +40,7 @@ namespace models {
         public:
 
             Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                           bool allow_exceed_end, bool has_fixed_time_step);
+                           bool has_fixed_time_step);
 
             Bmi_Py_Adapter(Bmi_Py_Adapter const&) = delete;
             Bmi_Py_Adapter(Bmi_Py_Adapter&&) = delete;

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -13,14 +13,12 @@ AbstractCLibBmiAdapter::AbstractCLibBmiAdapter(
     const std::string& type_name,
     std::string library_file_path,
     std::string bmi_init_config,
-    bool allow_exceed_end,
     bool has_fixed_time_step,
     std::string registration_func
 )
     : Bmi_Adapter(
           type_name,
           std::move(bmi_init_config),
-          allow_exceed_end,
           has_fixed_time_step
       )
     , bmi_lib_file(std::move(library_file_path))

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -9,7 +9,6 @@ namespace bmi {
 Bmi_Adapter::Bmi_Adapter(
     std::string model_name,
     std::string bmi_init_config,
-    bool allow_exceed_end,
     bool has_fixed_time_step
 )
     : model_name(std::move(model_name))

--- a/src/bmi/Bmi_Adapter.cpp
+++ b/src/bmi/Bmi_Adapter.cpp
@@ -15,7 +15,6 @@ Bmi_Adapter::Bmi_Adapter(
     : model_name(std::move(model_name))
     , bmi_init_config(std::move(bmi_init_config))
     , bmi_model_has_fixed_time_step(has_fixed_time_step)
-    , allow_model_exceed_end_time(allow_exceed_end)
     , bmi_model_time_convert_factor(1.0) {
     // This replicates a lot of Initialize, but it's necessary to be able to do it separately to
     // support "initializing" on construction, given using Initialize requires use of virtual

--- a/src/bmi/Bmi_C_Adapter.cpp
+++ b/src/bmi/Bmi_C_Adapter.cpp
@@ -10,15 +10,14 @@ using namespace models::bmi;
  *
  * @param type_name The name of the backing BMI module/model type.
  * @param library_file_path The string path to the shared library file for external module.
- * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path,
-                             bool allow_exceed_end, bool has_fixed_time_step,
+                             bool has_fixed_time_step,
                              const std::string& registration_func)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), "",
-                        allow_exceed_end, has_fixed_time_step, registration_func) { }
+                        has_fixed_time_step, registration_func) { }
 
 /**
  * Main public constructor.
@@ -26,15 +25,14 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param type_name The name of the backing BMI module/model type.
  * @param library_file_path The string path to the shared library file for external module.
  * @param bmi_init_config The string path to the BMI initialization config file for the module.
- * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                             bool allow_exceed_end, bool has_fixed_time_step,
+                             bool has_fixed_time_step,
                              std::string registration_func)
         : Bmi_C_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
-                        allow_exceed_end, has_fixed_time_step,
+                        has_fixed_time_step,
                         std::move(registration_func), true) { }
 
 /**
@@ -51,15 +49,14 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
  * @param type_name The name of the backing BMI module/model type.
  * @param library_file_path The string path to the shared library file for external module.
  * @param bmi_init_config The string path to the BMI initialization config file for the module.
- * @param allow_exceed_end Whether the backing model is allowed to execute beyond its advertised end_time.
  * @param has_fixed_time_step Whether the model has a fixed time step size.
  * @param registration_func The name for the @see bmi_registration_function.
  * @param do_initialization Whether initialization should be performed during construction or deferred.
  */
 Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_file_path, std::string bmi_init_config,
-                             bool allow_exceed_end, bool has_fixed_time_step,
+                             bool has_fixed_time_step,
                              std::string registration_func, bool do_initialization)
-                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), allow_exceed_end,
+                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config),
                              has_fixed_time_step, registration_func)
 {
     if (do_initialization) {
@@ -98,7 +95,6 @@ Bmi_C_Adapter::Bmi_C_Adapter(const std::string &type_name, std::string library_f
 // TODO: However, it may make sense to bring it back once it is possible to serialize and deserialize the model.
 /*
 Bmi_C_Adapter::Bmi_C_Adapter(Bmi_C_Adapter &adapter) : model_name(adapter.model_name),
-                                                       allow_model_exceed_end_time(adapter.allow_model_exceed_end_time),
                                                        bmi_init_config(adapter.bmi_init_config),
                                                        bmi_lib_file(adapter.bmi_lib_file),
                                                        bmi_model(adapter.bmi_model),

--- a/src/bmi/Bmi_Cpp_Adapter.cpp
+++ b/src/bmi/Bmi_Cpp_Adapter.cpp
@@ -7,23 +7,23 @@
 using namespace models::bmi;
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path,
-                             bool allow_exceed_end, bool has_fixed_time_step,
+                             bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func)
         : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), "",
-                        allow_exceed_end, has_fixed_time_step, creator_func, destroyer_func) { }
+                        has_fixed_time_step, creator_func, destroyer_func) { }
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                             bool allow_exceed_end, bool has_fixed_time_step,
+                             bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func)
         : Bmi_Cpp_Adapter(type_name, std::move(library_file_path), std::move(bmi_init_config),
-                        allow_exceed_end, has_fixed_time_step,
+                        has_fixed_time_step,
                         std::move(creator_func), std::move(destroyer_func), true) { }
 
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string library_file_path, std::string bmi_init_config,
-                             bool allow_exceed_end, bool has_fixed_time_step,
+                             bool has_fixed_time_step,
                              std::string creator_func, std::string destroyer_func,
                              bool do_initialization)
-                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config), allow_exceed_end,
+                             : AbstractCLibBmiAdapter(type_name, library_file_path, std::move(bmi_init_config),
                              has_fixed_time_step, creator_func),
                              model_create_fname(std::move(creator_func)),
                              model_destroy_fname(std::move(destroyer_func))
@@ -57,7 +57,6 @@ Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(const std::string& type_name, std::string libra
 // TODO: However, it may make sense to bring it back once it is possible to serialize and deserialize the model.
 /*
 Bmi_Cpp_Adapter::Bmi_Cpp_Adapter(Bmi_Cpp_Adapter &adapter) :
-                                                       allow_model_exceed_end_time(adapter.allow_model_exceed_end_time),
                                                        bmi_init_config(adapter.bmi_init_config),
                                                        bmi_lib_file(adapter.bmi_lib_file),
                                                        bmi_model(adapter.bmi_model),

--- a/src/bmi/Bmi_Py_Adapter.cpp
+++ b/src/bmi/Bmi_Py_Adapter.cpp
@@ -12,9 +12,9 @@ using namespace models::bmi;
 using namespace pybind11::literals; // to bring in the `_a` literal for pybind11 keyword args functionality
 
 Bmi_Py_Adapter::Bmi_Py_Adapter(const std::string &type_name, std::string bmi_init_config, const std::string &bmi_python_type,
-                               bool allow_exceed_end, bool has_fixed_time_step)
+                               bool has_fixed_time_step)
         : Bmi_Adapter(type_name + " (BMI Py)", std::move(bmi_init_config),
-                                  allow_exceed_end, has_fixed_time_step),
+                                  has_fixed_time_step),
           bmi_type_py_full_name(bmi_python_type),
           np(utils::ngenPy::InterpreterUtil::getPyModule("numpy")) /* like 'import numpy as np' */
 {

--- a/src/realizations/catchment/Bmi_C_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_C_Formulation.cpp
@@ -28,7 +28,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_C_Formulation::construct_model(const geojson::P
                     get_model_type_name(),
                     lib_file,
                     get_bmi_init_config(),
-                    get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed(),
                     reg_func);
 }

--- a/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Cpp_Formulation.cpp
@@ -37,7 +37,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_Cpp_Formulation::construct_model(const geojson:
                     get_model_type_name(),
                     lib_file,
                     get_bmi_init_config(),
-                    get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed(),
                     model_create_fname,
                     model_destroy_fname);

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -36,7 +36,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_Fortran_Formulation::construct_model(const geoj
             get_model_type_name(),
             lib_file,
             get_bmi_init_config(),
-            get_allow_model_exceed_end_time(),
             is_bmi_model_time_step_fixed(),
             reg_func);
 }

--- a/src/realizations/catchment/Bmi_Py_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Py_Formulation.cpp
@@ -28,7 +28,6 @@ std::shared_ptr<Bmi_Adapter> Bmi_Py_Formulation::construct_model(const geojson::
                     get_model_type_name(),
                     get_bmi_init_config(),
                     python_type_name,
-                    get_allow_model_exceed_end_time(),
                     is_bmi_model_time_step_fixed());
 }
 

--- a/test/bmi/Bmi_C_Adapter_Test.cpp
+++ b/test/bmi/Bmi_C_Adapter_Test.cpp
@@ -88,7 +88,7 @@ void Bmi_C_Adapter_Test::SetUp() {
     lib_file_name_0 = file_search(lib_dir_opts, BMI_TEST_C_LOCAL_LIB_NAME);
     bmi_module_type_name_0 = "test_bmi_c";
     adapter = std::make_unique<Bmi_C_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                              false, true, REGISTRATION_FUNC);
+                                              true, REGISTRATION_FUNC);
 }
 
 void Bmi_C_Adapter_Test::TearDown() {

--- a/test/bmi/Bmi_Cpp_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Cpp_Adapter_Test.cpp
@@ -80,7 +80,7 @@ void Bmi_Cpp_Adapter_Test::SetUp() {
     bmi_module_type_name_0 = "test_bmi_cpp";
     try {
         adapter = std::make_unique<Bmi_Cpp_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                                false, true, CREATOR_FUNC, DESTROYER_FUNC);
+                                                true, CREATOR_FUNC, DESTROYER_FUNC);
     }
     catch (const std::exception &e) {
         std::clog << e.what() << std::endl;

--- a/test/bmi/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Fortran_Adapter_Test.cpp
@@ -95,7 +95,7 @@ void Bmi_Fortran_Adapter_Test::SetUp() {
     lib_file_name_0 = file_search(lib_dir_opts, BMI_TEST_FORTRAN_LOCAL_LIB_NAME);
     bmi_module_type_name_0 = "test_bmi_fortran";
     adapter = std::make_unique<Bmi_Fortran_Adapter>(bmi_module_type_name_0, lib_file_name_0, config_file_name_0, 
-                                              false, true, REGISTRATION_FUNC);
+                                              true, REGISTRATION_FUNC);
 }
 
 void Bmi_Fortran_Adapter_Test::TearDown() {

--- a/test/bmi/Bmi_Py_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Py_Adapter_Test.cpp
@@ -138,7 +138,7 @@ void Bmi_Py_Adapter_Test::SetUp() {
                 + std::to_string(i) + ".yml";
 
         examples[i].adapter = std::make_shared<Bmi_Py_Adapter>(examples[i].module_name, examples[i].bmi_init_config,
-                                                               examples[i].module_name, false, true);
+                                                               examples[i].module_name, true);
     }
 }
 


### PR DESCRIPTION
The Formulations actually know and handle this behavior. Its presence in the Adapter layer is a relic.

## Changes

- Remove `allow_exceed_end_time` members and constructor parameters

## Testing

1. ctest, CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
