### PR TITLE
Using logging functions to standardize the std::cerr output messages

### DIFF
--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -20,6 +20,7 @@
 #include "Bmi_Adapter.hpp"
 
 #include "utilities/python/InterpreterUtil.hpp"
+#include "utilities/logging_utils.h"
 
 // Forward declaration to provide access to protected items in testing
 class Bmi_Py_Adapter_Test;
@@ -685,7 +686,7 @@ namespace models {
                     //This message is lost and often contains valuable info.  Either need to break up and catch 
                     //other possible exceptions, wrap all these in a custom exception, or at the very least, print
                     //the original messge before it gets lost in this re-throw.
-                    std::cerr<<init_exception_msg<<std::endl;
+                    logging::error((init_exception_msg + "\n").c_str());
                     throw e;
                 }
             }

--- a/include/core/HY_Features.hpp
+++ b/include/core/HY_Features.hpp
@@ -9,6 +9,7 @@
 #include <network.hpp>
 #include <Formulation_Manager.hpp>
 #include <HY_Features_Ids.hpp>
+#include "utilities/logging_utils.h"
 
 namespace hy_features {
 
@@ -173,21 +174,21 @@ namespace hy_features {
               auto downstream = network.get_destination_ids(id);
               if(downstream.size() > 1)
               {
-                std::cerr << "Catchment " << id << " has more than one downstream connection." << std::endl;
-                std::cerr << "Downstreams are: ";
+                logging::error(("Catchment " + id + " has more than one downstream connection.\n").c_str());
+                logging::error((std::string("Downstreams are: ")).c_str());
                 for(const auto& id : downstream){
-                  std::cerr <<id<<" ";
+                  logging::formatting((id+" ").c_str());
                 }
-                std::cerr << std::endl;
+                logging::formatting((std::string("\n")).c_str());
                 assert( false );
               }
               else if (downstream.size() == 0)
               {
-                std::cerr << "Catchment " << id << " has 0 downstream connections, must have 1." << std::endl;
+                logging::error(("Catchment " + id + " has 0 downstream connections, must have 1.\n").c_str());
                 assert( false );
               }
           }
-          std::cout<<"Catchment topology is dendritic."<<std::endl;
+          logging::critical((std::string("Catchment topology is dendritic.\n")).c_str());
         }
 
         /**

--- a/include/core/HY_Features_MPI.hpp
+++ b/include/core/HY_Features_MPI.hpp
@@ -13,6 +13,7 @@
 #include <network.hpp>
 #include <Formulation_Manager.hpp>
 #include <Partition_Parser.hpp>
+#include "logging_utils.h"
 
 namespace hy_features {
 
@@ -68,16 +69,16 @@ namespace hy_features {
             for(const auto& id : catchments()) {
                 auto downstream = network.get_destination_ids(id);
                 if(downstream.size() > 1) {
-                    std::cerr << "Catchment " << id << " has more than one downstream connection." << std::endl;
-                    std::cerr << "Downstreams are: ";
+                    logging::error((std::string("Catchment ") + id + " has more than one downstream connection.\n").c_str());
+                    logging::error((std::string("Downstreams are: ")).c_str());
                     for(const auto& id : downstream){
-                        std::cerr <<id<<" ";
+                        logging::formatting((id+std::string(" ")).c_str());
                     }
-                    std::cerr << std::endl;
+                    logging::formatting((std::string("\n")).c_str());
                     assert( false );
                 }
                 else if (downstream.size() == 0) {
-                    std::cerr << "Catchment " << id << " has 0 downstream connections, must have 1." << std::endl;
+                    logging::error((std::string("Catchment ") + id + " has 0 downstream connections, must have 1.\n").c_str());
                     assert( false );
                 }
             }

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -20,6 +20,7 @@
 #include "DataProviderSelectors.hpp"
 #include <exception>
 #include <UnitsHelper.hpp>
+#include "logging_utils.h"
 
 /**
  * @brief Forcing class providing time-series precipiation forcing data to the model.
@@ -165,7 +166,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         }
         catch (const std::runtime_error& e){
             #ifndef UDUNITS_QUIET
-            std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
+            logging::warning((std::string("WARN: Unit conversion unsuccessful - Returning unconverted value! (\"")+e.what()+"\")\n").c_str());
             #endif
             return value;
         }

--- a/include/geojson/features/CollectionFeature.hpp
+++ b/include/geojson/features/CollectionFeature.hpp
@@ -40,7 +40,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = "Point";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }
@@ -56,7 +56,7 @@ namespace geojson {
                         catch (boost::bad_get &exception) {
                             std::string template_name = "Point";
                             std::string expected_name = get_geometry_type(geometry);
-                            std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                            logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                             throw;
                         }
                     }
@@ -72,7 +72,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = "LineString";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }
@@ -88,7 +88,7 @@ namespace geojson {
                         catch (boost::bad_get &exception) {
                             std::string template_name = "LineString";
                             std::string expected_name = get_geometry_type(geometry);
-                            std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                            logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                             throw;
                         }
                     }
@@ -104,7 +104,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = "Polygon";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }
@@ -120,7 +120,7 @@ namespace geojson {
                         catch (boost::bad_get &exception) {
                             std::string template_name = "Polygon";
                             std::string expected_name = get_geometry_type(geometry);
-                            std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                            logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                             throw;
                         }
                     }
@@ -136,7 +136,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = "MultiPoint";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }
@@ -160,7 +160,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = "MultiLineString";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }
@@ -184,7 +184,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = "MultiPolygon";
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }

--- a/include/geojson/features/FeatureBase.hpp
+++ b/include/geojson/features/FeatureBase.hpp
@@ -4,6 +4,7 @@
 #include "JSONGeometry.hpp"
 #include "JSONProperty.hpp"
 #include "FeatureVisitor.hpp"
+#include "logging_utils.h"
 
 #include <memory>
 #include <ostream>
@@ -530,7 +531,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = boost::typeindex::type_id<T>().pretty_name();
                     std::string expected_name = get_geometry_type(this->geom);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }
@@ -547,7 +548,7 @@ namespace geojson {
                 catch (boost::bad_get &exception) {
                     std::string template_name = boost::typeindex::type_id<T>().pretty_name();
                     std::string expected_name = get_geometry_type(this->geometry_collection[index]);
-                    std::cerr << "Asked for " << template_name << ", but only " << expected_name << " is valid" << std::endl;
+                    logging::error((std::string("Asked for ") + template_name + ", but only " + expected_name + " is valid\n").c_str());
                     throw;
                 }
             }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -21,6 +21,7 @@
 #include "features/Features.hpp"
 #include "Formulation_Constructors.hpp"
 #include "LayerData.hpp"
+#include "logging_utils.h"
 #include "realizations/config/time.hpp"
 #include "realizations/config/routing.hpp"
 #include "realizations/config/config.hpp"
@@ -130,8 +131,8 @@ namespace realization {
                     using_routing = true;
                 #else
                     using_routing = false;
-                    std::cerr<<"WARNING: Formulation Manager found routing configuration"
-                             <<", but routing support isn't enabled. No routing will occur."<<std::endl;
+                    logging::warning((std::string("WARNING: Formulation Manager found routing configuration")
+                             +", but routing support isn't enabled. No routing will occur.\n").c_str());
                 #endif //NGEN_WITH_ROUTING
                  }
 
@@ -146,9 +147,9 @@ namespace realization {
                       if( catchment_index == -1 )
                       {
                           #ifndef NGEN_QUIET
-                          std::cerr<<"WARNING Formulation_Manager::read: Cannot create formulation for catchment "
-                                  <<catchment_config.first
-                                  <<" that isn't identified in the hydrofabric or requested subset"<<std::endl;
+                          logging::warning((std::string("WARNING Formulation_Manager::read: Cannot create formulation for catchment ")
+                                  +catchment_config.first
+                                  +" that isn't identified in the hydrofabric or requested subset\n").c_str());
                           #endif
                           continue;
                       }
@@ -577,15 +578,14 @@ namespace realization {
                             case geojson::PropertyType::List:
                             case geojson::PropertyType::Object:
                             default:
-                                std::cerr << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
-                                          << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
+                                logging::error((std::string("WARNING: property type ") + std::to_string(static_cast<int>(catchment_attribute.get_type())) + " not allowed as model parameter. " + "Must be one of: Natural (int), Real (double), Boolean, or String\n").c_str());
                                 break;
                         }
                     } else {
-                        std::cerr << "WARNING Failed to parse external parameter: catchment `"
-                                  << catchment_feature->get_id()
-                                  << "` does not contain the property `"
-                                  << param_name << "`\n";
+                        logging::error((std::string("WARNING Failed to parse external parameter: catchment `")
+                                  + catchment_feature->get_id()
+                                  + "` does not contain the property `"
+                                  + param_name + "`\n").c_str());
                     }
                 }
 
@@ -646,8 +646,7 @@ namespace realization {
                             default:
                                 // TODO: Should list/object values be passed to model parameters?
                                 //       Typically, feature properties *should* be scalars.
-                                std::cerr << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
-                                          << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
+                                logging::error((std::string("WARNING: property type ") + std::to_string(static_cast<int>(catchment_attribute.get_type())) + " not allowed as model parameter. " + "Must be one of: Natural (int), Real (double), Boolean, or String\n").c_str());
                                 break;
                         }
                     }

--- a/include/realizations/config/formulation.hpp
+++ b/include/realizations/config/formulation.hpp
@@ -130,8 +130,7 @@ namespace realization{
                     case geojson::PropertyType::Object:
                         // TODO: Should list/object values be passed to model parameters?
                         //       Typically, feature properties *should* be scalars.
-                        std::cerr << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
-                                    << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
+                        logging::error((std::string("WARNING: property type ") + std::to_string(static_cast<int>(catchment_attribute.get_type())) + " not allowed as model parameter. " + "Must be one of: Natural (int), Real (double), Boolean, or String\n").c_str());
                         break;
                     default:
                         attr.at(param.first) = geojson::JSONProperty(param.first, catchment_attribute);

--- a/include/utilities/logging_utils.h
+++ b/include/utilities/logging_utils.h
@@ -37,6 +37,12 @@ namespace logging {
      * @param msg The variable carries the humanly readable critical message.
      */
     void critical(const char* msg);
