### PR TITLE
feat: reduce netcdf reads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ include(CMakeDependentOption)
 
 option(NGEN_WITH_MPI         "Build with MPI support"             OFF)
 option(NGEN_WITH_NETCDF      "Build with NetCDF support"          OFF)
+option(NGEN_WITH_HDF5        "Build with HDF5 support"            OFF)
 option(NGEN_WITH_SQLITE      "Build with SQLite3 support"         OFF)
 option(NGEN_WITH_UDUNITS     "Build with UDUNITS2 support"        ON)
 option(NGEN_WITH_BMI_FORTRAN "Build with Fortran BMI support"     OFF)
@@ -198,6 +199,12 @@ if(NGEN_WITH_NETCDF)
     endif()
 endif()
 
+# -----------------------------------------------------------------------------
+if(NGEN_WITH_HDF5)
+    find_package(HDF5 REQUIRED COMPONENTS C CXX)
+    add_compile_definitions(NGEN_WITH_HDF5)
+endif()
+
 if(NGEN_WITH_EXTERN_SLOTH)
     # This is set because SLOTH will link to gtest by default,
     # which causes a configure error.
@@ -337,6 +344,11 @@ target_link_libraries(ngen
         NGen::bmi_protocols
 )
 
+if(NGEN_WITH_HDF5)
+    target_link_libraries(ngen PUBLIC ${HDF5_LIBRARIES})
+    target_include_directories(ngen PUBLIC ${HDF5_INCLUDE_DIRS})
+endif()
+
 if(NGEN_WITH_SQLITE)
     add_subdirectory("src/geopackage")
     target_link_libraries(ngen PUBLIC NGen::geopackage)
@@ -417,6 +429,7 @@ ngen_multiline_message(
 "  Flags:"
 "    NGEN_WITH_MPI: ${NGEN_WITH_MPI}"
 "    NGEN_WITH_NETCDF: ${NGEN_WITH_NETCDF}"
+"    NGEN_WITH_HDF5: ${NGEN_WITH_HDF5}"
 "    NGEN_WITH_SQLITE: ${NGEN_WITH_SQLITE}"
 "    NGEN_WITH_UDUNITS: ${NGEN_WITH_UDUNITS}"
 "    NGEN_WITH_BMI_FORTRAN: ${NGEN_WITH_BMI_FORTRAN}"
@@ -460,6 +473,12 @@ ngen_dependent_multiline_message(NGEN_WITH_NETCDF
 "    Include: ${NetCDF_INCLUDE_DIR}"
 "    Include (CXX): ${NetCDF_CXX_INCLUDE_DIR}"
 "    Parallel: ${NetCDF_HAS_PARALLEL}")
+ngen_dependent_multiline_message(NGEN_WITH_HDF5
+"  HDF5:"
+"    Version: ${HDF5_VERSION}"
+"    Libraries: ${HDF5_LIBRARIES}"
+"    Include: ${HDF5_INCLUDE_DIRS}"
+"    Is Parallel: ${HDF5_IS_PARALLEL}")
 ngen_dependent_multiline_message(NGEN_WITH_SQLITE
 "  SQLite:"
 "    Version: ${SQLite3_VERSION}"

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <set>
 #include <sstream>
 #include <exception>
 #include <mutex>
@@ -54,6 +55,9 @@ namespace data_access
          * the given path already exists, this argument will be ignored.
          */
         static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s);
+
+        // aaraney: improve naming and what does const mean?
+        void hint_shared_provider_id(const std::string& id);
 
         /**
          * @brief Cleanup the shared providers cache, ensuring that the files get closed.
@@ -122,7 +126,9 @@ namespace data_access
         std::vector<std::string> variable_names;
         std::vector<std::string> loc_ids;
         std::vector<double> time_vals;
-        std::map<std::string, std::size_t> id_pos;
+        std::set<std::string> hinted_ids;
+        std::map<std::string, std::size_t> id_pos;      // map from cat-id to position in vec of nc var values; accounts for chunking
+        std::vector<std::pair<size_t, size_t>> chunks;  // a chunk is the start and length of a span in the "catchment-id" dim of a nc variable
         double start_time;                              // the begining of the first time for which data is stored
         double stop_time;                               // the end of the last time for which data is stored
         TimeUnit time_unit;                             // the unit that time was stored as in the file
@@ -142,6 +148,7 @@ namespace data_access
 
         const std::string& get_ncvar_units(const std::string& name);
 
+        void maybe_update_chunks_with_hints();
     };
 }
 

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -141,7 +141,10 @@ namespace data_access
         std::map<std::string,netCDF::NcVar> ncvar_cache;
         std::map<std::string,std::string> units_cache;
         boost::compute::detail::lru_cache<std::string, std::shared_ptr<std::vector<double>>> value_cache;
-        size_t cache_slice_t_size = 1;
+        // number of time slices per cache entry
+        // this is a tunable parameter; your mileage may vary
+        // NOTE: it would be nice if this were divisible by 2 and 4
+        const size_t cache_slice_t_size = 18;
         size_t cache_slice_c_size = 1;
 
         const netCDF::NcVar& get_ncvar(const std::string& name);
@@ -150,6 +153,20 @@ namespace data_access
 
         void maybe_update_chunks_with_hints();
     };
+
+    /* TODO: aaraney
+    class ValueCache{
+        public:
+
+        void   guard();
+        void   set(const std::vector<double>& values);
+        double get(std::size_t cat_idx, std::size_t time_idx);
+
+        private:
+        std::vector<float> m_values;
+        std::vector<float> prev_cache_last_ts;
+    };
+    */
 }
 
 

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -151,6 +151,16 @@ namespace data_access
 
         const std::string& get_ncvar_units(const std::string& name);
 
