### PR TITLE
Add a nexus NetCDF output path that gathers to rank 0 in MPI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(NGEN_QUIET            "Silence output"                     OFF)
 cmake_dependent_option(NGEN_WITH_ROUTING "Build with t-route integration" ON "NGEN_WITH_PYTHON" OFF)
 cmake_dependent_option(NGEN_UPDATE_GIT_SUBMODULES "Update submodules on configure" ON "GIT_FOUND;NGEN_HAS_GIT_DIR" OFF)
 cmake_dependent_option(NGEN_WITH_COVERAGE "Build with test coverage" OFF "NGEN_WITH_TESTS" OFF)
+cmake_dependent_option(NGEN_WITH_PARALLEL_NETCDF "Build with NetCDF using HDF5-parallel support" OFF "NGEN_WITH_NETCDF" OFF)
 
 option(BMI_FORTRAN_ISO_C_LIB_DIR "Directory hint for middleware Fortran shared lib handling iso_c_binding" "${NGEN_ROOT_DIR}/extern/iso_c_fortran_bmi/cmake_build")
 option(BMI_FORTRAN_ISO_C_LIB_NAME "Name for middleware Fortran shared lib handling iso_c_binding" "iso_c_bmi")
@@ -198,10 +199,13 @@ if(NGEN_WITH_NETCDF)
         target_link_libraries(NetCDF INTERFACE netcdf-cxx4)
     endif()
 
-    if(NetCDF_HAS_PARALLEL)
-        add_compile_definitions(NGEN_WITH_PARALLEL_NETCDF)
+    if(NGEN_WITH_PARALLEL_NETCDF)
+        if(NetCDF_HAS_PARALLEL)
+            add_compile_definitions(NGEN_WITH_PARALLEL_NETCDF)
+        else()
+            message(FATAL_ERROR "Asked for NGEN_WITH_PARALLEL_NETCDF, but using a NetCDF installation that doesn't support it")
+        endif()
     endif()
-
 endif()
 
 if(NGEN_WITH_EXTERN_SLOTH)
