### PR TITLE
Fix version and update docs for proper version management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 # Define project version and use via generated config header
-project(ngen VERSION 0.1.0)
+project(ngen VERSION 0.2.0)
 
 add_executable(ngen "${NGEN_SRC_DIR}/NGen.cpp")
 

--- a/doc/RELEASE_MANAGEMENT.md
+++ b/doc/RELEASE_MANAGEMENT.md
@@ -23,7 +23,10 @@ The release process can be summarized fairly simply:
     - Version numbering should follow [Semantic Versioning](https://semver.org/) and its typical `MAJOR.MINOR.PATCH` pattern
 2. A release candidate branch, based on `master`, is created in the official OWP repo
     - The name of this branch will be `release-X` for version `X`
-3. All necessary testing and quality pre-release tasks are performed using this release candiate branch
+3. The version is incremented in the main [CMakeLists.txt](../CMakeLists.txt)
+    - Update the line setting the version, which will look something like `project(ngen VERSION x.y.z)`
+    - Then committed and pushed this change to the `release-X` branch
+4. All necessary testing and quality pre-release tasks are performed using this release candidate branch
     - **TODO**: to be documented in more detail
 4. (If necessary) Bug fixes, documentation updates, and other acceptable, non-feature changes are applied to the release branch
     - Such changes should go through some peer review process before inclusion in the official OWP branch (e.g., PRs, out-of-band code reviews, etc.)


### PR DESCRIPTION
Moving ngen CMake project to version number reflected by latest pre-existing tag, and updating documentation on release process to include updating the version number in this location.
