### PR TITLE
Stop ignoring include/NGenConfig.h, since it should no longer exist in source trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,6 @@ data/hydrofabric/huc01_demo/
 # NGen build-related items
 .venv
 boost_*
-include/NGenConfig.h
 
 # Large Example Datasets for certain tests #
 ############################################


### PR DESCRIPTION
Up until 71892b8314b88de625cabf23ca84cfa29efccffd from #682, CMake would stick the generated `NGenConfig.h` in `include/` in the source tree. This would contaminate later builds that generated the config file in the build tree if it were left around. Unfortunately, it had previously been ignored as a built output, and so it was not apparent when this was happening.

This is one of those issues that leads people to think they need to do a fresh clone when their build fails or they see some error they don't understand.

## Changes

- Remove `include/NGenConfig.h` from `.gitignore`, since it's no longer a file that should ever appear in the source tree

## Screenshots

An old copy with `#define NGEN_WITH_NETCDF 0` was present in someone's working directory, and they had configured a build with `-DNGEN_WITH_NETCDF=1`. There was maybe a disparity in `NGEN_WITH_BMI_FORTRAN` as well. The resulting link-time failures were incredibly obscure:

```
[ 51%] Linking CXX executable ngen
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Bmi_Fortran_Formulation.cpp.o): warning: relocation against `_ZTIN6models3bmi19Bmi_Fortran_AdapterE' in read-only section `.text._ZSt20dynamic_pointer_castIN6models3bmi19Bmi_Fortran_AdapterENS1_11Bmi_AdapterEESt10shared_ptrIT_ERKS4_IT0_E[_ZSt20dynamic_pointer_castIN6models3bmi19Bmi_Fortran_AdapterENS1_11Bmi_AdapterEESt10shared_ptrIT_ERKS4_IT0_E]'
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Formulation_Constructors.cpp.o): in function `realization::construct_formulation(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, forcing_params&, utils::StreamHandler)':
Formulation_Constructors.cpp:(.text+0x4d4): undefined reference to `data_access::NetCDFPerFeatureDataProvider::get_shared_provider(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long, long, utils::StreamHandler)'
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Bmi_Fortran_Formulation.cpp.o): in function `realization::Bmi_Fortran_Formulation::get_var_value_as_double(int const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
Bmi_Fortran_Formulation.cpp:(.text+0x857): undefined reference to `models::bmi::Bmi_Fortran_Adapter::GetVarType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Bmi_Fortran_Formulation.cpp.o): in function `models::bmi::Bmi_Fortran_Adapter::Bmi_Fortran_Adapter(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)':
Bmi_Fortran_Formulation.cpp:(.text._ZN6models3bmi19Bmi_Fortran_AdapterC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_S7_bS7_[_ZN6models3bmi19Bmi_Fortran_AdapterC5ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_S7_bS7_]+0xe9): undefined reference to `vtable for models::bmi::Bmi_Fortran_Adapter'
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Bmi_Fortran_Formulation.cpp.o): in function `std::shared_ptr<models::bmi::Bmi_Fortran_Adapter> std::dynamic_pointer_cast<models::bmi::Bmi_Fortran_Adapter, models::bmi::Bmi_Adapter>(std::shared_ptr<models::bmi::Bmi_Adapter> const&)':
Bmi_Fortran_Formulation.cpp:(.text._ZSt20dynamic_pointer_castIN6models3bmi19Bmi_Fortran_AdapterENS1_11Bmi_AdapterEESt10shared_ptrIT_ERKS4_IT0_E[_ZSt20dynamic_pointer_castIN6models3bmi19Bmi_Fortran_AdapterENS1_11Bmi_AdapterEESt10shared_ptrIT_ERKS4_IT0_E]+0x2d): undefined reference to `typeinfo for models::bmi::Bmi_Fortran_Adapter'
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Bmi_Fortran_Formulation.cpp.o): in function `models::bmi::Bmi_Fortran_Adapter::~Bmi_Fortran_Adapter()':
Bmi_Fortran_Formulation.cpp:(.text._ZN6models3bmi19Bmi_Fortran_AdapterD2Ev[_ZN6models3bmi19Bmi_Fortran_AdapterD5Ev]+0x13): undefined reference to `vtable for models::bmi::Bmi_Fortran_Adapter'
/usr/bin/ld: src/realizations/catchment/librealizations_catchment.a(Bmi_Multi_Formulation.cpp.o): in function `realization::construct_formulation(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, forcing_params&, utils::StreamHandler)':
Bmi_Multi_Formulation.cpp:(.text+0x4d4): undefined reference to `data_access::NetCDFPerFeatureDataProvider::get_shared_provider(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long, long, utils::StreamHandler)'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/ngen.dir/build.make:119: ngen] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:693: CMakeFiles/ngen.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```


## Testing

Upon removing the offending `include/NGenConfig.h` in the working directory, the build succeeded without any further remarkable behavior. Thus, Git should have told them the file didn't belong there.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
