### PR TITLE
Migrate project to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 
 # -----------------------------------------------------------------------------
 # Set global C++ options
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ As we attempt to apply hydrological modeling at different scales, the traditiona
 This framework includes an encapsulation strategy which focuses on the hydrologic data first, and then builds a functional abstraction of hydrologic behavior.  This abstraction is naturally recursive, and unlocks a higher level of modeling and reasoning using computational modeling for hydrology.  This is done by organizing model components along well-defined flow boundaries, and then implementing strict API’s to define the movement of water amongst these components.  This organization also allows control and orchestration of first-class model components to leverage more sophisticated programming techniques and data structures.
 
 
-  - **Technology stack**: Core Framework using C++ (minimum standard c++14) to provide polymorphic interfaces with reasonable systems integration.
+  - **Technology stack**: Core Framework using C++ (minimum standard c++17) to provide polymorphic interfaces with reasonable systems integration.
   - **Status**:  Version 0.1.0 in initial development including interfaces, logical data model, and framework structure.  See  [CHANGELOG](CHANGELOG.md) for revision details.
 
 ## Structural Diagrams

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -49,17 +49,17 @@ If CMake is unable to find a compiler automatically, the CMake `CMAKE_C_COMPILER
 
 ### Version Requirements
 
-Project C++ code needs to be compliant with the C++ 14 standard.  Supported compilers need to be of a recent enough version to be compatible.  
+Project C++ code needs to be compliant with the C++ 17 standard.  Supported compilers need to be of a recent enough version to be compatible.  
 
 Additionally, C++ compilers needs to be compatible (ideally officially *tested* as such) with other project C++ dependencies.
 
 #### GCC
 
-Based on [this page](https://gcc.gnu.org/projects/cxx-status.html#cxx14), the C++ 14 support requirement probably equates to a version of GCC \>= version `5.0.0`.
+Based on [this page](https://gcc.gnu.org/projects/cxx-status.html#cxx17), the C++ 17 support requirement probably equates to some GCC version `7` release or later.
 
 #### Clang
 
-The Clang versioning scheme is a little convoluted.  Using the official scheme, Clang 3.4 and later should support all C++ 14 features.
+The Clang versioning scheme is a little convoluted.  Using the official scheme, Clang 5 and later should support all C++ 17 features.
 
 However, Apple likes to apply their own versioning to Clang and LLVM.  The `Apple LLVM version 10.0.1 (clang-1001.0.46.4)` version released with MacOS 10.14.x should do fine.  Recent, earlier version likely will as well, but YMMV.
 

--- a/extern/test_bmi_cpp/CMakeLists.txt
+++ b/extern/test_bmi_cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 # Uncomment this and rebuild artifacts to enable debugging
 set(CMAKE_BUILD_TYPE Debug)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(testbmicppmodel VERSION 1.0.0 DESCRIPTION "BMI C++ Testing Model Shared Library")

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -254,7 +254,7 @@ namespace realization {
         virtual void check_mass_balance(const int& iteration, const int& total_steps, const std::string& timestamp) const override {
             //Create the protocol context, each member is const, and cannot change during the check
             models::bmi::protocols::Context ctx{iteration, total_steps, timestamp, id};
-            bmi_protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, ctx);
+            (void) bmi_protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, ctx);
         }
 
     protected:

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -36,4 +36,4 @@ if(NGEN_WITH_PYTHON)
     target_link_libraries(forcing PUBLIC pybind11::embed NGen::ngen_bmi)
 endif()
 
-#target_compile_options(forcing PUBLIC -std=c++14 -Wall)
+#target_compile_options(forcing PUBLIC -std=c++17 -Wall)

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -35,5 +35,3 @@ if(NGEN_WITH_PYTHON)
     )
     target_link_libraries(forcing PUBLIC pybind11::embed NGen::ngen_bmi)
 endif()
-
-#target_compile_options(forcing PUBLIC -std=c++17 -Wall)

--- a/src/utilities/bmi/mass_balance.cpp
+++ b/src/utilities/bmi/mass_balance.cpp
@@ -29,7 +29,7 @@ namespace models { namespace bmi { namespace protocols {
 
 NgenMassBalance::NgenMassBalance(const ModelPtr& model, const Properties& properties) :
   check(false), is_fatal(false), tolerance(1.0E-16), frequency(1){
-    initialize(model, properties);
+    (void) initialize(model, properties);
 }
 
 NgenMassBalance::NgenMassBalance() : check(false) {}
@@ -183,7 +183,7 @@ auto NgenMassBalance::initialize(const ModelPtr& model, const Properties& proper
     }
     if ( check ) {
         //Ensure the model is capable of mass balance using the protocol
-        check_support(model).or_else( error_or_warning );
+        (void) check_support(model).or_else( error_or_warning );
     }
     return {}; // important to return for the expected to be properly created!
 }

--- a/src/utilities/bmi/mass_balance.cpp
+++ b/src/utilities/bmi/mass_balance.cpp
@@ -183,7 +183,7 @@ auto NgenMassBalance::initialize(const ModelPtr& model, const Properties& proper
     }
     if ( check ) {
         //Ensure the model is capable of mass balance using the protocol
-        (void) check_support(model).or_else( error_or_warning );
+        return check_support(model).or_else( error_or_warning );
     }
     return {}; // important to return for the expected to be properly created!
 }

--- a/test/utils/bmi/mass_balance_Test.cpp
+++ b/test/utils/bmi/mass_balance_Test.cpp
@@ -167,10 +167,10 @@ TEST_F(Bmi_Mass_Balance_Test, check) {
     auto context = make_context(0, 2, time, model_name);
     testing::internal::CaptureStderr();
     auto protocols = NgenBmiProtocols(model, properties);
-    protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, context);
+    (void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, context);
     model->Update();
     time = "t1";
-    protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name));
+    (void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name));
     std::string output = testing::internal::GetCapturedStderr();
     // Not warning/errors printed, and no exceptions thrown is success
     EXPECT_EQ(output, "");
@@ -203,7 +203,7 @@ TEST_F(Bmi_Mass_Balance_Test, storage_fails) {
     model->SetValue(STORED_MASS_NAME, &mass_error); // Force a mass balance error
     time = "t1";
 
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
     try{
         // This should throw, so result won't be defined...
         auto result = protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name));
@@ -222,7 +222,7 @@ TEST_F(Bmi_Mass_Balance_Test, in_fails) {
     time = "t1";
     double mass_error = 2;
     model->SetValue(INPUT_MASS_NAME, &mass_error); // Force a mass balance error
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
     try{
         // This should throw, so result won't be defined...
         auto result = protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name));
@@ -241,7 +241,7 @@ TEST_F(Bmi_Mass_Balance_Test, out_fails) {
     time = "t1";
     double mass_error = 2;
     model->SetValue(OUTPUT_MASS_NAME, &mass_error); // Force a mass balance error
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
     try{
         // This should throw, so result won't be defined...
         auto result = protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name));
@@ -260,7 +260,7 @@ TEST_F(Bmi_Mass_Balance_Test, leaked_fails) {
     time = "t1";
     double mass_error = 2;
     model->SetValue(LEAKED_MASS_NAME, &mass_error); // Force a mass balance error
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
     try{
         // This should throw, so result won't be defined...
         auto result = protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name));
@@ -280,7 +280,7 @@ TEST_F(Bmi_Mass_Balance_Test, tolerance_fails) {
     model->GetValue(INPUT_MASS_NAME, &mass_error);
     mass_error += 1e-4; // Force a mass balance error not within tolerance
     model->SetValue(INPUT_MASS_NAME, &mass_error); // Force a mass balance error
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(0, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(0, 2, time, model_name)), ProtocolError);
     try{
         // This should throw, so result won't be defined...
         auto result = protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(0, 2, time, model_name));
@@ -353,7 +353,7 @@ TEST_F(Bmi_Mass_Balance_Test, frequency) {
     model->SetValue(OUTPUT_MASS_NAME, &mass_error);
     //Check initial mass balance -- should error which indicates it was propoerly checked
     //per frequency setting
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(0, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(0, 2, time, model_name)), ProtocolError);
     time = "t1";
     model->Update(); // advance model
     model->SetValue(OUTPUT_MASS_NAME, &mass_error);
@@ -366,7 +366,7 @@ TEST_F(Bmi_Mass_Balance_Test, frequency) {
     model->SetValue(OUTPUT_MASS_NAME, &mass_error);
     // Check mass balance again, this SHOULD error since the previous mass balance
     // will propagate, and it should now be checked based on the frequency
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(2, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(2, 2, time, model_name)), ProtocolError);
 }
 
 TEST_F(Bmi_Mass_Balance_Test, frequency_zero) {
@@ -400,7 +400,7 @@ TEST_F(Bmi_Mass_Balance_Test, frequency_end) {
     model->SetValue(OUTPUT_MASS_NAME, &mass_error);
     // Check mass balance again, this SHOULD error since its the last timestep and the previous mass balance
     // will propagate, and it should now be checked based on the frequency
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(2, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(2, 2, time, model_name)), ProtocolError);
 }
 
 TEST_F(Bmi_Mass_Balance_Test, nan) {
@@ -429,7 +429,7 @@ TEST_F(Bmi_Mass_Balance_Test, model_nan) {
     model->SetValue(OUTPUT_MASS_NAME, &mass_error); // Force a NaN into the mass balance computation
     time = "t1";
     // should cause an error since mass balance will be NaN using this value in its computation
-    ASSERT_THROW(protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
+    ASSERT_THROW((void) protocols.run(models::bmi::protocols::Protocol::MASS_BALANCE, make_context(1, 2, time, model_name)), ProtocolError);
 }
 
 #endif  // NGEN_BMI_CPP_LIB_TESTS_ACTIVE


### PR DESCRIPTION
MIgrating project to C++ 17 standard, and performing minimal code modifications to allow this. 

> [!IMPORTANT]
> Before starting this, I did hear from @christophertubbs that he had been informed we were clear to move the project to C++17. 

## Changes

- Change top-level project standard to 17.
- Change inter _test_bmi_cpp_ project standard to 17.
- Adjusting commented out line in forcing CMakeLists.txt that referenced 14 to avoid future issues if that is uncommented.
- Updating documentation to reflect the change.
- Explicitly casting return values to `(void)` for several functions marked as `nodiscard` but whose return values were being ignored

## Testing

1. Builds and test targets succeed for multiple build generation variants

## Notes

- The `(void)` casts were the most convenient way to address this, but I'm not sure that is the best approach.  The involve lines seems to be @hellkite500's and the (relatively new) BMI protocol work, so I'm wondering if he might comment a bit on this specifically. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
