### PR TITLE
Update ngen-build Github Action to make sure 1.x numpy is used

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -144,7 +144,7 @@ runs:
             python3 -m venv .venv
             . .venv/bin/activate
             pip install pip
-            pip install numpy<=2.0.0
+            pip install numpy<2.0.0
             deactivate
           shell: bash
 

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -144,7 +144,7 @@ runs:
             python3 -m venv .venv
             . .venv/bin/activate
             pip install pip
-            pip install numpy
+            pip install numpy<=2.0.0
             deactivate
           shell: bash
 

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -120,6 +120,13 @@ runs:
             tar xjf boost_1_79_0.tar.bz2
           shell: bash
 
+        - name: Set Pip Constraints
+          run: |
+            echo "numpy<2.0" > constraints.txt
+            sudo mv constraints.txt /constraints.txt
+            echo "PIP_CONSTRAINT=/constraints.txt" >> $GITHUB_ENV
+          shell: bash
+
         - name: Cache Python Dependencies
           id: cache-py3-dependencies
           uses: actions/cache@v3
@@ -144,7 +151,7 @@ runs:
             python3 -m venv .venv
             . .venv/bin/activate
             pip install pip
-            pip install numpy<2.0.0
+            pip install numpy
             deactivate
           shell: bash
 


### PR DESCRIPTION
Updating Actions depending on numpy install to use pre-2.0 numpy version.  Currently, CMake will raise an error if the found numpy version is >= 2.0.0.

## Changes

- Update "Get Numpy Python Dependency" of internal _ngen-build_ action to make _pip_ installed `numpy<2.0.0`

## Notes

This is going into the pending `release-0.3.0` branch.  The included changes will eventually make their way into `production` and `master` as part of other steps in the release process.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux (Ubuntu 22.04 Action runner)
- [x] MacOS (MacOS 12 Action runner)