+
+    /**
+      * Used for pretty printting when std::cerr has multi-line output
+      * @param msg The variable carries the humanly readable message.
+      */
+    void formatting(const char* msg);
 }
 
 #ifdef     __cplusplus

--- a/include/utilities/parallel_utils.h
+++ b/include/utilities/parallel_utils.h
@@ -20,6 +20,7 @@
 #define NGEN_MPI_PROTOCOL_TAG 101
 #endif
 
+#include "utilities/logging_utils.h"
 #include <cstring>
 #include <mpi.h>
 #include <string>
@@ -479,7 +480,7 @@ namespace parallel {
         #if !NGEN_WITH_PYTHON
         // We can't be good to proceed with this, because Python is not active
         isGood = false;
-        std::cerr << "Driver is unable to perform required hydrofabric subdividing when Python integration is not active." << std::endl;
+        logging::critical((std::string("Driver is unable to perform required hydrofabric subdividing when Python integration is not active.\n")).c_str());
 
 
         // Sync with the rest of the ranks and bail if any aren't ready to proceed for any reason
@@ -496,7 +497,7 @@ namespace parallel {
                                                                                    partitionConfigFile);
             }
             catch (const std::exception &e) {
-                std::cerr << e.what() << std::endl;
+                logging::error((e.what() + std::string("\n")).c_str());
                 // Set not good if the subdivider object couldn't be instantiated
                 isGood = false;
             }
