### PR TITLE
Suppress spurious macOS 15 AddressSanitizer error reports during BMI module loading

### DIFF
--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -172,6 +172,7 @@ jobs:
 
       - name: run_bmi_c_tests
         run: |
+          export ASAN_OPTIONS=${ASAN_OPTIONS}:detect_odr_violation=0,suppressions=$(pwd)/test/asan_suppressions.txt
           cd ./cmake_build/test/
           ./test_bmi_c
           cd ../../

--- a/src/bmi/AbstractCLibBmiAdapter.cpp
+++ b/src/bmi/AbstractCLibBmiAdapter.cpp
@@ -6,6 +6,22 @@
 
 #include <dlfcn.h>
 
+// Suppress false positive from ASan's own global registration
+// when dlopen()-ing instrumented shared libraries on macOS.
+// See: ASan runtime's AsanApplyToGlobals() calls getsectiondata()
+// in libmacho.dylib, which uses strcmp on Mach-O section names.
+// ASan's intercepted strcmp then reads shadow memory that has
+// already been poisoned (0xf9 = global redzone) by the same
+// initialization sequence, triggering a spurious report.
+#if defined(__APPLE__) && defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+extern "C" const char *__asan_default_suppressions() {
+    return "interceptor_via_lib:libmacho.dylib\n"
+           "interceptor_via_fun:getsectiondata\n";
+}
+#  endif
+#endif
+
 namespace models {
 namespace bmi {
 

--- a/test/asan_suppressions.txt
+++ b/test/asan_suppressions.txt
@@ -1,0 +1,1 @@
+interceptor_via_fun:getsectiondata


### PR DESCRIPTION
The CI failures seen for `test_bmi_c` on macOS were basically AddressSanitizer tripping over its own feet. Suppress error reports from within the stumbling-block function.

## Additions

- AddressSanitizer suppression file in the test suite, naming the particular macOS-specific function involved in the implementation of AddressSanitizer-instrumented `dlopen()`

## Changes

- Reference the ASan suppression file in the particular CI test that consistently fails

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. [x] Passes macOS 15 CI
2. [x] Passes Linux CI

## Notes

I originally tried various in-code changes based on investigatory effort in interaction with Claude. It inadvertently offered an approach that would only work on Linux, and was then able to explain why it didn't work on macOS once that became apparent.

Another alternative approach would be to not compile the BMI C test model with AddressSanitizer. As noted in comments, that would involve a lot more complicated CMake modifications, so I chose to use a suppression file instead.