### PR TITLE
Handle hydrofabric case when nexus has no contributing catchments

### DIFF
--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -15,10 +15,11 @@ void ngen::SurfaceLayer::update_models()
         for(const auto& id : features.nexuses()) {
             #if NGEN_WITH_MPI
             // When running with MPI, only be concerned with the local nexuses
-            if (!features.is_remote_sender_nexus(id) && features.nexus_at(id)->get_contributing_catchments().size() == 0) {
+            if (!features.is_remote_sender_nexus(id) && features.nexus_at(id)->get_contributing_catchments().size() == 0)
             #else
-            if (features.nexus_at(id)->get_contributing_catchments().size() == 0) {
+            if (features.nexus_at(id)->get_contributing_catchments().size() == 0)
             #endif
+            {
                 // Likely this means a flow value of 0.0, but that's dependent on the nexus class implementation
                 std::cout << "WARNING: Nexus "<< id << " has no contributing catchments for flow values!" << std::endl;
             }

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -10,6 +10,21 @@ void ngen::SurfaceLayer::update_models()
     
     Layer::update_models();
 
+    // One the first time step, check all the nexuses and warn user about ones have no contributing catchments
+    if (current_time_index == 0) {
+        for(const auto& id : features.nexuses()) {
+            #if NGEN_WITH_MPI
+            // When running with MPI, only be concerned with the local nexuses
+            if (!features.is_remote_sender_nexus(id) && features.nexus_at(id)->get_contributing_catchments().size() == 0) {
+            #else
+            if (features.nexus_at(id)->get_contributing_catchments().size() == 0) {
+            #endif
+                // Likely this means a flow value of 0.0, but that's dependent on the nexus class implementation
+                std::cout << "WARNING: Nexus "<< id << " has no contributing catchments for flow values!" << std::endl;
+            }
+        }
+    }
+
     //At this point, could make an internal routing pass, extracting flows from nexuses and routing
     //across the flowpath to the next nexus.
     //Once everything is updated for this timestep, dump the nexus output

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -10,7 +10,7 @@ void ngen::SurfaceLayer::update_models()
     
     Layer::update_models();
 
-    // One the first time step, check all the nexuses and warn user about ones have no contributing catchments
+    // On the first time step, check all the nexuses and warn user about ones have no contributing catchments
     if (current_time_index == 0) {
         for(const auto& id : features.nexuses()) {
             #if NGEN_WITH_MPI

--- a/src/core/nexus/HY_PointHydroNexus.cpp
+++ b/src/core/nexus/HY_PointHydroNexus.cpp
@@ -59,7 +59,7 @@ double HY_PointHydroNexus::get_downstream_flow(std::string catchment_id, time_st
         BOOST_THROW_EXCEPTION(invalid_downstream_request());
     }
 
-    if( get_contributing_catchments().size() == 0 ) {
+    if ( get_contributing_catchments().size() == 0 ) {
         // there are no contributing catchments so there is no flow to release
         return 0.0;
     }

--- a/src/core/nexus/HY_PointHydroNexus.cpp
+++ b/src/core/nexus/HY_PointHydroNexus.cpp
@@ -69,9 +69,9 @@ double HY_PointHydroNexus::get_downstream_flow(std::string catchment_id, time_st
         // there are no recorded flows for this time.
         // throw exception
 
-        std::cout << "No recorded flows for time step " << t << std::endl;
-        std::cout << "catchment id requesting flow: " << catchment_id << std::endl;
-        std::cout << "Nex id: " << id << std::endl;
+        std::cerr << "No recorded flows for time step " << t << "\n";
+        std::cerr << "catchment id requesting flow: " << catchment_id << "\n";
+        std::cerr << "Nex id: " << id << std::endl;
 
         BOOST_THROW_EXCEPTION(request_from_empty_nexus() );
     }

--- a/src/core/nexus/HY_PointHydroNexus.cpp
+++ b/src/core/nexus/HY_PointHydroNexus.cpp
@@ -58,10 +58,20 @@ double HY_PointHydroNexus::get_downstream_flow(std::string catchment_id, time_st
 
         BOOST_THROW_EXCEPTION(invalid_downstream_request());
     }
+
+    if( get_contributing_catchments().size() == 0 ) {
+        // there are no contributing catchments so there is no flow to release
+        return 0.0;
+    }
+
     else if ( s1 == upstream_flows.end() )
     {
         // there are no recorded flows for this time.
         // throw exception
+
+        std::cout << "No recorded flows for time step " << t << std::endl;
+        std::cout << "catchment id requesting flow: " << catchment_id << std::endl;
+        std::cout << "Nex id: " << id << std::endl;
 
         BOOST_THROW_EXCEPTION(request_from_empty_nexus() );
     }


### PR DESCRIPTION
While on some level counterintuitive, it is possible (and has been seen in practice somewhat frequently) for a hydrofabric dataset to contain nexuses that have no contributing catchments.  This appears to be a valid state for the nexus and a hydrofabric as a whole.  However, previously ngen did not account for this scenario properly.  There was no recorded upstream flow for such nexuses at any given time step, and a lack of flow data was treated as an error by the nexus class.  

This change updates the nexus class to infer and return a flow data value of `0.0` for the no-contributing-catchments case, reflecting that nothing contributed any flow.

Since the case is a bit counterintuitive though, this change also adds some warning messaging for any nexuses in such a state.  These will only be printed once at the first timestep.