@@ -425,6 +429,7 @@ ngen_multiline_message(
 "  Flags:"
 "    NGEN_WITH_MPI: ${NGEN_WITH_MPI}"
 "    NGEN_WITH_NETCDF: ${NGEN_WITH_NETCDF}"
+"    NGEN_WITH_PARALLEL_NETCDF: ${NGEN_WITH_PARALLEL_NETCDF}"
 "    NGEN_WITH_SQLITE: ${NGEN_WITH_SQLITE}"
 "    NGEN_WITH_UDUNITS: ${NGEN_WITH_UDUNITS}"
 "    NGEN_WITH_BMI_FORTRAN: ${NGEN_WITH_BMI_FORTRAN}"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,6 +61,7 @@ In addition to normal CMake options, the following `ngen` configuration options 
 Option                | Description
 --------------------- | -----------
 NGEN_WITH_NETCDF      | Include NetCDF support
+NGEN_WITH_PARALLEL_NETCDF | Use HDF5-parallel I/O for per-formulation nexus output (requires `NGEN_WITH_NETCDF` and a NetCDF library built with parallel I/O); without this, MPI builds gather per-timestep nexus data to rank 0 for serial writing
 NGEN_WITH_SQLITE3     | Include SQLite3 support (GeoPackage support)
 NGEN_WITH_UDUNITS     | Include UDUNITS support
 NGEN_WITH_MPI         | Include MPI (Parallel Execuation) support

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -15,7 +15,7 @@
 | [dmod.subsetservice](#the-dmodsubsetservice-package)                                       | external   |                    `>= 0.3.0`                     |           Only required to perform integrated [hydrofabric file subdividing](DISTRIBUTED_PROCESSING.md#subdivided-hydrofabric) for distributed processing .           |
 | [t-route](#t-route)                                                                        | submodule  |                     see below                     |                                                Module required to enable channel-routing.  Requires pybind11 to enable                                                |
 | [NetCDF Libraries](#netcdf-libraries)                                                      | external   |                    \>= `4.7.4`                    |                                                                      Enables NetCDF I/O support                                                                       |
-| [NetCDF-4 parallel support](https://docs.unidata.ucar.edu/netcdf-c/4.9.3/parallel_io.html) | external   |                                                   |   Optional, but required to use [per-formulation NetCDF nexus output files](REALIZATION_CONFIGURATION.md#per_formulation_nexus_files) in ngen builds supporting MPI   |
+| [NetCDF-4 parallel support](https://docs.unidata.ucar.edu/netcdf-c/4.9.3/parallel_io.html) | external   |                                                   |   Optional; opt in via `-DNGEN_WITH_PARALLEL_NETCDF=ON` so MPI ranks write [per-formulation NetCDF nexus output files](REALIZATION_CONFIGURATION.md#per_formulation_nexus_files) directly in parallel. Otherwise rank 0 gathers and writes serially.   |
 | [SQLite3](https://www.sqlite.org/cintro.html)                                              | external   |                    \> `3.7.17`                    |                                                                  Enables GeoPackage reading support                                                                   |
 # Details
 
@@ -230,11 +230,15 @@ First, check if your compute system already have a version that is up to date, u
 
 ### Parallel NetCDF
 
-In order to make use of the per-formulation NetCDF nexus output files capabilities [noted here](REALIZATION_CONFIGURATION.md#per_formulation_nexus_files) within installations of ngen that support parallel MPI execution, NetCDF-4 and its dependencies must have been built/installed with parallel I/O support.  [See here](https://docs.unidata.ucar.edu/netcdf-c/4.9.3/parallel_io.html) for further details in the NetCDF documentation.  
+[Per-formulation NetCDF nexus output files](REALIZATION_CONFIGURATION.md#per_formulation_nexus_files) work in any ngen build with NetCDF support, including MPI builds, without requiring NetCDF-4 parallel I/O. In MPI builds, every non-root rank gathers its per-timestep nexus data to rank 0, which writes the full row through the standard (serial) NetCDF C API.
 
-Without NetCDF Parallel I/O support, parallel builds of ngen will be limited to individual, per-nexus output files for nexus data in CSV format, and an error will occur if a realization config attempting to use per-formulation outputs is supplied.
+To have each MPI rank write its own slice of the file directly via HDF5-parallel I/O, opt in at CMake configure time:
 
-You can see if the NetCDF dependency found by CMake for ngen builds includes parallel support by looking for this part of the CMake output when you generate/regenerate the build system directory.  Note specifically the `Parallel` sub-item at the end of the NetCDF details.
+    -DNGEN_WITH_PARALLEL_NETCDF=ON
+
+This option defaults to `OFF`. When set to `ON` it requires that the NetCDF-4 library located by CMake was itself built with parallel I/O support; CMake will fail with a `FATAL_ERROR` at configure time if the library does not provide it. [See here](https://docs.unidata.ucar.edu/netcdf-c/4.9.3/parallel_io.html) for details on parallel I/O in the NetCDF documentation.
+
+You can see both whether the NetCDF library found by CMake supports parallel I/O and whether `NGEN_WITH_PARALLEL_NETCDF` is enabled for this build by examining the CMake configure-time summary. Note the `Parallel` sub-item at the end of the NetCDF details and the `NGEN_WITH_PARALLEL_NETCDF` line under `Flags`.
 
 ```
 ...
@@ -248,8 +252,13 @@ You can see if the NetCDF dependency found by CMake for ngen builds includes par
 --     Library (CXX): /opt/local/lib/libnetcdf_c++4.dylib
 --     Include: /opt/local/include
 --     Include (CXX): /opt/local/include
---     Parallel: TRUE 
+--     Parallel: TRUE
 --   SQLite:
 --     Version: 3.49.1
 ...
+--   Flags:
+--     NGEN_WITH_MPI: ON
+--     NGEN_WITH_NETCDF: ON
+--     NGEN_WITH_PARALLEL_NETCDF: OFF
+--     ...
 ```

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -34,7 +34,7 @@ The configuration may optionally contain a `per_formulation_nexus_files` key wit
 > [!IMPORTANT]
 > NetCDF support must be turned on for the ngen build to use this option for per-formulation NetCDF file.  This is done by including the `-DNGEN_WITH_NETCDF=ON` arg to CMake on the command line when generating a build directory.
 > 
-> Additionally, for ngen builds that also support MPI (i.e., `-DNGEN_WITH_MPI=ON`), using per-formulation NetCDF files also requires that NetCDF include [parallel I/O support](DEPENDENCIES.md#parallel-netcdf).
+> In MPI builds (i.e., `-DNGEN_WITH_MPI=ON`), per-formulation NetCDF files are written by gathering each timestep's nexus data to rank 0, which writes the file via the standard NetCDF C API. To instead have every rank write its own slice in parallel via HDF5-parallel I/O, opt in with `-DNGEN_WITH_PARALLEL_NETCDF=ON`; this additionally requires the NetCDF library itself to provide [parallel I/O support](DEPENDENCIES.md#parallel-netcdf).
 
 ### `catchments`
 The configuration may optionally contain a `catchments` key with a list of individual catchments that define their own formulations.  See [more details below](#catchments).

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -61,9 +61,7 @@ namespace realization {
                 if (per_formulation_setting) {
                     #if !NGEN_WITH_NETCDF
                     throw std::runtime_error("ERROR: per_formulation_nexus_files is set to true, but NGEN was built without NetCDF support.");
-                    #elif NGEN_WITH_MPI and !NGEN_WITH_PARALLEL_NETCDF
-                    throw std::runtime_error("ERROR: per_formulation_nexus_files is set to true, but parallel NGEN was built without **parallel** NetCDF support.");
-                    #else // Implies either (NGEN_WITH_MPI and NGEN_WITH_PARALLEL_NETCDF) or (NGEN_WITH_NETCDF and !NGEN_WITH_MPI)
+                    #else
                     use_per_formulation_nexus_files = per_formulation_setting->get_value<bool>();
                     #endif
                 }

--- a/include/utilities/output/PerFormulationNexusOutputMgr.hpp
+++ b/include/utilities/output/PerFormulationNexusOutputMgr.hpp
@@ -423,18 +423,15 @@ namespace utils
 
         /**
          * Per-rank counts of nexus ids, indexed by rank.  Used as the ``recvcounts`` argument to ``MPI_Gatherv`` calls.
-         *
-         * Populated on every rank during construction via ``MPI_Allgather`` of each rank's local nexus count.  Only
-         * meaningful when @ref gather_to_root is ``true``.
+         * Populated and held only on rank 0; empty on non-root ranks.  Only meaningful when @ref gather_to_root is
+         * ``true``.
          */
         std::vector<int> gather_recvcounts;
 
         /**
          * Per-rank write offsets into the global nexus array, indexed by rank.  Used as the ``displs`` argument to
-         * ``MPI_Gatherv`` calls.
-         *
-         * Populated on every rank during construction via ``MPI_Allgather`` of each rank's @ref local_offset.  Only
-         * meaningful when @ref gather_to_root is ``true``.
+         * ``MPI_Gatherv`` calls.  Populated and held only on rank 0; empty on non-root ranks.  Only meaningful when
+         * @ref gather_to_root is ``true``.
          */
         std::vector<int> gather_displs;
 

--- a/include/utilities/output/PerFormulationNexusOutputMgr.hpp
+++ b/include/utilities/output/PerFormulationNexusOutputMgr.hpp
@@ -238,6 +238,20 @@ namespace utils
         int netcdf_file_id = -1;
 
         /**
+         * Whether this instance is still operating on (or, on non-root gather-mode ranks, participating around) an
+         * open managed file.
+         *
+         * Defaults to ``false`` and is flipped to ``true`` only at the end of a successful constructor; this way a
+         * partially-constructed instance correctly reports as already-closed.
+         *
+         * Tracked separately from @ref netcdf_file_id because, in the gather-to-rank-0 path, non-root ranks never
+         * open a NetCDF file and so cannot use file id state to represent their open/closed status; without this
+         * flag they would falsely report as already-closed and bail out of @ref receive_data_entry and
+         * @ref commit_writes before participating in the per-timestep MPI gather.
+         */
+        bool is_file_open = false;
+
+        /**
          * The instance id for this instance, which should be the MPI rank if using MPI.
          *
          * For non-MPI use cases, there must always be an id 0, and it is assumed each new id is incremented by 1.
@@ -395,6 +409,42 @@ namespace utils
          * @param nc_var_id The numeric NetCDF variable id
          */
         void set_nc_var_parallel_collective(const int nc_var_id) const;
+        #endif
+
+        #if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
+        /**
+         * Whether this instance is participating in MPI gather-to-rank-0 output.
+         *
+         * Set during construction when MPI is initialized and there is more than one instance.  When ``false`` the
+         * instance follows the in-process multi-instance code path (rank/obj_id 0 creates the file; others open it),
+         * which is used by tests that don't initialize MPI.
+         */
+        bool gather_to_root = false;
+
+        /**
+         * Per-rank counts of nexus ids, indexed by rank.  Used as the ``recvcounts`` argument to ``MPI_Gatherv`` calls.
+         *
+         * Populated on every rank during construction via ``MPI_Allgather`` of each rank's local nexus count.  Only
+         * meaningful when @ref gather_to_root is ``true``.
+         */
+        std::vector<int> gather_recvcounts;
+
+        /**
+         * Per-rank write offsets into the global nexus array, indexed by rank.  Used as the ``displs`` argument to
+         * ``MPI_Gatherv`` calls.
+         *
+         * Populated on every rank during construction via ``MPI_Allgather`` of each rank's @ref local_offset.  Only
+         * meaningful when @ref gather_to_root is ``true``.
+         */
+        std::vector<int> gather_displs;
+
+        /**
+         * Rank-0 receive buffer for gathered flow values across all ranks for a single time step.
+         *
+         * Sized to @ref total_nexus_count and only allocated on rank 0; non-zero ranks leave it empty.  Reused on
+         * every call to @ref commit_writes.
+         */
+        std::vector<double> gather_flow_buffer;
         #endif
 
     };

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -478,10 +478,10 @@ int main(int argc, char *argv[]) {
             total_nexus_count = local_nexus_write_offset + local_nexus_count;
         MPI_Bcast(&total_nexus_count, 1, MPI_INT, mpi_num_procs - 1, MPI_COMM_WORLD);
 
-        #if NGEN_WITH_NETCDF and NGEN_WITH_PARALLEL_NETCDF
+        #if NGEN_WITH_NETCDF
         nexus_outputs_mgr = std::make_shared<utils::PerFormulationNexusOutputMgr>(nexus_ids, formulation_ids, manager->get_output_root(), timesteps, mpi_rank, local_nexus_write_offset, mpi_num_procs, total_nexus_count);
         #else
-        throw std::runtime_error("Parallel NetCDF support required to use per-formulation nexus files.");
+        throw std::runtime_error("NetCDF support required to use per-formulation nexus files.");
         #endif
 
         // One more barrier here to make sure other ranks wait while rank 0 creates the per-formulation nexus file

--- a/src/utilities/output/PerFormulationNexusOutputMgr.cpp
+++ b/src/utilities/output/PerFormulationNexusOutputMgr.cpp
@@ -113,14 +113,15 @@ utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
         gather_to_root = true;
 
         // Cache per-rank counts and write offsets so commit_writes can drive MPI_Gatherv without recomputing
-        // per timestep.  Both must be int (the type required by MPI_Gatherv), and total_nexus_count is already
-        // int upstream so size-fitness matches the existing assumptions.
-        gather_recvcounts.resize(instance_count);
-        gather_displs.resize(instance_count);
+        // per timestep.
+        if (obj_id == 0) {
+            gather_recvcounts.resize(instance_count);
+            gather_displs.resize(instance_count);
+        }
         const int local_nexus_count = static_cast<int>(nexus_ids.size());
         const int local_offset_int = static_cast<int>(this->local_offset);
-        MPI_Allgather(&local_nexus_count, 1, MPI_INT, gather_recvcounts.data(), 1, MPI_INT, MPI_COMM_WORLD);
-        MPI_Allgather(&local_offset_int, 1, MPI_INT, gather_displs.data(), 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Gather(&local_nexus_count, 1, MPI_INT, gather_recvcounts.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+        MPI_Gather(&local_offset_int, 1, MPI_INT, gather_displs.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
 
         if (obj_id == 0) {
             create_netcdf_file();

--- a/src/utilities/output/PerFormulationNexusOutputMgr.cpp
+++ b/src/utilities/output/PerFormulationNexusOutputMgr.cpp
@@ -106,6 +106,38 @@ utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
         open_netcdf_file();
         lookup_netcdf_metadata();
     }
+#elif NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
+    // Gather-to-rank-0 path: only rank 0 ever touches the NetCDF file; non-root ranks send their data to
+    // rank 0 each commit and rank 0 issues serial NetCDF C API writes covering the full global array.
+    if (instance_count > 1 && isMpiInitialized()) {
+        gather_to_root = true;
+
+        // Cache per-rank counts and write offsets so commit_writes can drive MPI_Gatherv without recomputing
+        // per timestep.  Both must be int (the type required by MPI_Gatherv), and total_nexus_count is already
+        // int upstream so size-fitness matches the existing assumptions.
+        gather_recvcounts.resize(instance_count);
+        gather_displs.resize(instance_count);
+        const int local_nexus_count = static_cast<int>(nexus_ids.size());
+        const int local_offset_int = static_cast<int>(this->local_offset);
+        MPI_Allgather(&local_nexus_count, 1, MPI_INT, gather_recvcounts.data(), 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Allgather(&local_offset_int, 1, MPI_INT, gather_displs.data(), 1, MPI_INT, MPI_COMM_WORLD);
+
+        if (obj_id == 0) {
+            create_netcdf_file();
+            setup_netcdf_metadata();
+            gather_flow_buffer.assign(total_nexus_count, flow_var_fill_value);
+        }
+    }
+    // No MPI run in progress (e.g., in-process tests): use the same multi-instance fallback as the parallel
+    // build path - rank/obj_id 0 creates and sets up, others open and look up metadata.
+    else if (instance_count == 1 || obj_id == 0) {
+        create_netcdf_file();
+        setup_netcdf_metadata();
+    }
+    else {
+        open_netcdf_file();
+        lookup_netcdf_metadata();
+    }
 #else
 
     // As with MPI-case code above, to support testing, support possibility of multiple instances opened,
@@ -121,11 +153,16 @@ utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
     }
 #endif
 
-    int nc_status = nc_sync(netcdf_file_id);
-    if (nc_status != NC_NOERR) {
-        throw std::runtime_error("Could not sync metadata during setup of '" + nexus_outfile + "': "
-            + parse_netcdf_return_code(nc_status));
+    if (netcdf_file_id != -1) {
+        int nc_status = nc_sync(netcdf_file_id);
+        if (nc_status != NC_NOERR) {
+            throw std::runtime_error("Could not sync metadata during setup of '" + nexus_outfile + "': "
+                + parse_netcdf_return_code(nc_status));
+        }
     }
+
+    // Reaching here means setup completed without throwing; flip from the default closed state to open.
+    is_file_open = true;
 }
 
 utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
@@ -152,7 +189,10 @@ utils::PerFormulationNexusOutputMgr::~PerFormulationNexusOutputMgr() {
 
 void utils::PerFormulationNexusOutputMgr::close() {
     if (is_closed()) return;
-    close_netcdf_file();
+    if (netcdf_file_id != -1) {
+        close_netcdf_file();
+    }
+    is_file_open = false;
 }
 
 void utils::PerFormulationNexusOutputMgr::commit_writes() {
@@ -167,33 +207,59 @@ void utils::PerFormulationNexusOutputMgr::commit_writes() {
     // On the first write, also write the nexus id variable values
     write_nexus_ids_once();
 
-    // For just obj_id 0, write the time value
-    if (obj_id == 0) {
-        long long epoch_minutes = current_epoch_time / 60;
-        const size_t start_t = static_cast<size_t>(current_time_index);
-        const size_t count_t = 1;
-        // TODO: (later) consider if we need to sanity check that times are consistent across obj_ids (we were
-        // TODO:        effectively assuming this to be the case when not explicitly writing times).
-
-        nc_status = nc_put_vara_longlong(netcdf_file_id, nc_var_id_time, &start_t, &count_t, &epoch_minutes);
-        if (nc_status != NC_NOERR) {
-            throw std::runtime_error("Error writing time value to nexus file '" + nexus_outfile + "' ("
-                + parse_netcdf_return_code(nc_status) + ") at time index " + std::to_string(current_time_index) + ".");
-        }
-    }
-
-    // Assume base on how constructor was set up (imply for conciseness)
+    // Default: this instance writes its own local slice straight from current_nexus_data.
     //size_t nexus_dim_index = 0;
     //size_t time_dim_index = 1;
-    const size_t start_f[2] = {local_offset, static_cast<size_t>(current_time_index)};
-    const size_t count_f[2] = {nexus_ids.size(), 1};
+    size_t start_f[2] = {SIZE_MAX, static_cast<size_t>(current_time_index)};
+    size_t count_f[2] = {SIZE_MAX, 1};
+    const double* flow_data = nullptr;
 
-    // TODO: perhaps later a configurable option about whether we should thrown an exception if any nexuses
-    //  didn't have a data value set (i.e., are still set to fill value)
-    nc_status = nc_put_vara_double(netcdf_file_id, nc_var_id_flow, start_f, count_f, current_nexus_data.data());
-    if (nc_status != NC_NOERR) {
-        throw std::runtime_error("Error writing flow value to nexus file '" + nexus_outfile + "' ("
-            + parse_netcdf_return_code(nc_status) + ") at time index " + std::to_string(current_time_index) + ".");
+#if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
+    if (gather_to_root) {
+        // All ranks contribute via MPI_Gatherv; on rank 0 the slice covers the full nexus dimension and the
+        // data buffer is the consolidated rank-0 receive buffer rather than this rank's local data.
+        MPI_Gatherv(current_nexus_data.data(), static_cast<int>(current_nexus_data.size()), MPI_DOUBLE,
+                    gather_flow_buffer.data(), gather_recvcounts.data(), gather_displs.data(), MPI_DOUBLE,
+                    0, MPI_COMM_WORLD);
+        start_f[0] = 0;
+        count_f[0] = static_cast<size_t>(total_nexus_count);
+        flow_data = gather_flow_buffer.data();
+    }
+    else
+#endif
+    {
+        start_f[0] = local_offset;
+        count_f[0] = nexus_ids.size();
+        flow_data = current_nexus_data.data();
+    }
+
+    // Only instances that own the file (i.e., have a valid netcdf_file_id) issue NetCDF calls.  This
+    // distinguishes gather-mode non-root ranks (which have netcdf_file_id == -1 and only participate in the
+    // MPI_Gatherv above) from every other configuration, where each instance opened or created the file and
+    // writes its own slice.
+    if (netcdf_file_id != -1) {
+        // For just obj_id 0, write the time value
+        if (obj_id == 0) {
+            long long epoch_minutes = current_epoch_time / 60;
+            const size_t start_t = static_cast<size_t>(current_time_index);
+            const size_t count_t = 1;
+            // TODO: (later) consider if we need to sanity check that times are consistent across obj_ids (we were
+            // TODO:        effectively assuming this to be the case when not explicitly writing times).
+
+            nc_status = nc_put_vara_longlong(netcdf_file_id, nc_var_id_time, &start_t, &count_t, &epoch_minutes);
+            if (nc_status != NC_NOERR) {
+                throw std::runtime_error("Error writing time value to nexus file '" + nexus_outfile + "' ("
+                    + parse_netcdf_return_code(nc_status) + ") at time index " + std::to_string(current_time_index) + ".");
+            }
+        }
+
+        // TODO: perhaps later a configurable option about whether we should throw an exception if any nexuses
+        //  didn't have a data value set (i.e., are still set to flow_var_fill_value)
+        nc_status = nc_put_vara_double(netcdf_file_id, nc_var_id_flow, start_f, count_f, flow_data);
+        if (nc_status != NC_NOERR) {
+            throw std::runtime_error("Error writing flow value to nexus file '" + nexus_outfile + "' ("
+                + parse_netcdf_return_code(nc_status) + ") at time index " + std::to_string(current_time_index) + ".");
+        }
     }
 
     current_time_index++;
@@ -201,7 +267,7 @@ void utils::PerFormulationNexusOutputMgr::commit_writes() {
     // Trigger a flush to disk every so often
     // It might be nice to utilize NetCDF's built-in chunk caching, but with MPI it looks like we can't:
     //  https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga034a5fc54d9b05296555544d8dd9fe89
-    if (current_time_index % data_flush_interval == 0) {
+    if (netcdf_file_id != -1 && current_time_index % data_flush_interval == 0) {
         nc_status = nc_sync(netcdf_file_id);
         if (nc_status != NC_NOERR) {
             throw std::runtime_error("Error syncing/flushing data to nexus file '" + nexus_outfile + "' after "
@@ -218,12 +284,12 @@ void utils::PerFormulationNexusOutputMgr::commit_writes() {
     current_formulation_id.clear();
 
     if (current_time_index == total_timesteps) {
-        close_netcdf_file();
+        close();
     }
 }
 
 bool utils::PerFormulationNexusOutputMgr::is_closed() {
-    return netcdf_file_id == -1;
+    return !is_file_open;
 }
 
 std::shared_ptr<std::vector<std::string>> utils::PerFormulationNexusOutputMgr::get_filenames() {
@@ -506,6 +572,31 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
         }
         numeric_nex_ids[i] = std::stoi(nexus_ids[i].substr(pos + 1));
     }
+
+#if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
+    if (gather_to_root) {
+        // Gather every rank's numeric nexus ids to rank 0, then rank 0 writes the full vector once.
+        std::vector<unsigned int> all_numeric_nex_ids;
+        if (obj_id == 0) {
+            all_numeric_nex_ids.resize(total_nexus_count);
+        }
+        MPI_Gatherv(numeric_nex_ids.data(), static_cast<int>(numeric_nex_ids.size()), MPI_UNSIGNED,
+                    all_numeric_nex_ids.data(), gather_recvcounts.data(), gather_displs.data(), MPI_UNSIGNED,
+                    0, MPI_COMM_WORLD);
+        if (obj_id != 0) {
+            return;
+        }
+        std::vector<size_t> start{0};
+        std::vector<size_t> count{static_cast<size_t>(total_nexus_count)};
+        int nc_status = nc_put_vara_uint(netcdf_file_id, nc_var_id_nexus_id, start.data(), count.data(),
+                                         all_numeric_nex_ids.data());
+        if (nc_status != NC_NOERR) {
+            throw std::runtime_error("Error writing nexus ids to netcdf for nexus output manager: "
+                + parse_netcdf_return_code(nc_status));
+        }
+        return;
+    }
+#endif
 
     std::vector<size_t> start{this->local_offset};
     std::vector<size_t> count{numeric_nex_ids.size()};

--- a/test/utils/PerFormulationNexusOutputMgr_Test.cpp
+++ b/test/utils/PerFormulationNexusOutputMgr_Test.cpp
@@ -247,7 +247,12 @@ TEST_F(PerFormulationNexusOutputMgr_Test, construct_2_a)
         }
     }
 
+    mgr.close();
+    MPI_Barrier(MPI_COMM_WORLD);
+
     ASSERT_TRUE(utils::FileChecker::file_can_be_written(mgr.get_filenames()->at(0)));
+
+    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 
@@ -303,6 +308,8 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_a)
         mgr.commit_writes();
     }
 
+    mgr.close();
+
     // When done writing everything, another barrier before any checks/asserts
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -325,6 +332,8 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_a)
                 << "Full timestep data for this timestep is: \n" << values << "\n ***** \n";
         }
     }
+
+    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 /** Test example 2 writes feature ids correctly using multiple simultaneous writes via MPI. */
@@ -373,6 +382,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
                                group_data->at(t)[n]);
     }
     mgr.commit_writes();
+    mgr.close();
 
     // When done writing, another barrier before any checks/asserts
     MPI_Barrier(MPI_COMM_WORLD);
@@ -395,6 +405,8 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
         nex_id_strs[i] = "nex-" + std::to_string(nex_id_numeric[i]);
     }
     ASSERT_EQ(nex_id_strs, ex_2_form_0_all_nexus_id);
+
+    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 #else


### PR DESCRIPTION
The existing NetCDF nexus output for MPI builds relies on hdf5-parallel support in the underlying NetCDF library. This poses testing/deployment issues, because that's hard to get configured and built correctly. It also poses performance issues due to the substantial synchronization entailed relative to the small volumes of data being transferred. 

## Additions

- In builds with MPI support, NetCDF nexus output can now be gathered to rank 0 and written by that single process using the non-parallel NetCDF API

## Changes

- `NGEN_WITH_PARALLEL_NETCDF` becomes a CMake configuration option, defaulting to off - i.e. in MPI builds, the new gather-to-rank-0 path will be the default

## Testing

`test_unit` and `test_mpi_unit` in builds with
1. non-parallel NetCDF (`test_mpi_unit` exercises the new code)
2. parallel NetCDF and `NGEN_WITH_PARALLEL_NETCDF=OFF` (`test_mpi_unit` exercises the new code)
3. parallel NetCDF and `NGEN_WITH_PARALLEL_NETCDF=ON` (`test_mpi_unit` exercises the existing code)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
