### PR TITLE
Misc cleanup: 'using namespace' and unnecessary 'friend'

### DIFF
--- a/include/core/nexus/HY_HydroNexus.hpp
+++ b/include/core/nexus/HY_HydroNexus.hpp
@@ -10,7 +10,6 @@
 #include <HY_Catchment.hpp>
 #include <HY_HydroLocation.hpp>
 
-using namespace hy_features::hydrolocation;
 class HY_HydroNexus
 {
     public:
@@ -19,7 +18,7 @@ class HY_HydroNexus
 
     //using Catchments = std::vector<std::shared_ptr<HY_Catchment>>;
     using Catchments = std::vector<std::string>;
-    using HydroLocation = std::shared_ptr<HY_HydroLocation>;
+    using HydroLocation = std::shared_ptr<hy_features::hydrolocation::HY_HydroLocation>;
 
     HY_HydroNexus(std::string nexus_id, Catchments receiving_catchments);
     HY_HydroNexus(std::string nexus_id, Catchments receiving_catchments, Catchments contributing_catchments);

--- a/include/realizations/catchment/Bmi_C_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_C_Formulation.hpp
@@ -100,8 +100,6 @@ namespace realization {
          */
         bool is_model_initialized() override;
 
-        friend class Bmi_Multi_Formulation;
-
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_C_Formulation_Test;

--- a/include/realizations/catchment/Bmi_Cpp_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Cpp_Formulation.hpp
@@ -40,10 +40,6 @@ namespace realization {
 
         bool is_model_initialized() override;
 
-                protected:
-
-        friend class Bmi_Multi_Formulation;
-
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_Cpp_Formulation_Test;

--- a/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
@@ -45,8 +45,6 @@ namespace realization {
 
         double get_var_value_as_double(const int &index, const std::string &var_name) override;
 
-        friend class Bmi_Multi_Formulation;
-
         // Unit test access
         friend class ::Bmi_Multi_Formulation_Test;
         friend class ::Bmi_Formulation_Test;

--- a/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Fortran_Formulation.hpp
@@ -6,15 +6,12 @@
 #if NGEN_WITH_BMI_FORTRAN
 
 #include "Bmi_Module_Formulation.hpp"
-#include "Bmi_Fortran_Adapter.hpp"
 #include <GenericDataProvider.hpp>
 
 // TODO: consider merging this somewhere with the C value in that formulation header
 #define BMI_FORTRAN_DEFAULT_REGISTRATION_FUNC "register_bmi"
 
 class Bmi_Fortran_Formulation_Test;
-
-using namespace models::bmi;
 
 namespace realization {
 
@@ -40,7 +37,7 @@ namespace realization {
          * @param properties Configuration properties for the formulation.
          * @return A shared pointer to a newly constructed model adapter object.
          */
-        std::shared_ptr<Bmi_Adapter> construct_model(const geojson::PropertyMap& properties) override;
+        std::shared_ptr<models::bmi::Bmi_Adapter> construct_model(const geojson::PropertyMap& properties) override;
 
         time_t convert_model_time(const double &model_time) override {
             return (time_t) (get_bmi_model()->convert_model_time_to_seconds(model_time));

--- a/include/realizations/catchment/Bmi_Py_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Py_Formulation.hpp
@@ -55,8 +55,6 @@ namespace realization {
          */
         bool is_model_initialized() override;
 
-        friend class Bmi_Multi_Formulation;
-
         // Unit test access
         friend class ::Bmi_Formulation_Test;
         friend class ::Bmi_Py_Formulation_Test;

--- a/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Fortran_Formulation.cpp
@@ -3,6 +3,7 @@
 #if NGEN_WITH_BMI_FORTRAN
 
 #include "Bmi_Fortran_Formulation.hpp"
+#include "Bmi_Fortran_Adapter.hpp"
 #include "Constants.h"
 
 using namespace realization;

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -15,6 +15,7 @@
 
 #include "Bmi_Module_Formulation.hpp"
 #include "Bmi_Fortran_Formulation.hpp"
+#include "Bmi_Fortran_Adapter.hpp"
 #include "gtest/gtest.h"
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
Just clearing out some poor form C++ that I noticed

## Changes

- Eliminate `using namespace models::bmi` in headers
- Eliminate `using namespace hy_features::hydrolocation;` in header
- Delete unnecessary `friend class Bmi_Multi_Formulation`
- Shift a header include from header where it wasn't needed to source files that actually depended on it

## Testing

Code still builds

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