+        /**
+         * @brief Check all variables can be read from the source file
+         * 
+         * This is also useful for warming up the netcdf/hdf5 caches.
+         * 
+         * @throws std::runtime_error if any variable cannot be read
+         * 
+         */
+        void test_readable_data();
+
         void maybe_update_chunks_with_hints();
     };
 

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -161,6 +161,19 @@ namespace data_access
          */
         void test_readable_data();
 
+        /**
+         * @brief Attempts to align the internal cache size with the chunking parameters of
+         * the underlying netCDF variables.
+         * If no chunking is present, the default cache size is used.
+         * 
+         * This can have some significant performance implications.
+         * both in terms of memory use and speed of access.
+         * If the variables are chunked too large, then the cache will hold
+         * a lot of data in memory.  If they are too small, then we end up
+         * doing a lot of small reads from the netCDF file.
+         */
+        void align_cache_with_chunks();
+
         void maybe_update_chunks_with_hints();
     };
 

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -161,7 +161,7 @@ namespace data_access
          * @throws std::runtime_error if any variable cannot be read
          * 
          */
-        void test_readable_data();
+        void test_data_is_readable();
 
         /**
          * @brief Attempts to align the internal cache size with the chunking parameters of

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -65,7 +65,7 @@ namespace data_access
         static void cleanup_shared_providers();
 
         NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s);
-
+        NetCDFPerFeatureDataProvider() = delete;
         // Default implementation defined in the .cpp file so that
         // client code doesn't need to have the full definition of
         // NcFile visible for the compiler to implicitly generate

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -56,7 +56,9 @@ namespace data_access
          */
         static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s);
 
-        // aaraney: improve naming and what does const mean?
+        /**
+         * @brief Tell provider an id it is expected to provide.
+         */
         void hint_shared_provider_id(const std::string& id);
 
         /**
@@ -176,20 +178,6 @@ namespace data_access
 
         void maybe_update_chunks_with_hints();
     };
-
-    /* TODO: aaraney
-    class ValueCache{
-        public:
-
-        void   guard();
-        void   set(const std::vector<double>& values);
-        double get(std::size_t cat_idx, std::size_t time_idx);
-
-        private:
-        std::vector<float> m_values;
-        std::vector<float> prev_cache_last_ts;
-    };
-    */
 }
 
 

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -144,7 +144,7 @@ namespace data_access
         // number of time slices per cache entry
         // this is a tunable parameter; your mileage may vary
         // NOTE: it would be nice if this were divisible by 2 and 4
