### PR TITLE
Don't reuse global model params

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -385,9 +385,11 @@ namespace realization {
                 //because they will eventually be used by someone, someday, looking at configurations
                 //being turned into concrecte formulations...
                 // geojson::JSONProperty::print_property(global_config.formulation.parameters.at("modules"));
-                global_config.formulation.link_external(feature);
-                // geojson::JSONProperty::print_property(global_config.formulation.parameters.at("modules"));
-                missing_formulation->create_formulation(global_config.formulation.parameters);
+
+                //Make a copy of the global configuration so parameters don't clash when linking to external data
+                auto formulation =  realization::config::Formulation(global_config.formulation);
+                formulation.link_external(feature);
+                missing_formulation->create_formulation(formulation.parameters);
 
                 return missing_formulation;
             }

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -954,13 +954,24 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
     this->fabric->remove_feature_by_id("cat-27115");
 
     manager = realization::Formulation_Manager(stream_b);
-    
+   
+    //Test that two hydrofabric features, using global formulation (EXAMPLE_5_b)
+    //end up with unique hydrofabric parameters in the formulations after they
+    //are created and linked to the attributes.  Uses the same parameter name with
+    //different values.
+ 
     add_and_check_feature("cat-67", geojson::PropertyMap{
       { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 9231 } },
       { "val",           geojson::JSONProperty{"val",       7.41722 } }
     });
-
+    
+    add_and_check_feature("cat-27", geojson::PropertyMap{
+      { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 18 } },
+      { "val",          geojson::JSONProperty{"val", 3} }
+    });
+    
     manager.read(this->fabric, catchment_output);
-
+    
+    check_formulation_values(manager, "cat-27",    { 3.00000, 18.0 });
     check_formulation_values(manager, "cat-67", { 7.41722, 9231 });
 }


### PR DESCRIPTION
Fixing bug in reuse of global `model_params` when linking external data from a global formulation definition

## Changes

- Copy global formulation config before modifying with `link_external`

## Testing

1. Tested on realization provided in #871 and ensured each feature on the BMI receiving end has correct area values

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
