### PR TITLE
Include git commit ID in configuration summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND CMAKE_MODULE_PATH "${NGEN_MOD_DIR}")
 #   (1) finds Git package
 #   (2) Sets ${NGEN_HAS_GIT_DIR} to ON/OFF if ${NGEN_ROOT_DIR}/.git exists
 #   (3) Function `git_update_submodule` which updates a given submodule
+#   (4) Sets ${NGEN_GIT_COMMIT} to the current commit hash if available
 include(GitUpdateSubmodules)
 
 # NGen CMake module for automating external subdirectory builds (i.e. testbmicpp)
@@ -406,7 +407,10 @@ ngen_multiline_message(
 "  C Compiler: ${CMAKE_C_COMPILER}"
 "  C Flags: ${CMAKE_C_FLAGS}"
 "  CXX Compiler: ${CMAKE_CXX_COMPILER}"
-"  CXX Flags: ${CMAKE_CXX_FLAGS}"
+"  CXX Flags: ${CMAKE_CXX_FLAGS}")
+ngen_dependent_multiline_message(NGEN_HAS_GIT_DIR
+"  Git Commit ID: ${NGEN_GIT_COMMIT}")
+ngen_multiline_message(
 "  Flags:"
 "    NGEN_WITH_MPI: ${NGEN_WITH_MPI}"
 "    NGEN_WITH_NETCDF: ${NGEN_WITH_NETCDF}"

--- a/cmake/GitUpdateSubmodules.cmake
+++ b/cmake/GitUpdateSubmodules.cmake
@@ -2,6 +2,13 @@ find_package(Git QUIET)
 
 if(EXISTS "${NGEN_ROOT_DIR}/.git")
     set(NGEN_HAS_GIT_DIR ON)
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+        WORKING_DIRECTORY ${NGEN_ROOT_DIR}
+        OUTPUT_VARIABLE NGEN_GIT_COMMIT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 else()
     set(NGEN_HAS_GIT_DIR OFF)
 endif()


### PR DESCRIPTION
This PR adds the repo's git commit ID to the CMake configuration summary output. This will also include it when calling `ngen --info`.

Example:

```
NGen version: 0.1.0
-- Build configuration summary:
--   Generator: Ninja
--   Build type: Debug
--   System: Linux
--   C Compiler: /usr/bin/clang
--   C Flags: -Wpessimizing-move
--   CXX Compiler: /usr/bin/clang++
--   CXX Flags: -Wpessimizing-move -pedantic-errors
--   Git Commit ID: 2ffedf8ecb3d6311be65d8c7c8f99c2fecf7ee07
--   Flags:
...
```

## Additions

- Adds `NGEN_GIT_COMMIT` CMake variable.


## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