-        const size_t cache_slice_t_size = 18;
+        size_t cache_slice_t_size = 18;
         size_t cache_slice_c_size = 1;
 
         const netCDF::NcVar& get_ncvar(const std::string& name);

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -176,6 +176,11 @@ namespace data_access
          */
         void align_cache_with_chunks();
 
+        /**
+         * @brief If applicable, update chunk spans.
+         * Note, no hint_shared_provider_id() calls should be made afterwards.
+         * Note, additional calls have no effect.
+         */
         void maybe_update_chunks_with_hints();
     };
 }

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -57,10 +57,9 @@ namespace realization {
             // TODO: this likely needs to be rethought and refactored, but for now, 
             // this allows the NetCDF provider to log to standard output while still allowing
             // formulations to log to their own output streams as needed.
-            // aaraney: where forcing provider is actually setup
             std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> f;
             f = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
-            // aaraney: this is not _ideal_ but implements the idea.
+            // TODO: this is not _ideal_ but implements the idea.
             // refactor in the future.
             f->hint_shared_provider_id(identifier);
             fp = f;

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -57,7 +57,13 @@ namespace realization {
             // TODO: this likely needs to be rethought and refactored, but for now, 
             // this allows the NetCDF provider to log to standard output while still allowing
             // formulations to log to their own output streams as needed.
-            fp = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
+            // aaraney: where forcing provider is actually setup
+            std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> f;
+            f = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
+            // aaraney: this is not _ideal_ but implements the idea.
+            // refactor in the future.
+            f->hint_shared_provider_id(identifier);
+            fp = f;
         }
 #endif
         else if (forcing_config.provider == "NullForcingProvider"){

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -435,6 +435,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     // update chunks during the first timestep
     if (hinted_ids.size() > 0){
         // 'maybe_update_chunks_with_hints' clears 'hinted_ids'
+        // assumes all id's will have been hinted before 'get_value' is called.
         maybe_update_chunks_with_hints();
     }
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -48,6 +48,10 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         std::cerr<<e.what()<<std::endl;
         throw;
     }
+    // do a quick test of the netcdf variables to ensure
+    // they are readable, especially if compressed with HDF5 filters
+    // This also has the added benefit of warming up the chunk cache
+    test_readable_data();
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
 
@@ -629,6 +633,57 @@ const std::string& NetCDFPerFeatureDataProvider::get_ncvar_units(const std::stri
     }
 
     throw std::runtime_error("Got units request for variable " + name + " but it was not found in the cache. This should not happen." + SOURCE_LOC);
+}
+
+void NetCDFPerFeatureDataProvider::test_readable_data() {
+    // Try to read one element from each variable to test if NetCDF/HDF5 linking works for compressed data
+    auto var_set = nc_file->getVars();
+    for (const auto& var_pair : var_set) {
+        const std::string& var_name = var_pair.first;
+        auto var = var_pair.second;
+        // Skip scalar variables
+        if (var.getDimCount() == 0) continue;
+        std::vector<size_t> start(var.getDimCount(), 0);
+        std::vector<size_t> count(var.getDimCount(), 1);
+        try {
+            if (var.getType().getTypeClass() == NC_STRING) {
+                // Handle string variable
+                std::vector<char*> buffer(1);
+                var.getVar(start, count, buffer.data());
+                nc_free_string(1, buffer.data());
+            } else if (var.getType().getTypeClass() == NC_INT) {
+                // Handle int variable
+                int val;
+                var.getVar(start, count, &val);
+            } else if (var.getType().getTypeClass() == NC_DOUBLE) {
+                // Handle double variable
+                double val;
+                var.getVar(start, count, &val);
+            } else {
+                // Skip other types
+                continue;
+            }
+        } catch (const netCDF::exceptions::NcException& e) {
+            std::string err_str = e.what();
+            // libnetcxx puts a lot of noice in the error message
+            // so filter it out for clarity...
+            size_t file_pos = err_str.find("file:");
+            if (file_pos != std::string::npos) {
+                err_str = err_str.substr(0, file_pos);
+            }
+            std::string msg = "Error reading " + var_name + " variable: " + err_str;
+            // If ngen isn't directly linked against HDF5, then loading hdf5 plugin filters
+            // fails, and compressed data cannot be read.  So check for filter issues
+            // and provide a more helpful error message.
+            if (err_str.find("NetCDF") != std::string::npos && (err_str.find("filter") != std::string::npos || err_str.find("Filter") != std::string::npos)) {
+                msg +=  "This may happen if HDF5 isn't properly linked with ngen. "
+                        "Ensure the build uses NGEN_WITH_HDF5. "
+                        "Also check the $HDF5_PLUGIN_PATH environment variable and/or "
+                        "nc-config --plugindir to ensure filter plugins are available.";
+            }
+            throw std::runtime_error(msg);
+        }
+    }
 }
 
 }

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -8,6 +8,11 @@
 std::mutex data_access::NetCDFPerFeatureDataProvider::shared_providers_mutex;
 std::map<std::string, std::shared_ptr<data_access::NetCDFPerFeatureDataProvider>> data_access::NetCDFPerFeatureDataProvider::shared_providers;
 
