### PR TITLE
Fix bad uses of `sizeof(char[])/sizeof(char*)`

### DIFF
--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -53,7 +53,7 @@ namespace realization {
 
             if (id_index != std::string::npos) {
                 do {
-                    value = value.replace(id_index, sizeof(pattern.c_str()) - 2, replacement);
+                    value = value.replace(id_index, pattern.size(), replacement);
                     id_index = value.find(pattern);
                 } while (id_index != std::string::npos);
 

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -53,7 +53,7 @@ namespace realization {
 
             if (id_index != std::string::npos) {
                 do {
-                    value = value.replace(id_index, pattern.size(), replacement);
+                    value.replace(id_index, pattern.size(), replacement);
                     id_index = value.find(pattern);
                 } while (id_index != std::string::npos);
 

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -49,7 +49,7 @@ namespace realization {
             }
 
             std::string value = it->second.as_string();
-            size_t id_index = value.find(pattern);
+            auto id_index = value.find(pattern);
 
             if (id_index != std::string::npos) {
                 do {

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -472,7 +472,7 @@ namespace realization {
 
                 std::string filepattern = forcing_prop_map.at("file_pattern").as_string();
                 std::string id_pattern = "{{id}}";
-                int id_index = filepattern.find(id_pattern);
+                auto id_index = filepattern.find(id_pattern);
 
                 // If an index for '{{id}}' was found, we can count on that being where the id for this realization can be found.
                 //     For instance, if we have a pattern of '.*{{id}}_14_15.csv' and this is named 'cat-87',

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -478,7 +478,7 @@ namespace realization {
                 //     For instance, if we have a pattern of '.*{{id}}_14_15.csv' and this is named 'cat-87',
                 //     this will match on 'stuff_example_cat-87_14_15.csv'
                 if (id_index != std::string::npos) {
-                    filepattern = filepattern.replace(id_index, id_pattern.size(), identifier);
+                    filepattern.replace(id_index, id_pattern.size(), identifier);
                 }
 
                 // Create a regular expression used to identify proper file names

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -471,14 +471,14 @@ namespace realization {
                 }
 
                 std::string filepattern = forcing_prop_map.at("file_pattern").as_string();
-
-                int id_index = filepattern.find("{{id}}");
+                std::string id_pattern = "{{id}}";
+                int id_index = filepattern.find(id_pattern);
 
                 // If an index for '{{id}}' was found, we can count on that being where the id for this realization can be found.
                 //     For instance, if we have a pattern of '.*{{id}}_14_15.csv' and this is named 'cat-87',
                 //     this will match on 'stuff_example_cat-87_14_15.csv'
                 if (id_index != std::string::npos) {
-                    filepattern = filepattern.replace(id_index, sizeof("{{id}}") - 1, identifier);
+                    filepattern = filepattern.replace(id_index, id_pattern.size(), identifier);
                 }
 
                 // Create a regular expression used to identify proper file names

--- a/test/data/bmi/test_bmi_c/test_bmi_c_config_cat-67.txt
+++ b/test/data/bmi/test_bmi_c/test_bmi_c_config_cat-67.txt
@@ -1,0 +1,2 @@
+epoch_start_time=1448949600
+num_time_steps=720

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -785,6 +785,42 @@ const std::string EXAMPLE_6 = "{ "
     "} "
 "}";
 
+
+const std::string EXAMPLE_7 = "{ "
+    "\"global\": { "
+      "\"formulations\": [ "
+        "{"
+          "\"name\":\"bmi_c++\","
+          "\"params\": {"
+            "\"model_type_name\": \"test_bmi_cpp\","
+            "\"library_file\": \"{{EXTERN_LIB_DIR_PATH}}" BMI_TEST_CPP_LIB_NAME "\","
+            "\"init_config\": \"{{BMI_C_INIT_DIR_PATH}}/test_bmi_c_config_{{id}}.txt\","
+            "\"main_output_variable\": \"OUTPUT_VAR_2\","
+            "\"" BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "\": { "
+              "\"INPUT_VAR_2\": \"" AORC_FIELD_NAME_TEMP_2M_AG  "\","
+              "\"INPUT_VAR_1\": \"" AORC_FIELD_NAME_PRECIP_RATE "\""
+            "},"
+            "\"create_function\": \"bmi_model_create\","
+            "\"destroy_function\": \"bmi_model_destroy\","
+            "\"uses_forcing_file\": false"
+          "} "
+        "} "
+      "], "
+      "\"forcing\": { "
+          "\"file_pattern\": \".*{{id}}.*.csv\", "
+          "\"path\": \"./data/forcing/\", "
+          "\"provider\": \"CsvPerFeature\" "
+      "} "
+    "}, "
+    "\"time\": { "
+        "\"start_time\": \"2015-12-01 00:00:00\", "
+        "\"end_time\": \"2015-12-30 23:00:00\", "
+        "\"output_interval\": 3600 "
+    "}, "
+    "\"disable_catchment_output\": true"
+"}";
+
+
 TEST_F(Formulation_Manager_Test, basic_reading_1) {
     std::stringstream stream;
 
@@ -914,6 +950,25 @@ TEST_F(Formulation_Manager_Test, read_extra) {
 
     ASSERT_TRUE(manager.is_empty());
     
+    this->add_feature("cat-67");
+    manager.read(this->fabric, catchment_output);
+
+    ASSERT_EQ(manager.get_size(), 1);
+    ASSERT_TRUE(manager.contains("cat-67"));
+}
+
+TEST_F(Formulation_Manager_Test, init_config_pattern_match) {
+    std::stringstream stream;
+    stream << fix_paths(EXAMPLE_7);
+
+    std::ostream* raw_pointer = &std::cout;
+    std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
+    utils::StreamHandler catchment_output(s_ptr);
+
+    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+
+    ASSERT_TRUE(manager.is_empty());
+
     this->add_feature("cat-67");
     manager.read(this->fabric, catchment_output);
 


### PR DESCRIPTION
In both cases, we're ultimately getting the length `6` of the literal string `"{{id}}"`, without `'\0'` terminator

In the case where the literal string is passed to `sizeof`, it's obtusely correct, because that evaluates the literal `char[]`, which takes serious language-lawyering to recognize. It's also very fragile to array-to-pointer-decay if someone attempts to refactor the code in some way, which would leave it over by one.

In the case where `std::string pattern` is a function parameter and the code says `sizeof(pattern.c_string()) - 2`, it's only managed to operate correctly because all of the current call sites pass an argument of `"{{id}}"`, and it's only tested on 64-bit systems.

## Changes

- Replace two instances of `sizeof(<string literal>)` with `std::string::size()` to be more durably correct

## Todos

- @robertbartel offered to add tests for this as appropriate

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
