### PR TITLE
Fix Forcings Engine test compile definition for `test_all`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,9 +201,10 @@ if(TARGET test_forcings_engine)
         "${CMAKE_CURRENT_LIST_DIR}/../data/forcing/forcings-engine/config_aorc.yml.in" # Input
         "${CMAKE_CURRENT_BINARY_DIR}/config_aorc.yml"
     )
-    target_compile_definitions(test_forcings_engine
-      PUBLIC
-        -DNGEN_LUMPED_CONFIG_PATH="${CMAKE_CURRENT_BINARY_DIR}/config_aorc.yml")
+
+    # Use global add instead of target add so that both `test_forcings_engine` and `test_all`
+    # receive this compile definition.
+    add_compile_definitions(NGEN_LUMPED_CONFIG_PATH="${CMAKE_CURRENT_BINARY_DIR}/config_aorc.yml")
 endif()
 
 ########################## Series Unit Tests


### PR DESCRIPTION
This PR fixes an issue where the `test_all` target is not compiled with `-DNGEN_LUMPED_CONFIG_PATH`.

This is because the definition is added with `target_compile_definitions` only to `test_forcings_engine`, but if that target exists, then `test_all` will include its objects. By replacing `target_compile_definitions` with `add_compile_definitions` , ensures `test_all` will have it defined.

## Changes

- `target_compile_definitions` -> `add_compile_definitions` in tests/CMakeLists.txt

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