+// limit access outside of complication unit.
+namespace {
+    const size_t N_EXPECTED_FORCING_VARS = 8;
+}
+
 namespace data_access {
 
 std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s)
@@ -31,7 +36,7 @@ void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
     shared_providers.clear();
 }
 
-NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(8),
+NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(N_EXPECTED_FORCING_VARS),
     sim_start_date_time_epoch(sim_start),
     sim_end_date_time_epoch(sim_end)
 {

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -122,8 +122,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     std::vector< char* > string_buffers(num_ids);
 
     // read the id strings
-    ids.getVar(&string_buffers[0]);
-
+    ids.getVar(string_buffers.data());
     // initalize the map of catchment-name to offset location and free the strings allocated by the C library
     size_t loc = 0;
     for_each( string_buffers.begin(), string_buffers.end(), [&](char* str)

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -54,7 +54,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     test_readable_data();
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
-
+    align_cache_with_chunks();
     //get the listing of all variables
     auto var_set = nc_file->getVars();
 
@@ -684,6 +684,34 @@ void NetCDFPerFeatureDataProvider::test_readable_data() {
             throw std::runtime_error(msg);
         }
     }
+}
+
+void NetCDFPerFeatureDataProvider::align_cache_with_chunks()
+{
+    auto num_times = nc_file->getDim("time").getSize();
+
+    auto var_set = nc_file->getVars();
+    for (const auto& var_pair : var_set) {
+        const std::string& var_name = var_pair.first;
+        auto var = var_pair.second;
+        // Skip the Time variable itself and ids, look for data variables with at least 2 dimensions
+        if (var_name == "Time" || var_name == "ids" || var_name == "catchment-id" || var.getDimCount() < 2) continue;
+        netCDF::NcVar::ChunkMode mode;
+        std::vector<size_t> chunk_sizes;
+        var.getChunkingParameters(mode, chunk_sizes);
+        if (mode == netCDF::NcVar::ChunkMode::nc_CHUNKED && chunk_sizes.size() >= 2) {
+            cache_slice_t_size = chunk_sizes[1];  // Assume second dimension is time
+            break;  // Use the first suitable chunk size found
+        }
+    }
+    if(cache_slice_t_size > num_times){
+        cache_slice_t_size = num_times;
+    }else if(cache_slice_t_size <= 0){
+        cache_slice_t_size = 24; // default to 24 if no chunking info found
+    }
+    //At this point the time slice cache is either aligned with the chunking of the data variables
+    //or set to a default value of 24 (e.g. one day of hourly data)
+    return;
 }
 
 }

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -156,6 +156,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     // if absent, assume seconds
     double time_scale_factor = 1;
     time_unit = TIME_SECONDS;
