### PR TITLE
Minor changes to Forcings Engine Data Provider for derived implementations

### DIFF
--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -194,6 +194,27 @@ struct ForcingsEngineDataProvider
         var_output_names_ = bmi_->GetOutputVarNames();
     }
 
+    std::string ensure_variable(std::string name, const std::string& suffix = "_ELEMENT") const
+    {
+        // TODO: use get_available_var_names() once const
+        auto vars = boost::span<const std::string>{var_output_names_};
+
+        if (std::find(vars.begin(), vars.end(), name) != vars.end()) {
+          return name;
+        }
+
+        auto suffixed_name = std::move(name) + suffix;
+        if (std::find(vars.begin(), vars.end(), suffixed_name) != vars.end()) {
+          return suffixed_name;
+        }
+
+        throw std::runtime_error{
+          "ForcingsEngineDataProvider: neither variable `"
+          + suffixed_name.substr(0, suffixed_name.size() - suffix.size())
+          + "` nor `" + suffixed_name + "` exist."
+        };
+    }
+
     //! Forcings Engine instance
     std::shared_ptr<models::bmi::Bmi_Py_Adapter> bmi_ = nullptr;
 

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -200,10 +200,6 @@ struct ForcingsEngineDataProvider
     //! Output variable names
     std::vector<std::string> var_output_names_{};
 
-  private:
-    //! Initialization config file path
-    std::string init_;
-
     //! Calendar time for simulation beginning
     clock_type::time_point time_begin_{};
 
@@ -212,6 +208,9 @@ struct ForcingsEngineDataProvider
 
     //! Duration of a single simulation tick
     clock_type::duration time_step_{};
+
+    //! Initialization config file path
+    std::string init_;
 };
 
 } // namespace data_access


### PR DESCRIPTION
This PR makes 2 changes to support derived implementations:

1. Moves timing and configuration file path member variables outside of `private` scope into `protected` so derived implementations can directly access these.
2. Adds `ForcingsEngineDataProvider::ensure_variable`, which is a helper function that helps handle variable name aliasing from what NGen expects to what the forcings engine expects.

## Additions

- `ForcingsEngineDataProvider::ensure_variable`

## Changes

- `init_`, `time_begin_`, `time_end_`, and `time_step_` from `private` to `protected` scope.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
