### PR TITLE
Document commonly used hydrologic model output variable units

### DIFF
--- a/doc/UNITS_IN_NextGen.md
+++ b/doc/UNITS_IN_NextGen.md
@@ -2,7 +2,7 @@
 
 * [Summary](#summary)
 * [CFE Model](#cfe-model)
-* [PET Model](#pet-model))
+* [PET Model](#pet-model)
 * [Noah OWP Modular](#noah-owp-modular)
 * [Topmodel](#topmodel)
 
@@ -12,7 +12,7 @@ When running model engine with hydrofabric, the outputs are typically stored in 
 
 As for the nex-###.csv outputs, these are the accumulated overland flow contributions at the point from all directly connected catchments assoicated with the nexus. These values should be in units of m^3/s given that a formulation's main_output_variable returns a rate, e.g. m/s, the main_output_variable is currently automatically multiplied by the catchment's area to produce the volumetric flow rate.
 
-That said, for users who are interested in using the CSV format, we tabulate below output as well as input variables with their units for a few commonly used hydrologic models for users' convenience.
+That said, for users who are interested in using the CSV format, we tabulate below output as well as input variables with their units for a few commonly used hydrologic models for users' reference.
 
 ## CFE Model
 
@@ -20,7 +20,7 @@ That said, for users who are interested in using the CSV format, we tabulate bel
 | ------------- | :-----: | :--------: |
 | RAIN_RATE | the amount of rain that falls over a specific time period per unit area | m/h |
 | DIRECT_RUNOFF | Water that flows over the ground surface directly into water bodies | m/h |
-| GIUH_RUNOFF | rainfall-runoff from Geomorphological Instantaneous Unit Hydrograph model | m/h |
+| GIUH_RUNOFF | rainfall runoff from Geomorphological Instantaneous Unit Hydrograph model | m/h |
 | NASH_LATERAL_RUNOFF | lateral runoff from Nash-cascade of reservoirs model | m/h |
 | DEEP_GW_TO_CHANNEL_FLUX | flux from the deep reservoir into the channels | m/h |
 | SOIL_TO_GW_FLUX | the movement of water from the soil layer into the groundwater table below | m/h |
@@ -35,7 +35,7 @@ That said, for users who are interested in using the CSV format, we tabulate bel
 | Input Variable Name | Physical Meaning | Units |
 | ------------- | :-----: | :--------: |
 | atmosphere_water__liquid_equivalent_precipitation_rate | rainfall rate | mm/h |
-| water_potential_evaporation_flux | land surface_water potential_evaporation volume flux | m/s |
+| water_potential_evaporation_flux | land surface water potential evaporation volume flux | m/s |
 | ice_fraction_schaake | the amount of water that is ice based on Schaake runoff scheme | m |
 | ice_fraction_xinanjiang | fraction of top soil layer that is frozen based on xinanjiang runoff scheme | none |
 | soil_moisture_profile | entire profile of the soil column (1D array) | none |


### PR DESCRIPTION
On a number of occasions in recent time and past, users of ngen have asked about the units of output variables from running ngen. As ngen becomes more freqiently used in the community, there is a need to address this issue in a centralized document. This PR summarizes the comments made in the past and tabulate the output variables used in the commonly used hydrologic models so that users can easily find them. Input variables for these models are also tabulated for reference.

## Additions

doc/UNITS_IN_NextGen.md

## Removals

-

## Changes

-

## Testing

Visually inspecting the md formatted document.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [x ] Code can be automatically merged (no conflicts)
- [x ] Code follows project standards (link if applicable)
- [x ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