+    std::string unit_epoch_str = "";
     try {
         auto time_unit_att = time_var.getAtt("units");
 
@@ -163,15 +164,18 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         // TODO determine how this should be handled
         std::string time_unit_str;
 
-        if ( time_unit_att.isNull() )
+        if ( !time_unit_att.isNull() )
         {
-            log_stream << "Warning using defualt time units\n";
-        }
-        else
-        {  
             time_unit_att.getValues(time_unit_str);
         }
 
+        // CF conventions may have units of the form "<unit> since <date>"
+        size_t pos = time_unit_str.find(" since ");
+        if(pos != std::string::npos)
+        {
+            unit_epoch_str = time_unit_str.substr(pos + 7); // 7 is length of " since "
+            time_unit_str.erase(pos);
+        }
         // set time unit and scale factor
         if ( time_unit_str == "h" || time_unit_str == "hours")
         {
@@ -209,32 +213,46 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     }
     catch(const netCDF::exceptions::NcException& e){
         std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning using defualt time units\n";
+        log_stream << "Warning: Couldn't read time unit attribute, using defualt time unit of Seconds\n";
     }
     assert(time_scale_factor != 0); // This should not happen.
 
     std::string epoch_start_str = "01/01/1970 00:00:00";
-    try {
-        // read the meta data to get the epoc start
-        auto epoch_att = time_var.getAtt("epoch_start");
+    std::string epoch_format = "%D %T";
+    if(!unit_epoch_str.empty())
+    {
+        epoch_start_str = unit_epoch_str;
+        //CF convention in time units formats as "YYYY-MM-DD HH:MM:SS"
+        epoch_format = "%Y-%m-%d %H:%M:%S";
+    }
+    else{
+        try {
+            // read the meta data to get the epoc start
+            auto epoch_att = time_var.getAtt("epoch_start");
 
-        if ( epoch_att.isNull() )
-        {
+            if ( epoch_att.isNull() )
+            {
+                log_stream << "Warning using defualt epoc string\n";
+            }
+            else
+            {  
+                epoch_att.getValues(epoch_start_str);
+            }
+        }
+        catch(const netCDF::exceptions::NcException& e) {
+            std::cerr<<e.what()<<std::endl;
             log_stream << "Warning using defualt epoc string\n";
         }
-        else
-        {  
-            epoch_att.getValues(epoch_start_str);
-        }
     }
-    catch(const netCDF::exceptions::NcException& e) {
-        std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning using defualt epoc string\n";
-    }
-    
     std::tm tm{};
     std::stringstream s(epoch_start_str);
-    s >> std::get_time(&tm, "%D %T");
+    s >> std::get_time(&tm, epoch_format.c_str());
+    if(s.fail()){
+        std::stringstream ss;
+        ss << "std::get_time failed to parse epoch string with: " << epoch_start_str << " with format string " << epoch_format << "\n";
+        log_stream << ss.str();
+        throw std::runtime_error(ss.str());
+    }
     //std::time_t epoch_start_time = mktime(&tm);
     // See also comments in Simulation_Time.h .. timegm is not available on Windows at least (elsewhere?)
     //TODO: Probably make the default string above explicit to UTC and interpret TZ from the string in all cases?

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -31,7 +31,7 @@ void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
     shared_providers.clear();
 }
 
-NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
+NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(8),
     sim_start_date_time_epoch(sim_start),
     sim_end_date_time_epoch(sim_end)
 {

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -328,7 +328,9 @@ void NetCDFPerFeatureDataProvider::maybe_update_chunks_with_hints()
             }
         }
     }