@@ -512,7 +513,7 @@ namespace parallel {
                 isGood = subdivider->execSubdivision();
             }
             catch (const std::exception &e) {
-                std::cerr << e.what() << std::endl;
+                logging::error((e.what() + std::string("\n")).c_str());
                 // Set not good if the subdivider object couldn't be instantiated
                 isGood = false;
             }

--- a/include/utilities/python/HydrofabricSubsetter.hpp
+++ b/include/utilities/python/HydrofabricSubsetter.hpp
@@ -7,6 +7,7 @@
 
 #include <pybind11/embed.h>
 #include "InterpreterUtil.hpp"
+#include "utilities/logging_utils.h"
 
 namespace py = pybind11;
 
@@ -96,7 +97,7 @@ namespace utils {
                     result = bool_result;
                 }
                 catch (const std::exception &e) {
-                    std::cerr << "Failed to subdivide hydrofabric: " << e.what() << std::endl;
+                    logging::error((std::string("Failed to subdivide hydrofabric: ") + e.what()).c_str());
                     result = false;
                 }
                 return result;
@@ -109,7 +110,7 @@ namespace utils {
                     result = bool_result;
                 }
                 catch (const std::exception &e) {
-                    std::cerr << "Failed to subdivide hydrofabric for index " << index << ": " << e.what() << std::endl;
+                    logging::error((std::string("Failed to subdivide hydrofabric for index ") + std::to_string(index) + ": " + e.what() + "\n").c_str());
                     result = false;
                 }
                 return result;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -16,6 +16,7 @@
 
 #include "NGenConfig.h"
 
+#include "utilities/logging_utils.h"
 #include <FileChecker.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/range/algorithm/sort.hpp>
@@ -348,10 +349,10 @@ int main(int argc, char *argv[]) {
         std::vector<PartitionData> &partitions = partition_parser.partition_ranks;
         local_data = std::move(partitions[mpi_rank]);
         if (!nexus_subset_ids.empty()) {
-            std::cerr << "Warning: CLI provided nexus subset will be ignored when using partition config";
+            logging::critical((std::string("Warning: CLI provided nexus subset will be ignored when using partition config \n")).c_str());
         }
         if (!catchment_subset_ids.empty()) {
-            std::cerr << "Warning: CLI provided catchment subset will be ignored when using partition config";
+            logging::critical((std::string("Warning: CLI provided catchment subset will be ignored when using partition config \n")).c_str());
         }
         nexus_subset_ids = std::vector<std::string>(local_data.nexus_ids.begin(), local_data.nexus_ids.end());
         catchment_subset_ids = std::vector<std::string>(local_data.catchment_ids.begin(), local_data.catchment_ids.end());

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -1,5 +1,6 @@
 #include <HY_Features.hpp>
 #include <HY_PointHydroNexus.hpp>
+#include "utilities/logging_utils.h"
 
 using namespace hy_features;
 
@@ -63,8 +64,7 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         }
         else
         {
-          std::cerr<<"HY_Features::HY_Features unknown feature identifier type "<<feat_type<<" for feature id."<<feat_id
-                   <<" Skipping feature"<<std::endl;
+          logging::warning(("WARN: HY_Features::HY_Features unknown feature identifier type "+feat_type+" for feature id."+feat_id+" Skipping feature\n").c_str());
         }
       }
 

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -1,5 +1,6 @@
 #include <HY_Features_MPI.hpp>
 #include <HY_PointHydroNexusRemote.hpp>
