### PR TITLE
Only check if model supports mass balance checks if mass balance feature is enabled

### DIFF
--- a/src/utilities/bmi/mass_balance.cpp
+++ b/src/utilities/bmi/mass_balance.cpp
@@ -137,12 +137,9 @@ auto NgenMassBalance::check_support(const ModelPtr& model) -> expected<void, Pro
 
 auto NgenMassBalance::initialize(const ModelPtr& model, const Properties& properties) -> expected<void, ProtocolError>
 {
-    //Ensure the model is capable of mass balance using the protocol
-    check_support(model).or_else( error_or_warning );
-
     //now check if the user has requested to use mass balance
     auto protocol_it = properties.find(CONFIGURATION_KEY);
-    if ( supported && protocol_it != properties.end() ) {
+    if ( protocol_it != properties.end() ) {
         geojson::PropertyMap mass_bal = protocol_it->second.get_values();
 
         auto _it = mass_bal.find(TOLERANCE_KEY);
@@ -183,6 +180,10 @@ auto NgenMassBalance::initialize(const ModelPtr& model, const Properties& proper
     } else{
         //no mass balance requested, or not supported, so don't check it
         check = false;
+    }
+    if ( check ) {
+        //Ensure the model is capable of mass balance using the protocol
+        check_support(model).or_else( error_or_warning );
     }
     return {}; // important to return for the expected to be properly created!
 }


### PR DESCRIPTION
~Currently, `ngen` will throw an exception if any model in the model stack does not support mass balance checks regardless of if mass balance checking is configured. The fixed~ The new behavior checks if a bmi model supports mass balance checks only if the mass balance checking feature is enabled.

Revisiting this. The exception I was getting from `ngen` was not related to the mass balance checker.

I do think we should still change the behavior to only check if a model is capable of mass balance checks if configured. Otherwise, `stderr` is spammed with messages like the following for each divide w/ a model that does not support mass balance checks:

```shell
Error(Integration)::mass_balance: Error getting mass balance values for module 'Simple Logical Tautology Handler (SLoTH) Model': GetValuePtr called for unknown variable: ngen::mass_in (/home/user/ngen/extern/sloth/src/sloth.cpp:114)
```