-
+    if(idx_map.empty()){
+        throw std::runtime_error("NetCDF source has no ids matching the domain hinted ids.");
+    }
     // Build chunks where a chunk has:
     // a starting nc index
     // the length of the chunk relative to its starting index

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -388,7 +388,8 @@ void NetCDFPerFeatureDataProvider::maybe_update_chunks_with_hints()
 
     cache_slice_c_size = loc_ids.size();
 
-    // aaraney: improve this; we only want this method to "do something" once
+    // TODO: improve this; we only want this method to "do something" once.
+    //       invariant is, weakly, enforced by prelude guard clause.
     hinted_ids.clear();
 }
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -118,7 +118,9 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     }
 
     auto num_ids = id_dim.getSize();
-    assert(num_ids > 0);
+    if (num_ids <= 0){
+        throw std::runtime_error("Provided NetCDF file has no features");
+    }
     // include all catchments in the "default" chunk
     auto pair = std::pair<size_t, size_t>(0, num_ids);
     chunks.push_back(pair);

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -8,7 +8,7 @@
 std::mutex data_access::NetCDFPerFeatureDataProvider::shared_providers_mutex;
 std::map<std::string, std::shared_ptr<data_access::NetCDFPerFeatureDataProvider>> data_access::NetCDFPerFeatureDataProvider::shared_providers;
 
-// limit access outside of complication unit.
+// limit access outside of compilation unit.
 namespace {
     const size_t N_EXPECTED_FORCING_VARS = 8;
 }

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -40,8 +40,14 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     //nc_set_chunk_cache(sizep, nelemsp, preemptionp);
 
     //open the file
-    nc_file = std::make_shared<netCDF::NcFile>(input_path, netCDF::NcFile::read);
-    
+    try{
+        nc_file = std::make_shared<netCDF::NcFile>(input_path, netCDF::NcFile::read);
+    }
+    catch(const netCDF::exceptions::NcException& e){
+        std::cerr<<"Error opening NetCDF file: "<<input_path<<std::endl;
+        std::cerr<<e.what()<<std::endl;
+        throw;
+    }
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -488,6 +488,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     std::size_t time_idx = idx1 % cache_slice_t_size;
 
     std::size_t n_cache_slices = (read_len / cache_slice_t_size) + std::min(read_len % cache_slice_t_size, std::size_t(1));
+    size_t value_idx = idx1;
     // For reference: https://stackoverflow.com/a/72030286
     for( size_t i = 0; i < n_cache_slices; i++ ) {
         // rows: catchments; columns: time;
@@ -538,21 +539,12 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
 
             value_cache.insert(key, cached);
         }
-
-        // NOTE: aaraney: this is pretty gross.
-        // is there a better way to do this?
-        std::size_t s = 0;
-        std::size_t e = cache_slice_t_size;
-        if (i == 0){
-            s = time_idx;
-        }
-        if(i == n_cache_slices-1){
-            e = (idx2 % cache_slice_t_size) + 1;
-        }
-        // read from idx1 to idx2
-        for(; s < e; s++){
-            std::size_t idx = (cat_idx * cache_slice_t_size) + s;
-            raw_values.push_back(cached->at(idx));
+        // Find all values in the current cache slice and push them onto raw_values
+        while(value_idx >= cache_slice_start && 
+              value_idx < cache_slice_start + cache_slice_t_size &&
+              value_idx <= idx2){
+            raw_values.push_back(cached->at((cat_idx * cache_slice_t_size) + (value_idx % cache_slice_t_size)));
+            value_idx++;
         }
     }
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -110,7 +110,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     }
 
     auto num_ids = id_dim.getSize();
-
+    assert(num_ids > 0);
     // include all catchments in the "default" chunk
     auto pair = std::pair<size_t, size_t>(0, num_ids);
     chunks.push_back(pair);
@@ -130,7 +130,9 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         loc_ids.push_back(str);
         id_pos[str] = loc++;
     });
