### PR TITLE
Close nexus csv outputs before routing

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -564,6 +564,11 @@ int main(int argc, char *argv[]) {
 
     } //done time
 
+    // flush and close nexus
+    for (auto& output_file: nexus_outfiles) {
+        output_file.second.close();
+    }
+
 #if NGEN_WITH_MPI
     MPI_Barrier(MPI_COMM_WORLD);
 #endif


### PR DESCRIPTION
#### Problem

Nexus buffers are not flushed before running routing.
Nexus output files are incomplete because of this causing t-route to fail.
This only occurs when `ngen` runs routing.

This issue was introduced in #945.