### PR TITLE
Fix t-route integration tests requiring `fiona`

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -113,7 +113,7 @@ jobs:
           pip install 'pip>=23.0,<23.1'
           pip install -U setuptools
           pip install -r requirements.txt
-          pip install deprecated 'pyarrow==11.0.0' tables geopandas numpy
+          pip install deprecated 'pyarrow==11.0.0' tables geopandas numpy fiona
           if [ ${{ runner.os }} == 'macOS' ] 
           then
             export LIBRARY_PATH=/usr/local/lib/gcc/11/


### PR DESCRIPTION
`geopandas<1.0.0` included `fiona` as a required dependency. However, since v1.0.0, they switched to using `pyogrio` as the default engine for I/O -- as a result, `fiona` is currently an unspecified dependency in t-route.

## Changes

- Include `fiona` in pip install call in CI

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