-
+    // Make sure we were able to read an actual string type
+    // each id should start with "cat-"
+    assert(loc_ids[0].size() > 4);;
     // correct string release
     nc_free_string(num_ids,&string_buffers[0]);
 
@@ -548,7 +550,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
         }
     }
 
-    
+    assert(raw_values.size() == read_len);
     rvalue = 0.0;
 
     double a , b = 0.0;

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -495,7 +495,11 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
         std::shared_ptr<std::vector<double>> cached;
 
         std::size_t cache_slice_start = idx1_cache_slice_start + (i * cache_slice_t_size);
-
+        std::size_t adjusted_size = cache_slice_t_size;
+        // Read up to the end of the data, but not beyond
+        if(cache_slice_start + cache_slice_t_size > time_vals.size() ){
+            adjusted_size = time_vals.size() - cache_slice_start;
+        }
         std::string key = ncvar.getName() + "|" + std::to_string(cache_slice_start);
         if(value_cache.contains(key)){
             cached = value_cache.get(key).get();
@@ -527,9 +531,9 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
                 count.clear();
                 count.push_back(chunk.second);
 
-                count.push_back(cache_slice_t_size);
+                count.push_back(adjusted_size);
                 ncvar.getVar(start,count,&(*cached)[next_cache_idx]);
-                next_cache_idx += chunk.second * cache_slice_t_size;
+                next_cache_idx += chunk.second * adjusted_size;
             }
 
             value_cache.insert(key, cached);

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -56,7 +56,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     // do a quick test of the netcdf variables to ensure
     // they are readable, especially if compressed with HDF5 filters
     // This also has the added benefit of warming up the chunk cache
-    test_readable_data();
+    test_data_is_readable();
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
     align_cache_with_chunks();
@@ -641,7 +641,7 @@ const std::string& NetCDFPerFeatureDataProvider::get_ncvar_units(const std::stri
     throw std::runtime_error("Got units request for variable " + name + " but it was not found in the cache. This should not happen." + SOURCE_LOC);
 }
 
