### PR TITLE
Fix race with creating configured output directory

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -339,8 +339,11 @@ namespace realization {
                         int result = mkdir(dir, 0755);      
                         if (result == 0)
                             return str;
-                        else
-                            throw std::runtime_error("failed to create directory '" + str + "': " + std::strerror(errno));
+                        // Another process/MPI rank may have created the directory between this rank's stat and
+                        // mkdir calls, so consider EEXIST as success as long as the path is a directory.
+                        if (errno == EEXIST && stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode))
+                            return str;
+                        throw std::runtime_error("failed to create directory '" + str + "': " + std::strerror(errno));
                     }
                 }
  


### PR DESCRIPTION
## Summary
A race condition can occur in _Formulation_Manager::get_output_root_ in certain conditions.   One rank may create the output directory after a second rank has checked whether it needs to create the directory, leading to an error.  

## Setup
The error requires:
* executing with MPI and multiple ranks  
* the output directory not existing at the start of execution

Also, while I'm not completely certain this is a strict requirement, I only have observed this occurring when the config option added in #943 is set to disable catchment output.

## Solution
Gracefully recognize when the race occurred and allow execution to continue.  I.e., also treat output directory setup as successful if all the following are true:
* the `mkdir` call to create the output directory returns non-zero 
* the resulting value set to `errno` indicates a file already exists
* the existing file at the output directory path is a directory
