### PR TITLE
ci(ngen-submod-build): bump default mac gfortran from 11 to 12

### DIFF
--- a/.github/actions/ngen-submod-build/action.yaml
+++ b/.github/actions/ngen-submod-build/action.yaml
@@ -42,7 +42,9 @@ runs:
           if: |
             runner.os == 'macOS'
           run: |
-            echo "FC=gfortran-11" >> $GITHUB_ENV
+            # see macOS image readmes for supported versions
+            # https://github.com/actions/runner-images/tree/main/images/macos
+            echo FC="gfortran-12" >> $GITHUB_ENV
           shell: bash
 
         - name: Cmake Initialization


### PR DESCRIPTION
`github` `macOS` images no longer provide `gfortran-11` out of the box. `github` actions that use the `ngen-submod-build` [action are failing](https://github.com/NOAA-OWP/noah-owp-modular/actions/runs/10743723118/job/29799082266) if they try to use the configured fortran compiler (`gfortran-11`). See available software and version for each image [here](https://github.com/actions/runner-images/tree/main/images/macos).

This PR bumps the configured fortran version to `gfortran-12`. All current `macOS` `github` `action` images provide this `gfortran`.