### PR TITLE
Fix placement of constraints.txt in Action

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -122,9 +122,8 @@ runs:
 
         - name: Set Pip Constraints
           run: |
-            echo "numpy<2.0" > constraints.txt
-            sudo mv constraints.txt /constraints.txt
-            echo "PIP_CONSTRAINT=/constraints.txt" >> $GITHUB_ENV
+            echo "numpy<2.0" > $GITHUB_WORKSPACE/constraints.txt
+            echo "PIP_CONSTRAINT=$GITHUB_WORKSPACE/constraints.txt" >> $GITHUB_ENV
           shell: bash
 
         - name: Cache Python Dependencies


### PR DESCRIPTION
Cannot move `constraints.txt`  to `/` due to read-only file system; instead, use `$GITHUB_WORKSPACE` in order to be able to specify absolute path to file in `PIP_CONSTRAINT`.

Relates to #891.
