### PR TITLE
Update Formulation_Manager.hpp to use boost regex

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -463,8 +463,7 @@ namespace realization {
                 if (directory != nullptr) {
                     bool match;
                     while ((entry = readdir(directory))) {
-                        match = boost::regex_match(entry->d_name, pattern);
-                        if( match ) {
+                        if (filepattern == entry->d_name || boost::regex_match(entry->d_name, pattern)) {
                             // If the entry is a regular file or symlink AND the name matches the pattern, 
                             //    we can consider this ready to be interpretted as valid forcing data (even if it isn't)
                             #ifdef _DIRENT_HAVE_D_TYPE

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -9,8 +9,8 @@
 #include <functional>
 #include <dirent.h>
 #include <sys/stat.h>
-#include <regex>
 
+#include <boost/regex.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <FeatureBuilder.hpp>
@@ -410,7 +410,7 @@ namespace realization {
                 }
 
                 // Create a regular expression used to identify proper file names
-                std::regex pattern(filepattern);
+                boost::regex pattern(filepattern);
 
                 // A stream providing the functions necessary for evaluating a directory:
                 //    https://www.gnu.org/software/libc/manual/html_node/Opening-a-Directory.html#Opening-a-Directory
@@ -463,7 +463,7 @@ namespace realization {
                 if (directory != nullptr) {
                     bool match;
                     while ((entry = readdir(directory))) {
-                        match = std::regex_match(entry->d_name, pattern);
+                        match = boost::regex_match(entry->d_name, pattern);
                         if( match ) {
                             // If the entry is a regular file or symlink AND the name matches the pattern, 
                             //    we can consider this ready to be interpretted as valid forcing data (even if it isn't)


### PR DESCRIPTION
# Update the formulation manager to use boost::regex instead of std.

When matching complex regex for finding forcing files, std::regex becomes a significant portion of Ngen init. Especially with large numbers of catchments per core.

For an extreme example, when running serially for wb-479197 and it's upstreams ~6500 catchments. NGen::init takes ~153s, if I use the line "forcing": {"file_pattern": ".\*{{id}}.\*.csv" in my realization.
removing those wildcards reduces the time to 69 seconds.

For use cases where ngen is being run over a large area, this init time can become a non-insignificant portion of the total runtime, in the serial example, it took 153 seconds to init, 43s to run the models, 19s to route for a 24h simulation.


## Changes

- std::regex -> boost::regex

## Testing

This was all tested on ngiab images using ngen [f91e2ea](https://github.com/NOAA-OWP/ngen/commit/f91e2ea)
The run package was generated using the [ngiab_preprocessor](https://github.com/CIROH-UA/NGIAB_data_preprocess)
24h run of ~6500 catchments, sloth + cfe + noaa-owp-modular + troute, subset from wb-479197 on hydrofabric v20.1

<details>
  <summary>Hardware used</summary>
Model name:            Intel(R) Xeon(R) CPU E5-2697 v3 @ 2.60GHz
    Thread(s) per core:  2
    Core(s) per socket:  14
    Socket(s):           2
    CPU max MHz:         3600.0000
    CPU min MHz:         1200.0000
RAM 2100mhz DDR4
Storage ~500mbs sata ssd
</details>

<details>
 <summary> Realization.json </summary>

```json  

{
    "global": {
        "formulations": [
            {
                "name": "bmi_multi",
                "params": {
                    "name": "bmi_multi",
                    "model_type_name": "bmi_multi",
                    "main_output_variable": "Q_OUT",
                    "forcing_file": "",
                    "init_config": "",
                    "allow_exceed_end_time": true,
                    "modules": [
                        {
                            "name": "bmi_c++",
                            "params": {
                                "name": "bmi_c++",
                                "model_type_name": "SLOTH",
                                "main_output_variable": "z",
                                "init_config": "/dev/null",
                                "allow_exceed_end_time": true,
                                "fixed_time_step": false,
                                "uses_forcing_file": false,
                                "model_params": {
                                    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
                                    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
                                    "sloth_soil_moisture_profile(1,double,1,node)": 0.0
                                },
                                "library_file": "/dmod/shared_libs/libslothmodel.so",
                                "registration_function": "none"
                            }
                        },
                        {
                            "name": "bmi_fortran",
                            "params": {
                                "name": "bmi_fortran",
                                "model_type_name": "NoahOWP",
                                "library_file": "/dmod/shared_libs/libsurfacebmi.so",
                                "forcing_file": "",
                                "init_config": "./config/cat_config/NOAH-OWP-M/{{id}}.input",
                                "allow_exceed_end_time": true,
                                "main_output_variable": "QINSUR",
                                "variables_names_map": {
                                    "PRCPNONC": "precip_rate",
                                    "Q2": "SPFH_2maboveground",
                                    "SFCTMP": "TMP_2maboveground",
                                    "UU": "UGRD_10maboveground",
                                    "VV": "VGRD_10maboveground",
                                    "LWDN": "DLWRF_surface",
                                    "SOLDN": "DSWRF_surface",
                                    "SFCPRS": "PRES_surface"
                                },
                                "uses_forcing_file": false
                            }
                        },
                        {
                            "name": "bmi_c",
                            "params": {
                                "name": "bmi_c",
                                "model_type_name": "CFE",
                                "main_output_variable": "Q_OUT",
                                "init_config": "./config/cat_config/CFE/{{id}}.ini",
                                "allow_exceed_end_time": true,
                                "fixed_time_step": false,
                                "uses_forcing_file": false,
                                "registration_function": "register_bmi_cfe",
                                "variables_names_map": {
                                    "water_potential_evaporation_flux": "EVAPOTRANS",
                                    "atmosphere_water__liquid_equivalent_precipitation_rate": "QINSUR",
                                    "ice_fraction_schaake": "sloth_ice_fraction_schaake",
                                    "ice_fraction_xinanjiang": "sloth_ice_fraction_xinanjiang",
                                    "soil_moisture_profile": "sloth_soil_moisture_profile"
                                },
                                "library_file": "/dmod/shared_libs/libcfebmi.so.1.0.0"
                            }
                        }
                    ],
                    "uses_forcing_file": false
                }
            }
        ],
        "forcing": {
            "file_pattern": "{{id}}.csv",
            "path": "./forcings/by_catchment/",
            "provider": "CsvPerFeature"
        }
    },
    "time": {
        "start_time": "2010-01-01 00:00:00",
        "end_time": "2010-01-02 00:00:00",
        "output_interval": 3600,
        "nts": 288.0
    },
    "routing": {
        "t_route_config_file_with_path": "/ngen/ngen/data/config/ngen.yaml"
    },
    "output_root": "/ngen/ngen/data/outputs/ngen"
}

```

</details>

`boost+exact` first checks if file_pattern matched the file exactly, then runs regex if it does not match

`exact path` is where the "path" formulation variable accepts the `{{id}}` placeholder allowing for file_pattern to be omitted and no regex being run. 

### Serial
| library | .\*{{id}}.\*.cat <br> | {{id}}.cat |
| ------- | --------------------- | ---------- |
| std     | 153s                  | 69s        |
| boost   | 62s                   | 55s        |
| re2     | 37s                   | 36s        |
| exact path | NA | 27s |

### 10 mpi ranks
| library | {{id}}.cat |
| ------- | ---------- |
| std     | 8.6s      |
| boost   |  7.4s        |
| re2     |  5.2s        |
| exact path | 4.2s  |

### 56 mpi ranks
| library | {{id}}.cat |
| ------- | ---------- |
| std     | 4.8s        |
| boost   |  4.5s        |
| re2     |  3.9s        |
| exact path |  3.2s |  



## Screenshots


[interactive version of the graph here](https://claude.site/artifacts/7ab67fc0-f7f1-4e48-99e9-ba225bb37014)
![image](https://github.com/NOAA-OWP/ngen/assets/26720477/d174cb97-b66f-4616-8b17-c29809e67173)
<details>
<summary>std, boost, re2, on 10 cores</summary>   

![image](https://github.com/NOAA-OWP/ngen/assets/26720477/a5916aba-5669-4c39-8fa3-dc938c7cdfee)
</details>

<details>
<summary>perf Flamegraph of unmodified fomulation manager running serially with double wildcards</summary>   

![kernel](https://github.com/NOAA-OWP/ngen/assets/26720477/7d892169-4817-4942-9598-c7496c88ab6b)
</details>

## Notes
- re2 is faster, but I don't know if it's worth adding the dependency when we're already using boost
- If it's worth it, I can open a PR for a version using re2
- I'm not sure how common these wildcarded regex use cases are, or how many people would be running serially for large numbers of catchments
- read.cpp in the geopackage code also uses std::regex, but it's called so infrequently that the performance benefit is negligible. I left it unchanged to reduce code modification, although I'm unsure if that's the correct decision.
- changing {{id}}.cat to {{id}}\\.cat reduces all times further, but I noticed the lack of escapement after I'd finished all my testing
- I can upload the various docker images used to test to dockerhub if needed

## Future work
I wanted to keep changes minimal because I'm not too familiar with the rest of ngen, but would it be worth modifying the formulation manager further to optionally disable regex completely?
For my use-case, the forcing files are just named cat-1234.csv and there is one per catchment so I don't need to use regex at all after the formulation manager replaces the {{id}} placeholder.