-void NetCDFPerFeatureDataProvider::test_readable_data() {
+void NetCDFPerFeatureDataProvider::test_data_is_readable() {
     // Try to read one element from each variable to test if NetCDF/HDF5 linking works for compressed data
     auto var_set = nc_file->getVars();
     for (const auto& var_pair : var_set) {

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -28,7 +28,6 @@ std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_
     return p;
 }
 
-
 void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
 {
     const std::lock_guard<std::mutex> lock(shared_providers_mutex);

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -28,19 +28,11 @@ class NetCDFPerFeatureDataProviderTest : public ::testing::Test {
 
     void setupForcing();
 
-    std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> nc_provider;
-
-    typedef struct tm time_type;
-
-    std::shared_ptr<time_type> start_date_time;
-
-    std::shared_ptr<time_type> end_date_time;
-
+    std::string forcing_file_name;
+    std::unique_ptr<forcing_params> forcing_p;
 };
 
 void NetCDFPerFeatureDataProviderTest::SetUp() {
-    //setupForcing();
-
     setupForcing();
 }
 
@@ -58,21 +50,134 @@ void NetCDFPerFeatureDataProviderTest::setupForcing()
         "../data/forcing/cats-27_52_67-2015_12_01-2015_12_30.nc",
         "../../data/forcing/cats-27_52_67-2015_12_01-2015_12_30.nc"
         };
-    std::string forcing_file_name = utils::FileChecker::find_first_readable(forcing_file_names);
+    forcing_file_name = utils::FileChecker::find_first_readable(forcing_file_names);
 
     // Using this to compute epoch times... this is what's done in Formulation_Constructors.hpp, FWIW...
-    forcing_params forcing_p(forcing_file_name, "NetCDF", "2015-12-01 00:00:00", "2015-12-30 23:00:00");
+    forcing_p = std::make_unique<forcing_params>(forcing_file_name, "NetCDF", "2015-12-01 00:00:00", "2015-12-30 23:00:00");
+}
 
-    nc_provider = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(forcing_file_name, forcing_p.simulation_start_t, forcing_p.simulation_end_t, utils::getStdErr() );
-    start_date_time = std::make_shared<time_type>();
-    end_date_time = std::make_shared<time_type>();
+///Test AORC Forcing Object
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadUsingIds)
+{
+    std::vector<std::string> ids = {"cat-27", "cat-52", "cat-67"};
+
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for(const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 3> expected = {285.8, 285.9, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+
+    ASSERT_EQ(ids, nc_provider.get_ids());
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadUsingIdsIsNotReverse)
+{
+    std::vector<std::string> ids = {"cat-27", "cat-52", "cat-67"};
+    auto rev = ids;
+    std::reverse(rev.begin(), rev.end());
+
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for(const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 3> expected = {285.8, 285.9, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+    auto ids_out = nc_provider.get_ids();
+    ASSERT_NE(rev, ids_out);
+    ASSERT_EQ(ids, ids_out);
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadUsingIdsSingle)
+{
+    std::vector<std::string> ids = {"cat-52"};
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    nc_provider.hint_shared_provider_id(ids[0]);
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    double value = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+    EXPECT_NEAR(value, 285.9, tol);
+    ASSERT_EQ(ids, nc_provider.get_ids());
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadSpan)
+{
+    std::vector<std::string> ids = {"cat-52", "cat-67"};
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for (const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 2> expected = {285.9, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+    ASSERT_EQ(ids, nc_provider.get_ids());
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadMultiSpan)
+{
+    std::vector<std::string> ids = {"cat-27", "cat-67"};
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for (const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 2> expected = {285.8, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+    ASSERT_EQ(ids, nc_provider.get_ids());
 }
 
 ///Test AORC Forcing Object
 TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
 {
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+
     // check to see that the variable "T2D" exists
-    auto var_names = nc_provider->get_available_variable_names();
+    auto var_names = nc_provider.get_available_variable_names();
     auto pos = std::find(var_names.begin(), var_names.end(), CSDMS_STD_NAME_SURFACE_TEMP);
     if ( pos != var_names.end() )
     {
@@ -84,14 +189,14 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
         FAIL();
     }
 
-    auto start_time = nc_provider->get_data_start_time();
-    auto ids = nc_provider->get_ids();
-    auto duration = nc_provider->record_duration();
+    auto start_time = nc_provider.get_data_start_time();
+    auto ids = nc_provider.get_ids();
+    auto duration = nc_provider.record_duration();
 
     //std::cout << "Checking values in catchment "<<ids[0]<<" at time "<<start_time<<" with duration "<<duration<<"..."<<std::endl;
 
     // read exactly one time step correctly aligned
-    double val1 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+    double val1 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
 
     //double tol = 0.00000612;
     double tol = 0.00002;
@@ -99,18 +204,18 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
     EXPECT_NEAR(val1, 285.8, tol);
 
     // read 1/2 of a time step correctly aligned
-    double val2 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration / 2, "K"), data_access::MEAN);
+    double val2 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration / 2, "K"), data_access::MEAN);
 
     EXPECT_NEAR(val2, 285.8, tol);
 
     // read 4 time steps correctly aligned
-    double val3 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration * 4, "K"), data_access::MEAN);
+    double val3 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration * 4, "K"), data_access::MEAN);
 
     EXPECT_NEAR(val3, 284.95, tol);
 
     // read exactly one time step correctly aligned but with a incorrect variable
     EXPECT_THROW(
-        double val4 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);, 
+        double val4 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);,
         std::runtime_error);
     
 }


### PR DESCRIPTION
NOTE: I need to prune some of the feature creep that has bled into this branch.

Only read data required for simulation.
Increase time dimension read buffer size.

### Previous Behavior

All features in netcdf file were read regardless if they were in the simulation domain.

## Changes

- Only read features from netcdf required for a simulation.
- Increase time dimension read buffer size.