+#include "utilities/logging_utils.h"
 
 #if NGEN_WITH_MPI
 
@@ -80,8 +81,7 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         }
         else
         {
-          std::cerr<<"HY_Features::HY_Features unknown feature identifier type "<<feat_type<<" for feature id."<<feat_id
-                   <<" Skipping feature"<<std::endl;
+          logging::error(("HY_Features::HY_Features unknown feature identifier type "+feat_type+" for feature id."+feat_id+" Skipping feature\n").c_str());
         }
       }	
 }

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -1,4 +1,5 @@
 #include "SurfaceLayer.hpp"
+#include "utilities/logging_utils.h"
 
 /***
  * @brief Run one simulation timestep for each model in this layer, then gather catchment output
@@ -34,7 +35,7 @@ void ngen::SurfaceLayer::update_models()
             cat_id = "terminal";
         }
 
-        //std::cerr << "Requesting water from nexus, id = " << id << " at time = " <<current_time_index << ",  percent = 100, destination = " << cat_id << std::endl;
+        //logging::warning(("Requesting water from nexus, id = " + id + " at time = " + std::to_string(current_time_index) + ",  percent = 100, destination = " + cat_id + "\n").c_str());
         double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
         
         if(nexus_outfiles[id].is_open()) {
@@ -44,7 +45,8 @@ void ngen::SurfaceLayer::update_models()
         #if NGEN_WITH_MPI
         }
         #endif
-        //std::cout<<"\tNexus "<<id<<" has "<<contribution_at_t<<" m^3/s"<<std::endl;
+        //contribution_at_t out of scope unless for serial build
+        //logging::info(("\tNexus "+id+" has "+std::to_string(contribution_at_t)+" m^3/s"+"\n").c_str());
 
         //Note: Use below if developing in-memory transfer of nexus flows to routing
         //If using below, then another single time vector would be needed to hold the timestamp

--- a/src/core/nexus/CMakeLists.txt
+++ b/src/core/nexus/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(core_nexus PUBLIC
 target_link_libraries(core_nexus PUBLIC
         Boost::boost                # Headers-only Boost
         NGen::config_header
+        NGen::logging
         )
 
 if(NGEN_WITH_MPI)

--- a/src/core/nexus/HY_PointHydroNexusRemote.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemote.cpp
@@ -1,6 +1,6 @@
 #include "HY_PointHydroNexusRemote.hpp"
 #include "Constants.h"
-
+#include "logging_utils.h"
 
 #if NGEN_WITH_MPI
 
@@ -101,7 +101,7 @@ HY_PointHydroNexusRemote::~HY_PointHydroNexusRemote()
 
     while ( (stored_receives.size() > 0 || stored_sends.size() > 0) && !mpi_finalized )
     {
-        //std::cerr << "Neuxs with rank " << id << " has pending communications\n";
+        //logging::error(("Neuxs with rank " + id + " has pending communications\n").c_str());
 
         process_communications();
 
@@ -151,10 +151,10 @@ double HY_PointHydroNexusRemote::get_downstream_flow(std::string catchment_id, t
 
        		MPI_Handle_Error(status); 
        		
-                //std::cerr << "Creating receive with target_rank=" << rank << " on tag=" << tag << "\n";
+                //logging::info(("Creating receive with target_rank=" + std::to_string(rank) + " on tag=" + std::to_string(tag) + "\n").c_str());
     	}
     	
-        //std::cerr << "Waiting on receives\n";
+        //logging::info((std::string("Waiting on receives\n")).c_str());
         while ( stored_receives.size() > 0 )
     	{
     		process_communications();
@@ -214,8 +214,7 @@ void HY_PointHydroNexusRemote::add_upstream_flow(double val, std::string catchme
 		        MPI_COMM_WORLD,
 		        &stored_sends.back().mpi_request);
 		        
-		    //std::cerr << "Creating send with target_rank=" << *downstream_ranks.begin() << " on tag=" << tag << "\n";	
-		        
+                    //logging::info(("Creating send with target_rank=" + std::to_string(*downstream_ranks.begin()) + " on tag=" + std::to_string(tag) + "\n").c_str());
 		    
 		    while ( stored_sends.size() > 0 )
 		    {

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(forcing PUBLIC
         NGen::core
         Boost::boost                # Headers-only Boost
         NGen::config_header
+        NGen::logging
         Threads::Threads
 )
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -2,6 +2,7 @@
 
 #if NGEN_WITH_NETCDF
 #include "NetCDFPerFeatureDataProvider.hpp"
+#include "logging_utils.h"
 
 #include <netcdf>
 
@@ -198,7 +199,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         }
     }
     catch(const netCDF::exceptions::NcException& e){
-        std::cerr<<e.what()<<std::endl;
+        logging::error((std::string(e.what()) + "\n").c_str());
         log_stream << "Warning using defualt time units\n";
     }
     assert(time_scale_factor != 0); // This should not happen.
@@ -218,7 +219,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         }
     }
     catch(const netCDF::exceptions::NcException& e) {
-        std::cerr<<e.what()<<std::endl;
+        logging::error((std::string(e.what()) + "\n").c_str());
         log_stream << "Warning using defualt epoc string\n";
     }
     
@@ -428,7 +429,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     catch (const std::runtime_error& e)
     {
         #ifndef UDUNITS_QUIET
-        std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
+        logging::warning(("WARN: Unit conversion unsuccessful - Returning unconverted value! (\""+e.what()+"\")\n").c_str());
         #endif
         return rvalue;
     }

--- a/src/geojson/CMakeLists.txt
+++ b/src/geojson/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(geojson STATIC
 add_library(NGen::geojson ALIAS geojson)
 target_include_directories(geojson PUBLIC
         ${PROJECT_SOURCE_DIR}/include/geojson
+        ${PROJECT_SOURCE_DIR}/include/utilities
         )
 target_link_libraries(geojson PUBLIC
         Boost::boost                # Headers-only Boost

--- a/src/geopackage/CMakeLists.txt
+++ b/src/geopackage/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(geopackage proj.cpp
 add_library(NGen::geopackage ALIAS geopackage)
 target_include_directories(geopackage PUBLIC ${PROJECT_SOURCE_DIR}/include/geopackage)
 target_include_directories(geopackage PUBLIC ${PROJECT_SOURCE_DIR}/include/utilities)
-target_link_libraries(geopackage PUBLIC NGen::geojson Boost::boost sqlite3)
+target_link_libraries(geopackage PUBLIC NGen::geojson Boost::boost sqlite3 NGen::logging)

--- a/src/geopackage/read.cpp
+++ b/src/geopackage/read.cpp
@@ -1,4 +1,5 @@
 #include "geopackage.hpp"
+#include "logging_utils.h"
 
 #include <numeric>
 #include <regex>
@@ -57,7 +58,7 @@ std::shared_ptr<geojson::FeatureCollection> ngen::geopackage::read(
         catch (const std::exception& e){
             #ifndef NGEN_QUIET
             // output debug info on what is read exactly
-            std::cout << "WARN: Using legacy ID column \"id\" in layer " << layer << " is DEPRECATED and may stop working at any time." << std::endl;
+            logging::warning(("WARN: Using legacy ID column \"id\" in layer " + layer + " is DEPRECATED and may stop working at any time.\n").c_str()) ;
             #endif
         }
     }
@@ -85,15 +86,15 @@ std::shared_ptr<geojson::FeatureCollection> ngen::geopackage::read(
 
     #ifndef NGEN_QUIET
     // output debug info on what is read exactly
-    std::cout << "Reading " << layer_feature_count << " features from layer " << layer << " using ID column `"<< id_column << "`";
+    logging.debug(("Reading " << std::to_string(layer_feature_count) + " features from layer " + layer + " using ID column `" + id_column + "`").c_str());
     if (!ids.empty()) {
-        std::cout << " (id subset:";
+        logging::formatting((std::string(" (id subset:")).c_str());
         for (auto& id : ids) {
-            std::cout << " " << id;
+            logging::formatting((" " + id).c_str());
         }
-        std::cout << ")";
+        logging::formatting((std::string(")")).c_str());
     }
-    std::cout << std::endl;
+    logging::formatting((std::string("\n")).c_str());
     #endif
 
     // Get layer feature metadata (geometry column name + type)

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -203,7 +203,7 @@ namespace realization {
                 }
                 catch (const std::runtime_error& e){
                     #ifndef UDUNITS_QUIET
-                    std::cerr<<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
+                    logging::warning(("WARN: Unit conversion unsuccessful - Returning unconverted value! (\""+e.what()+"\")"+"\n").c_str());
                     #endif
                     return value;
                 }
@@ -661,7 +661,7 @@ namespace realization {
                     if(values.size() == 1){
                         //FIXME this isn't generic broadcasting, but works for scalar implementations
                         #ifndef NGEN_QUIET
-                        std::cerr << "WARN: broadcasting variable '" << var_name << "' from scalar to expected array\n";
+                        logging::warning(("WARN: broadcasting variable '"+var_name+"' from scalar to expected array\n").c_str());
                         #endif
                         values.resize(numItems, values[0]);
                     } else if (values.size() != numItems) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -11,6 +11,7 @@
 #include "Bmi_C_Formulation.hpp"
 #include "Bmi_Fortran_Formulation.hpp"
 #include "Bmi_Py_Formulation.hpp"
+#include "utilities/logging_utils.h"
 
 using namespace realization;
 
@@ -130,8 +131,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             set_output_header_fields(out_headers);
         }
         else {
-            std::cerr << "WARN: configured output headers have " << out_headers.size() << " fields, but there are "
-                      << get_output_variable_names().size() << " variables in the output" << std::endl;
+            logging::warning((std::string("WARN: configured output headers have ") + std::to_string(out_headers.size())
+                              + " fields, but there are " + std::to_string(get_output_variable_names().size())
+                              + " variables in the output\n").c_str());
             set_output_header_fields(get_output_variable_names());
         }
     }

--- a/src/routing/CMakeLists.txt
+++ b/src/routing/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(routing PUBLIC
 target_link_libraries(routing PUBLIC
                               pybind11::embed
                               NGen::config_header
+                              NGen::logging
                               )
 
 

--- a/src/routing/Routing_Py_Adapter.cpp
+++ b/src/routing/Routing_Py_Adapter.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <iostream>
 #include "Routing_Py_Adapter.hpp"
+#include "logging_utils.h"
 
 using namespace routing_py_adapter;
 
@@ -25,7 +26,7 @@ Routing_Py_Adapter::Routing_Py_Adapter(std::string t_route_config_file_with_path
       this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("nwm_routing.__main__");
     }
     catch (const pybind11::error_already_set& e){
-      std::cerr<<"FAIL: Unable to import a supported routing module."<<std::endl;
+      logging::error((std::string("FAIL: Unable to import a supported routing module.\n")).c_str());
       throw e;
     }
   }

--- a/src/utilities/logging/logging_utils.cpp
+++ b/src/utilities/logging/logging_utils.cpp
@@ -40,6 +40,11 @@ extern "C" {
         std::cerr<<"CRITICAL: " <<std::string(msg);
     }
 
+    void formatting(const char* msg)
+    {
+        std::cerr<<std::string(msg);
+    }
+
 #ifdef     __cplusplus
 }
 #endif

--- a/test/core/nexus/NexusRemoteTests.cpp
+++ b/test/core/nexus/NexusRemoteTests.cpp
@@ -2,6 +2,7 @@
 
 #include "gtest/gtest.h"
 #include "HY_PointHydroNexusRemote.hpp"
+#include "logging_utils.h"
 
 
 #include <vector>
@@ -38,7 +39,7 @@ protected:
     {
         MPI_Finalize();
 
-        std::cerr << "Rank " << mpi_rank << " called finalize\n";
+        logging::critical((std::string("Rank ") + std::to_string(mpi_rank) + " called finalize\n").c_str());
     }
 
     std::vector<double> stored_discharge;
@@ -99,7 +100,7 @@ TEST_F(Nexus_Remote_Test, TestInit0)
         switch(mpi_rank)
         {
             case 0:
-                std::cerr << "Rank 0: Sending flow of " << discharge << " to catchment 26\n";
+                logging::critical((std::string("Rank 0: Sending flow of ") + std::to_string(discharge) + " to catchment 26\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-26",ts);
                 //nexus->get_downstream_flow("cat-27",ts,100);
             break;
@@ -108,7 +109,7 @@ TEST_F(Nexus_Remote_Test, TestInit0)
                 //nexus->add_upstream_flow(dummy_flow,"cat-26",ts);
                 double received_flow = nexus->get_downstream_flow("cat-27",ts,100);
                 ASSERT_EQ(discharge,received_flow);
-                std::cerr << "Rank 1: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 26\n";
+                logging::critical((std::string("Rank 1: Recieving flow of ") + std::to_string(received_flow) + " from catchment Nexus connected to catchment 26\n").c_str());
             break;
         }
 
@@ -177,16 +178,16 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders)
             case 0:
                 received_flow = nexus->get_downstream_flow("cat-27",ts,100);
                 ASSERT_EQ(discharge+discharge,received_flow);
-                std::cerr << "Rank 0: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
+                logging::critical((std::string("Rank 0: Recieving flow of ") + std::to_string(received_flow) + " from catchment Nexus connected to catchment 27\n").c_str());
             break;
             
             case 1:
-                std::cerr << "Rank 1: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 1: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-25",ts);
             break;
 
             case 2:
-                std::cerr << "Rank 2: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 2: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-26",ts);
             break;
             
@@ -259,16 +260,16 @@ TEST_F(Nexus_Remote_Test, Test2RemoteSenders1LocalSender)
                 nexus->add_upstream_flow(discharge,"cat-24",ts);
                 received_flow = nexus->get_downstream_flow("cat-27",ts,100);
                 ASSERT_EQ(discharge*3,received_flow);
-                std::cerr << "Rank 0: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
+                logging::critical((std::string("Rank 0: Recieving flow of ") + std::to_string(received_flow) + " from catchment Nexus connected to catchment 27\n").c_str());
             break;
             
             case 1:
-                std::cerr << "Rank 1: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 1: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-25",ts);
             break;
 
             case 2:
-                std::cerr << "Rank 2: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 2: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-26",ts);
             break;
             
@@ -368,16 +369,16 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
                 nexus->add_upstream_flow(discharge,"cat-24",ts);
                 received_flow = nexus->get_downstream_flow("cat-27",ts,100);
                 ASSERT_EQ(discharge*3,received_flow);
-                std::cerr << "Rank 0: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
+                logging::critical((std::string("Rank 0: Recieving flow of ") + std::to_string(received_flow) + " from catchment Nexus connected to catchment 27\n").c_str());
             break;
             
             case 1:
-                std::cerr << "Rank 1: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 1: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-25",ts);
             break;
 
             case 2:
-                std::cerr << "Rank 2: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 2: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-26",ts);
             break;
             
@@ -385,16 +386,16 @@ TEST_F(Nexus_Remote_Test, Test4R2S2LS)
                 nexus->add_upstream_flow(discharge,"cat-14",ts);
                 received_flow = nexus->get_downstream_flow("cat-17",ts,100);
                 ASSERT_EQ(discharge*3,received_flow);
-                std::cerr << "Rank 3: Recieving flow of " << received_flow << " from catchment Nexus connected to catchment 27\n";
+                logging::critical((std::string("Rank 3: Recieving flow of ") + std::to_string(received_flow) + " from catchment Nexus connected to catchment 27\n").c_str());
             break;
             
             case 4:
-                std::cerr << "Rank 4: Sending flow of " << discharge << " to catchment 17\n";
+                logging::critical((std::string("Rank 4: Sending flow of ") + std::to_string(discharge) + " to catchment 17\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-15",ts);
             break;
 
             case 5:
-                std::cerr << "Rank 5: Sending flow of " << discharge << " to catchment 27\n";
+                logging::critical((std::string("Rank 5: Sending flow of ") + std::to_string(discharge) + " to catchment 27\n").c_str());
                 nexus->add_upstream_flow(discharge,"cat-16",ts);
             break;
             
@@ -570,26 +571,25 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
         
         nexus_map[i] = std::make_shared<HY_PointHydroNexusRemote>(nex_id, downstream_catchments, upstream_catchments, local_map);
         
-                
-        std::cerr << "mpi rank: " << mpi_rank << " constucted nexus with type = " 
-        	      << std::to_string(nexus_map[i]->get_communicator_type()) << " at tree position " << i << "\n";
-        std::cerr << "upstream catchments = [ " ;
+        logging::critical((std::string("mpi rank: ") + std::to_string(mpi_rank) + " constucted nexus with type = " 
+        	      + std::to_string(nexus_map[i]->get_communicator_type()) + " at tree position " + std::to_string(i) + "\n").c_str());
+        logging::critical((std::string("upstream catchments = [ ")).c_str()) ;
         for ( std::size_t i = 0; i < upstream_catchments.size(); ++i )
-        	std::cerr << upstream_catchments[i] << ",";
-        std::cerr << "\b] for node=" << i << "\n";
+        	logging::formatting((upstream_catchments[i] + std::string(",")).c_str());
+        logging::formatting((std::string("\b] for node=") + std::to_string(i) + "\n").c_str());
         
-        std::cerr << "downstream catchments = [ " ;
+        logging::critical((std::string("downstream catchments = [ ")).c_str());
         for ( std::size_t i = 0; i < downstream_catchments.size(); ++i )
-        	std::cerr << downstream_catchments[i] << ",";
-        std::cerr << "\b] for node=" << i << "\n";
+        	logging::formatting((downstream_catchments[i] + std::string(",")).c_str());
+        logging::formatting((std::string("\b] for node=") + std::to_string(i) + "\n").c_str());
         
-        std::cerr << "local map = [ " ;
+        logging::critical((std::string("local map = [ ")).c_str());
         for ( auto p : local_map )
-        	std::cerr << p.first << ":" << p.second << ",";
-        std::cerr << "\b] for node=" << i << "\n";
+        	logging::formatting((p.first + std::string(":") + std::to_string(p.second) + ",").c_str());
+        logging::formatting((std::string("\b] for node=") + std::to_string(i) + "\n").c_str());
     }
 
-    std::cerr << "-----Rank " << mpi_rank << " Finshed creating nexus objects\n";
+    logging::critical((std::string("-----Rank ") + std::to_string(mpi_rank) + " Finshed creating nexus objects\n").c_str());
 
 
     long ts = 0;
@@ -597,18 +597,18 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
     // for each nexus accept upstream flow
     for( int i = stop_id; i >= start_id; --i )
     {
-        std::cerr << "-----Rank " << mpi_rank << " Processing nexus object at position " << i << std::endl;
+        logging::critical((std::string("-----Rank ") + std::to_string(mpi_rank) + " Processing nexus object at position " + std::to_string(i) + "\n").c_str());
 
         if ( leaf(i) )
         {
-            std::cerr << "mpi rank: " << mpi_rank << " adding forcing at node " << i << "\n";
+            logging::critical((std::string("mpi rank: ") + std::to_string(mpi_rank) + " adding forcing at node " + std::to_string(i) + "\n").c_str());
             // if this is a leaf we need a synthetic flow
             nexus_map[i]->add_upstream_flow(1.0,"forcing", ts);
 
         }
         else
         {
-            std::cerr << "mpi rank: " << mpi_rank << " processing node " << i << "\n";
+            logging::critical((std::string("mpi rank: ") + std::to_string(mpi_rank) + " processing node " + std::to_string(i) + "\n").c_str());
             // if this is not a leaf try to get flow from its upstreams
 
             int l = left(i);
@@ -624,7 +624,7 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
 
             try
             {
-            	std::cerr << "mpi rank: " << mpi_rank << " processing node " << i << " left \n";
+                logging::critical((std::string("mpi rank: ") + std::to_string(mpi_rank) + " processing node " + std::to_string(i) + " left \n").c_str());
             	float f = nexus_map.at(l)->get_downstream_flow(current_id, ts, 100.0);
             	flow += f;
             	nexus_map[i]->add_upstream_flow(f, left_id, ts );
@@ -636,7 +636,7 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
   			
   			try
             {
-            	std::cerr << "mpi rank: " << mpi_rank << " processing node " << i << " right \n";
+                logging::critical((std::string("mpi rank: ") + std::to_string(mpi_rank) + " processing node " + std::to_string(i) + " right \n").c_str());
             	float f = nexus_map.at(r)->get_downstream_flow(current_id, ts, 100.0);
             	flow += f;
             	nexus_map[i]->add_upstream_flow(flow, right_id, ts );
@@ -650,10 +650,10 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
             {
             	if ( p != i )
             	{
-            		std::cerr << "mpi rank: " << mpi_rank << " processing node " << i << "parent \n";
+                        logging::critical((std::string("mpi rank: ") + std::to_string(mpi_rank) + " processing node " + std::to_string(i) + " parent \n").c_str());
             		//flow = nexus_map[i]->get_downstream_flow(p_id,ts,100.0);
-            		std::cerr << "p = " << p << "\n";
-            		std::cerr << "i = " << i << "\n";
+            		logging::critical((std::string("p = ") + std::to_string(p) + "\n").c_str());
+                        logging::critical((std::string("i = ") + std::to_string(i) + "\n").c_str());
             		nexus_map.at(p)->add_upstream_flow(flow, current_id, ts );
             	}
             }
@@ -674,7 +674,7 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestTree1)
     {
         double flow = 0.0;
         flow = nexus_map[0]->get_downstream_flow("cat-0", ts, 100.0);
-        std::cerr << "Rank " << mpi_rank<< " final Flow = " << flow << std::endl;
+        logging::critical((std::string("Rank ") + std::to_string(mpi_rank) + " final Flow = " + std::to_string(flow) + "\n").c_str());
 
         ASSERT_TRUE(flow == 512);
     }

--- a/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
+++ b/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
@@ -92,7 +92,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataRead)
     int current_day_of_year;
     int i = 65;
     time_t t = begin+(i*3600);
-    std::cerr << std::ctime(&t) << std::endl;
+    logging::critical((std::ctime(&t) + std::string("\n")).c_str());
 
     current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
@@ -125,7 +125,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataReadAltFormat)
     int current_day_of_year;
     int i = 8;
     time_t t = begin+(i*3600);
-    std::cerr << std::ctime(&t) << std::endl;
+    logging::critical((std::ctime(&t) + std::string("\n")).c_str());
 
     current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 
@@ -154,7 +154,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataUnitConversion)
     int current_day_of_year;
     int i = 65;
     time_t t = begin+(i*3600);
-    std::cerr << std::ctime(&t) << std::endl;
+    logging::critical((std::ctime(&t) + std::string("\n")).c_str());
 
     current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
 

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -165,7 +165,7 @@ class Formulation_Manager_Test : public ::testing::Test {
           }
           std::string right_path = utils::FileChecker::find_first_readable(v);
           if(right_path != forcing_paths[i]){
-            std::cerr<<"Replacing "<<forcing_paths[i]<<" with "<<right_path<<std::endl;
+            logging::critical((std::string("Replacing ") + forcing_paths[i] + " with " + right_path + "\n").c_str());
             boost::replace_all(json, forcing_paths[i] , right_path);
           }
         }

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -16,6 +16,7 @@
 #include "Bmi_Module_Formulation.hpp"
 #include "Bmi_Fortran_Formulation.hpp"
 #include "Bmi_Fortran_Adapter.hpp"
+#include "utilities/logging_utils.h"
 #include "gtest/gtest.h"
 #include <iostream>
 #include <vector>
@@ -174,8 +175,8 @@ void Bmi_Fortran_Formulation_Test::SetUp() {
     registration_functions[1] = "register_bmi";
     uses_forcing_file[1] = false;
 
-    std::cerr<<"lib_file[0]: "<<lib_file[0]<<std::endl;
-    std::cerr<<"lib_file[1]: "<<lib_file[1]<<std::endl;
+    logging::critical((std::string("lib_file[0]: ")+lib_file[0]+"\n").c_str());
+    logging::critical((std::string("lib_file[1]: ")+lib_file[1]+"\n").c_str());
 
     std::string variables_with_rain_rate = "                \"output_variables\": [\"OUTPUT_VAR_2\",\n"
                                            "                    \"OUTPUT_VAR_1\",\n"


### PR DESCRIPTION
Using functions defined in src/utilities/logging/logging_utils.cpp, this PR replaces each std::cerr output in the framework code with a properly classified function so that the nature of the std::cerr instance is more easily recognizibale. The logging function classifications are as follows:
logging::debug(...)
logging::info(...)
logging::warning(...)
logging::error(...)
logging::critical(...)

## Additions

-

## Removals

-

## Changes

As shown in the commit

## Testing

Unit tests on local machine
ngen run tests in serial and mpi modes

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x ] Any _change_ in functionality is tested
- [x ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x ] Linux
