### PR TITLE
Parallel utils refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ add_subdirectory("src/geojson")
 add_subdirectory("src/bmi")
 add_subdirectory("src/realizations/catchment")
 add_subdirectory("src/forcing")
+add_subdirectory("src/utilities")
 add_subdirectory("src/utilities/mdarray")
 add_subdirectory("src/utilities/mdframe")
 add_subdirectory("src/utilities/logging")
@@ -347,6 +348,7 @@ target_link_libraries(ngen
         NGen::logging
         NGen::bmi_protocols
         NGen::output
+        NGen::parallel
 )
 
 if(NGEN_WITH_SQLITE)

--- a/include/utilities/parallel_utils.h
+++ b/include/utilities/parallel_utils.h
@@ -20,14 +20,8 @@
 #define NGEN_MPI_PROTOCOL_TAG 101
 #endif
 
-#include <cstring>
-#include <mpi.h>
 #include <string>
-#include <set>
 #include <vector>
-#if NGEN_WITH_PYTHON
-#include "python/HydrofabricSubsetter.hpp"
-#endif // NGEN_WITH_PYTHON
 
 namespace parallel {
 
@@ -50,37 +44,7 @@ namespace parallel {
      *                 is not in the success/ready state.
      * @return Whether all ranks coordinating status had a success/ready status value.
      */
-    bool mpiSyncStatusAnd(bool status, int mpi_rank, int mpi_num_procs, const std::string &taskDesc) {
-        
-        // Expect 0 is good and 1 is no good for goodCode
-        // TODO: assert this in constructor or somewhere, or maybe just in a unit test
-        unsigned short codeBuffer;
-        bool printMessage = !taskDesc.empty();
-        // For the other ranks, start by properly setting the status code value in the buffer and send to rank 0
-        if (mpi_rank != 0) {
-            codeBuffer = status ? MPI_HF_SUB_CODE_GOOD : MPI_HF_SUB_CODE_BAD;
-            MPI_Send(&codeBuffer, 1, MPI_UNSIGNED_SHORT, 0, 0, MPI_COMM_WORLD);
-        }
-        // In rank 0, the first step is to receive and process codes from the other ranks into unified global status
-        else {
-            for (int i = 1; i < mpi_num_procs; ++i) {
-                MPI_Recv(&codeBuffer, 1, MPI_UNSIGNED_SHORT, i, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-                // If any is ever "not good", overwrite status to be "false"
-                if (codeBuffer != MPI_HF_SUB_CODE_GOOD) {
-                    if (printMessage) {
-                        std::cout << "Rank " << i << " not successful/ready after " << taskDesc << std::endl;
-                    }
-                    status = false;
-                }
-            }
-            // Rank 0 must also now prepare the codeBuffer value for broadcasting the global status
-            codeBuffer = status ? MPI_HF_SUB_CODE_GOOD : MPI_HF_SUB_CODE_BAD;
-        }
-
-        // Execute broadcast of global status rooted at rank 0
-        MPI_Bcast(&codeBuffer, 1, MPI_UNSIGNED_SHORT, 0, MPI_COMM_WORLD);
-        return codeBuffer == MPI_HF_SUB_CODE_GOOD;
-    }
+    bool mpiSyncStatusAnd(bool status, int mpi_rank, int mpi_num_procs, const std::string &taskDesc);
 
     /**
      * Convenience method for overloaded function when no message is needed, and thus no description param provided.
@@ -91,9 +55,7 @@ namespace parallel {
      * @return Whether all ranks coordinating status had a success/ready status value.
      * @see mpiSyncStatusAnd(bool, const std::string&)
      */
-    bool mpiSyncStatusAnd(bool status, int mpi_rank, int mpi_num_procs) {
-        return mpiSyncStatusAnd(status, mpi_rank, mpi_num_procs, "");
-    }
+    bool mpiSyncStatusAnd(bool status, int mpi_rank, int mpi_num_procs);
 
     /**
      * Check whether the parameter hydrofabric files have been subdivided into appropriate per partition files.
@@ -114,21 +76,7 @@ namespace parallel {
      * @return Whether proprocessing has already been performed to divide the main hydrofabric into existing, individual
      *         sub-hydrofabric files for each partition/process.
      */
-    bool is_hydrofabric_subdivided(const std::string &catchmentDataFile, int mpi_rank, int mpi_num_procs, bool printMsg) {
-        std::string name = catchmentDataFile + "." + std::to_string(mpi_rank);
-        // Initialize isGood based on local state.  Here, local file is "good" when it already exists.
-        // TODO: this isn't actually checking whether the files are right (just that they are present) so do we need to?
-        bool isGood = utils::FileChecker::file_is_readable(name);
-
-        if (mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs)) {
-            if (printMsg) { std::cout << "Process " << mpi_rank << ": Hydrofabric already subdivided in " << mpi_num_procs << " files." << std::endl; }
-            return true;
-        }
-        else {
-            if (printMsg) { std::cout << "Process " << mpi_rank << ": Hydrofabric has not yet been subdivided." << std::endl; }
-            return false;
-        }
-    }
+    bool is_hydrofabric_subdivided(const std::string &catchmentDataFile, int mpi_rank, int mpi_num_procs, bool printMsg);
 
     /**
      * Set each rank's host "id" value in a provided host array.
@@ -145,78 +93,7 @@ namespace parallel {
      * @param mpi_num_procs The number of ranks.
      * @param host_array A pointer to an allocated array of size ``mpi_num_procs``.
      */
-    void get_hosts_array(int mpi_rank, int mpi_num_procs, int *host_array) {
-        const int ROOT_RANK = 0;
-        // These are the lengths of the (trimmed) C-string representations of the hostname for each rank
-        std::vector<int> actualHostnameCStrLength(mpi_num_procs);
-        // Initialize to -1 to represent unknown
-        for (int i = 0; i < mpi_num_procs; ++i) {
-            actualHostnameCStrLength[i] = -1;
-        }
-
-        // Get this rank's hostname (things should never be longer than 256)
-        char myhostname[256];
-        gethostname(myhostname, 256);
-
-        // Set the one for this rank
-        actualHostnameCStrLength[mpi_rank] = std::strlen(myhostname);
-
-        // First, gather the hostname string lengths
-        MPI_Gather(&actualHostnameCStrLength[mpi_rank], 1, MPI_INT, actualHostnameCStrLength.data(), 1, MPI_INT, ROOT_RANK,
-                   MPI_COMM_WORLD);
-        // Per-rank start offsets/displacements in our hostname strings gather buffer.
-        std::vector<int> recvDisplacements(mpi_num_procs);
-        int totalLength = 0;
-        for (int i = 0; i < mpi_num_procs; ++i) {
-            // Displace each rank's string by the sum of the length of the previous rank strings
-            recvDisplacements[i] = totalLength;
-            // Adding the extra to make space for the \0
-            actualHostnameCStrLength[i] += 1;
-            // Then update the total length
-            totalLength += actualHostnameCStrLength[i];
-
-        }
-        // Now we can create our buffer array and gather the hostname strings into it
-        char hostnames[totalLength];
-        MPI_Gatherv(myhostname, actualHostnameCStrLength[mpi_rank], MPI_CHAR, hostnames, actualHostnameCStrLength.data(),
-                    recvDisplacements.data(), MPI_CHAR, ROOT_RANK, MPI_COMM_WORLD);
-
-        if (mpi_rank == ROOT_RANK) {
-            host_array[0] = 0;
-            int next_host_id = 1;
-
-            int rank_with_matching_hostname;
-            char *checked_rank_hostname, *known_rank_hostname;
-
-            for (int rank_being_check = 0; rank_being_check < mpi_num_procs; ++rank_being_check) {
-                // Set this as negative initially for each rank check to indicate no match found (at least yet)
-                rank_with_matching_hostname = -1;
-                // Get a C-string pointer for this rank's hostname, offset by the appropriate displacement
-                checked_rank_hostname = &hostnames[recvDisplacements[rank_being_check]];
-
-                // Assume that hostnames for any ranks less than the current rank being check are already known
-                for (int known_rank = 0; known_rank < rank_being_check; ++known_rank) {
-                    // Get the right C-string pointer for the current known rank's hostname also
-                    known_rank_hostname = &hostnames[recvDisplacements[known_rank]];
-                    // Compare the hostnames, setting and breaking if a match is found
-                    if (std::strcmp(known_rank_hostname, checked_rank_hostname) == 0) {
-                        rank_with_matching_hostname = known_rank;
-                        break;
-                    }
-                }
-                // This indicates this rank had no earlier rank with a matching hostname.
-                if (rank_with_matching_hostname < 0) {
-                    // Assign new host id, then increment what the next id will be
-                    host_array[rank_being_check] = next_host_id++;
-                }
-                else {
-                    host_array[rank_being_check] = host_array[rank_with_matching_hostname];
-                }
-            }
-        }
-        // Now, broadcast the results out
-        MPI_Bcast(host_array, mpi_num_procs, MPI_INT, 0, MPI_COMM_WORLD);
-    }
+    void get_hosts_array(int mpi_rank, int mpi_num_procs, int *host_array);
 
     /**
      * Send the contents of a text file to another MPI rank.
@@ -228,58 +105,7 @@ namespace parallel {
      * @param destRank The MPI rank to which the file data should be sent.
      * @return Whether sending was successful.
      */
-    bool mpi_send_text_file(const char *fileName, const int mpi_rank, const int destRank) {
-        int bufSize = 4096;
-        std::vector<char> buf(bufSize);
-        int code;
-        // How much has been transferred so far
-        int totalNumTransferred = 0;
-
-        FILE *file = fopen(fileName, "r");
-
-        // Transmit error code instead of expected size and return false if file can't be opened
-        if (file == NULL) {
-            // TODO: output error message
-            code = -1;
-            MPI_Send(&code, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-            return false;
-        }
-
-        // Send expected size to start
-        MPI_Send(&bufSize, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-
-        // Then get back expected size to infer other side is good to go
-        MPI_Recv(&code, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-        if (code != bufSize) {
-            // TODO: output error message
-            fclose(file);
-            return false;
-        }
-        int continueCode = 1;
-        // Then while there is more of the file to read and send, read the next batch and ...
-        while (fgets(buf.data(), bufSize, file) != NULL) {
-            // Indicate we are ready to continue sending data
-            MPI_Send(&continueCode, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-
-            // Send this batch
-            MPI_Send(buf.data(), bufSize, MPI_CHAR, destRank, NGEN_MPI_DATA_TAG, MPI_COMM_WORLD);
-
-            // Then get back a code, which will be -1 if bad and need to exit and otherwise good
-            MPI_Recv(&code, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-            if (code < 0) {
-                // TODO: output error message
-                fclose(file);
-                return false;
-            }
-        }
-        // Once there is no more file to read and send, we should stop continuing
-        continueCode = 0;
-        MPI_Send(&continueCode, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-        // Expect to get back a code of 0
-        MPI_Recv(&code, 1, MPI_INT, destRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-        fclose(file);
-        return code == 0;
-    }
+    bool mpi_send_text_file(const char *fileName, const int mpi_rank, const int destRank);
 
     /**
      * Receive text data from another MPI rank and write the contents to a text file.
@@ -293,58 +119,7 @@ namespace parallel {
      * @param destRank The MPI rank to which the file data should be sent.
      * @return Whether sending was successful.
      */
-    bool mpi_recv_text_file(const char *fileName, const int mpi_rank, const int srcRank) {
-        int bufSize, writeCode;
-        // Receive expected buffer size to start
-        MPI_Recv(&bufSize, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-        // If the sending side couldn't open the file, then immediately return false
-        if (bufSize == -1) {
-            // TODO: output error
-            return false;
-        }
-
-        // Try to open recv file ...
-        FILE *file = fopen(fileName, "w");
-        // ... and let sending size know whether this was successful by sending error code if not ...
-        if (file == NULL) {
-            // TODO: output error message
-            bufSize = -1;
-            MPI_Send(&bufSize, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-            return false;
-        }
-
-        // Send back the received buffer it if file opened, confirming things are good to go for transfer
-        MPI_Send(&bufSize, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-
-        // How much has been transferred so far
-        int totalNumTransferred = 0;
-        std::vector<char> buf(bufSize);
-
-        int continueCode;
-
-        while (true) {
-            // Make sure the other side wants to continue sending data
-            MPI_Recv(&continueCode, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-            if (continueCode <= 0)
-                break;
-
-            MPI_Recv(buf.data(), bufSize, MPI_CHAR, srcRank, NGEN_MPI_DATA_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-            writeCode = fputs(buf.data(), file);
-            MPI_Send(&writeCode, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-
-            if (writeCode < 0) {
-                fclose(file);
-                return false;
-            }
-        }
-
-        fclose(file);
-        MPI_Send(&continueCode, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
-        return true;
-    }
-
+    bool mpi_recv_text_file(const char *fileName, const int mpi_rank, const int srcRank);
 
     /**
      * Distribute subdivided hydrofabric files to ranks on other hosts as needed.
@@ -397,51 +172,7 @@ namespace parallel {
      */
     bool distribute_subdivided_hydrofabric_files(const std::string &baseCatchmentFile, const std::string &baseNexusFile,
                                                  const int sendingRank, const int mpi_rank, const int mpi_num_procs,
-                                                 const int *hostIdForRank, bool syncReturnStatus, bool blockAll)
-    {
-        // Start with status as good
-        bool isGood = true;
-        // FIXME: For now, just have rank 0 send everything, but optimize with multiple procs or threads later
-        // Only need to process this if sending rank or a receiving ranks (i.e., not on same host as sending rank)
-        if (mpi_rank == sendingRank || hostIdForRank[mpi_rank] != hostIdForRank[sendingRank]) {
-            // Have the sending rank send out all files
-            if (mpi_rank == sendingRank) {
-                // In rank 0, for all the other ranks ...
-                for (int otherRank = 0; otherRank < mpi_num_procs; ++otherRank) {
-                    // If another rank is on a different host (note that this covers otherRank == sendingRank case) ...
-                    if (hostIdForRank[otherRank] != hostIdForRank[mpi_rank]) {
-                        // ... then send that rank its rank-specific catchment and nexus files
-                        std::string catFileToSend = baseCatchmentFile + "." + std::to_string(otherRank);
-                        std::string nexFileToSend = baseNexusFile + "." + std::to_string(otherRank);
-                        // Note that checking previous isGood is necessary here because of loop
-                        isGood = isGood && mpi_send_text_file(catFileToSend.c_str(), mpi_rank, otherRank);
-                        isGood = isGood && mpi_send_text_file(nexFileToSend.c_str(), mpi_rank, otherRank);
-                    }
-                }
-            }
-            else {
-                // For a rank not on the same host as the sending rank, receive the transmitted file
-                std::string catFileToReceive = baseCatchmentFile + "." + std::to_string(mpi_rank);
-                std::string nexFileToReceive = baseNexusFile + "." + std::to_string(mpi_rank);
-                // Note that, unlike a bit earlier, don't need to check prior isGood in 1st receive, because not in loop
-                isGood = mpi_recv_text_file(catFileToReceive.c_str(), mpi_rank, sendingRank);
-                isGood = isGood && mpi_recv_text_file(nexFileToReceive.c_str(), mpi_rank, sendingRank);
-            }
-        }
-
-        // Wait when appropriate
-        if (blockAll) { MPI_Barrier(MPI_COMM_WORLD); }
-
-        // Sync status among the ranks also, if appropriate
-        if (syncReturnStatus) {
-            return mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "distributing subdivided hydrofabric files");
-        }
-        // Otherwise, just return the local status value
-        else {
-            return isGood;
-        }
-    }
-
+                                                 const int *hostIdForRank, bool syncReturnStatus, bool blockAll);
 
     /**
      * Attempt to subdivide the passed hydrofabric files into a series of per-partition files.
@@ -458,70 +189,27 @@ namespace parallel {
      * @return Whether subdividing was successful.
      */
     bool subdivide_hydrofabric(int mpi_rank, int mpi_num_procs, const std::string &catchmentDataFile,
-                               const std::string &nexusDataFile, const std::string &partitionConfigFile)
-    {
-        // Track whether things are good, meaning ok to continue and, at the end, whether successful
-        // Start with a value of true
-        bool isGood = true;
+                               const std::string &nexusDataFile, const std::string &partitionConfigFile);
 
-        #if !NGEN_WITH_PYTHON
-        // We can't be good to proceed with this, because Python is not active
-        isGood = false;
-        std::cerr << "Driver is unable to perform required hydrofabric subdividing when Python integration is not active." << std::endl;
+    /**
+     * MPI_Gather vector<string> values from all processes. The result may include duplicate values.
+     * 
+     * @param local_strings Vector of strings from the current process
+     * @param mpi_rank Rank of the current process
+     * @param mpi_num_procs Number of processes
+     * @return A vector of the gathered strings from all processes. This will only be populated if mpi_rank == 0
+     */
+    std::vector<std::string> gather_strings(const std::vector<std::string>& local_strings, int mpi_rank, int mpi_num_procs);
 
-
-        // Sync with the rest of the ranks and bail if any aren't ready to proceed for any reason
-        if (!mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "initializing hydrofabric subdivider")) {
-            return false;
-        }
-        #else // i.e., #if NGEN_WITH_PYTHON
-        // Have rank 0 handle the generation task for all files/partitions
-        std::unique_ptr<utils::ngenPy::HydrofabricSubsetter> subdivider;
-        // Have rank 0 handle the generation task for all files/partitions
-        if (mpi_rank == 0) {
-            try {
-                subdivider = std::make_unique<utils::ngenPy::HydrofabricSubsetter>(catchmentDataFile, nexusDataFile,
-                                                                                   partitionConfigFile);
-            }
-            catch (const std::exception &e) {
-                std::cerr << e.what() << std::endl;
-                // Set not good if the subdivider object couldn't be instantiated
-                isGood = false;
-            }
-        }
-        // Sync ranks and bail if any aren't ready to proceed for any reason
-        if (!mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "initializing hydrofabric subdivider")) {
-            return false;
-        }
-
-        if (mpi_rank == 0) {
-            // Try to perform the subdividing
-            try {
-                isGood = subdivider->execSubdivision();
-            }
-            catch (const std::exception &e) {
-                std::cerr << e.what() << std::endl;
-                // Set not good if the subdivider object couldn't be instantiated
-                isGood = false;
-            }
-        }
-        // Sync ranks again here on whether subdividing was successful, having them all exit at this point if not
-        if (!mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "executing hydrofabric subdivision")) {
-            return false;
-        }
-        // But if the subdividing went fine ...
-        else {
-            // ... figure out what ranks are on hosts with each other by getting an id for host of each rank
-            std::vector<int> hostIdForRank(mpi_num_procs);
-            get_hosts_array(mpi_rank, mpi_num_procs, hostIdForRank.data());
-
-            // ... then (when necessary) transferring files around
-            return distribute_subdivided_hydrofabric_files(catchmentDataFile, nexusDataFile, 0, mpi_rank,
-                                                           mpi_num_procs, hostIdForRank.data(), true, true);
-
-        }
-        #endif // NGEN_WITH_PYTHON
-    }
+    /**
+     * Send a vector<string> from root to all other processes.
+     * 
+     * @param strings If mpi_rank == 0, the strings that will be broadcasted. Unused for other processes.
+     * @param mpi_rank Rank of the current process
+     * @param mpi_num_procs Number of processes
+     * @return vector<string> of the broadcasted strings from mpi_rank == 0
+     */
+    std::vector<std::string> broadcast_strings(const std::vector<std::string>& strings, int mpi_rank, int mpi_num_procs);
 }
 
 #endif // NGEN_WITH_MPI

--- a/include/utilities/parallel_utils.h
+++ b/include/utilities/parallel_utils.h
@@ -106,6 +106,7 @@ namespace parallel {
      * ``catchmentDataFile`` and ``nexusDataFile`` variables respectively.  The number of MPI processes is obtained from
      * the global ``mpi_rank`` variable.
      *
+     * @param catchmentDataFile The path to the catchment data file for the hydrofabric.
      * @param mpi_rank The rank of the current process.
      * @param mpi_num_procs The total number of MPI processes.
      * @param printMessage Whether a supplemental message should be printed to standard out indicating status.
@@ -113,7 +114,7 @@ namespace parallel {
      * @return Whether proprocessing has already been performed to divide the main hydrofabric into existing, individual
      *         sub-hydrofabric files for each partition/process.
      */
-    bool is_hydrofabric_subdivided(int mpi_rank, int mpi_num_procs, bool printMsg) {
+    bool is_hydrofabric_subdivided(const std::string &catchmentDataFile, int mpi_rank, int mpi_num_procs, bool printMsg) {
         std::string name = catchmentDataFile + "." + std::to_string(mpi_rank);
         // Initialize isGood based on local state.  Here, local file is "good" when it already exists.
         // TODO: this isn't actually checking whether the files are right (just that they are present) so do we need to?
@@ -127,19 +128,6 @@ namespace parallel {
             if (printMsg) { std::cout << "Process " << mpi_rank << ": Hydrofabric has not yet been subdivided." << std::endl; }
             return false;
         }
-    }
-
-    /**
-     * Convenience overloaded method for when no supplemental output message is required.
-     *
-     * @param mpi_rank The rank of the current process.
-     * @param mpi_num_procs The total number of MPI processes.
-     * @return Whether proprocessing has already been performed to divide the main hydrofabric into existing, individual
-     *         sub-hydrofabric files for each partition/process.
-     * @see is_hydrofabric_subdivided(bool)
-     */
-    bool is_hydrofabric_subdivided(int mpi_rank, int mpi_num_procs) {
-        return is_hydrofabric_subdivided(mpi_rank, mpi_num_procs, false);
     }
 
     /**

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -33,11 +33,6 @@
 #include "routing/Routing_Py_Adapter.hpp"
 #endif // NGEN_WITH_ROUTING
 
-std::string catchmentDataFile = "";
-std::string nexusDataFile = "";
-std::string REALIZATION_CONFIG_PATH = "";
-bool is_subdivided_hydrofabric_wanted = false;
-
 // Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
 int mpi_rank = 0;
 
@@ -138,7 +133,11 @@ void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept
 
 } // ngen::exec_info::runtime_summary
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
+    std::string catchmentDataFile         = "";
+    std::string nexusDataFile             = "";
+    std::string REALIZATION_CONFIG_PATH   = "";
+    bool is_subdivided_hydrofabric_wanted = false;
 
     if (argc > 1 && std::string{argv[1]} == "--info") {
         #if NGEN_WITH_MPI
@@ -307,11 +306,16 @@ int main(int argc, char *argv[]) {
 
         // Do some extra steps if we expect to load a subdivided hydrofabric
         if (is_subdivided_hydrofabric_wanted) {
-            // Ensure the hydrofabric is subdivided (either already or by doing it now), and then adjust these paths
-            if (parallel::is_hydrofabric_subdivided(mpi_rank, mpi_num_procs, true) ||
-                parallel::subdivide_hydrofabric(mpi_rank, mpi_num_procs, catchmentDataFile, nexusDataFile,
-                                                PARTITION_PATH))
-            {
+            // Ensure the hydrofabric is subdivided (either already or by doing it now), and then
+            // adjust these paths
+            if (parallel::is_hydrofabric_subdivided(catchmentDataFile, mpi_rank, mpi_num_procs, true) ||
+                parallel::subdivide_hydrofabric(
+                    mpi_rank,
+                    mpi_num_procs,
+                    catchmentDataFile,
+                    nexusDataFile,
+                    PARTITION_PATH
+                )) {
                 catchmentDataFile += "." + std::to_string(mpi_rank);
                 nexusDataFile += "." + std::to_string(mpi_rank);
             }

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_library(ngen_parallel)
+add_library(NGen::parallel ALIAS ngen_parallel)
+
+target_include_directories(ngen_parallel
+  PUBLIC
+    ${NGEN_INC_DIR}
+)
+
+target_link_libraries(ngen_parallel
+  PUBLIC
+    NGen::config_header
+    NGen::logging
+)
+
+if(NGEN_WITH_MPI)
+  target_link_libraries(ngen_parallel
+    PUBLIC
+      MPI::MPI_C
+      Boost::boost
+  )
+  if(NGEN_WITH_PYTHON)
+    target_link_libraries(ngen_parallel
+      PUBLIC
+        pybind11::embed
+    )
+  endif()
+endif()
+
+target_sources(ngen_parallel
+  PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/parallel_utils.cpp"
+)

--- a/src/utilities/parallel_utils.cpp
+++ b/src/utilities/parallel_utils.cpp
@@ -1,0 +1,460 @@
+#include <utilities/parallel_utils.h>
+
+#if NGEN_WITH_MPI
+
+#include <cstring>
+#include <mpi.h>
+#include <utilities/FileChecker.h>
+
+#if NGEN_WITH_PYTHON
+#include "utilities/python/HydrofabricSubsetter.hpp"
+#endif // NGEN_WITH_PYTHON
+
+namespace parallel {
+    bool mpiSyncStatusAnd(bool status, int mpi_rank, int mpi_num_procs, const std::string &taskDesc) {
+        // Expect 0 is good and 1 is no good for goodCode
+        // TODO: assert this in constructor or somewhere, or maybe just in a unit test
+        unsigned short codeBuffer;
+        bool printMessage = !taskDesc.empty();
+        // For the other ranks, start by properly setting the status code value in the buffer and send to rank 0
+        if (mpi_rank != 0) {
+            codeBuffer = status ? MPI_HF_SUB_CODE_GOOD : MPI_HF_SUB_CODE_BAD;
+            MPI_Send(&codeBuffer, 1, MPI_UNSIGNED_SHORT, 0, 0, MPI_COMM_WORLD);
+        }
+        // In rank 0, the first step is to receive and process codes from the other ranks into unified global status
+        else {
+            for (int i = 1; i < mpi_num_procs; ++i) {
+                MPI_Recv(&codeBuffer, 1, MPI_UNSIGNED_SHORT, i, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                // If any is ever "not good", overwrite status to be "false"
+                if (codeBuffer != MPI_HF_SUB_CODE_GOOD) {
+                    if (printMessage) {
+                        std::cerr << "Rank " << i << " not successful/ready after " << taskDesc << std::endl;
+                    }
+                    status = false;
+                }
+            }
+            // Rank 0 must also now prepare the codeBuffer value for broadcasting the global status
+            codeBuffer = status ? MPI_HF_SUB_CODE_GOOD : MPI_HF_SUB_CODE_BAD;
+        }
+
+        // Execute broadcast of global status rooted at rank 0
+        MPI_Bcast(&codeBuffer, 1, MPI_UNSIGNED_SHORT, 0, MPI_COMM_WORLD);
+        return codeBuffer == MPI_HF_SUB_CODE_GOOD;
+    }
+
+    bool mpiSyncStatusAnd(bool status, int mpi_rank, int mpi_num_procs) {
+        return mpiSyncStatusAnd(status, mpi_rank, mpi_num_procs, "");
+    }
+
+    bool is_hydrofabric_subdivided(const std::string &catchmentDataFile, int mpi_rank, int mpi_num_procs, bool printMsg) {
+        std::string name = catchmentDataFile + "." + std::to_string(mpi_rank);
+        // Initialize isGood based on local state.  Here, local file is "good" when it already exists.
+        // TODO: this isn't actually checking whether the files are right (just that they are present) so do we need to?
+        bool isGood = utils::FileChecker::file_is_readable(name);
+
+        if (mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs)) {
+            if (printMsg) {
+                std::cerr << "Process " << mpi_rank << ": Hydrofabric already subdivided in " << mpi_num_procs << " files." << std::endl;
+            }
+            return true;
+        }
+        else {
+            if (printMsg) {
+                std::cerr << "Process " << mpi_rank << ": Hydrofabric has not yet been subdivided." << std::endl;
+            }
+            return false;
+        }
+    }
+
+    void get_hosts_array(int mpi_rank, int mpi_num_procs, int *host_array) {
+        const int ROOT_RANK = 0;
+        // These are the lengths of the (trimmed) C-string representations of the hostname for each rank
+        std::vector<int> actualHostnameCStrLength(mpi_num_procs);
+        // Initialize to -1 to represent unknown
+        for (int i = 0; i < mpi_num_procs; ++i) {
+            actualHostnameCStrLength[i] = -1;
+        }
+
+        // Get this rank's hostname (things should never be longer than 256)
+        char myhostname[256];
+        gethostname(myhostname, 256);
+
+        // Set the one for this rank
+        actualHostnameCStrLength[mpi_rank] = std::strlen(myhostname);
+
+        // First, gather the hostname string lengths
+        MPI_Gather(&actualHostnameCStrLength[mpi_rank], 1, MPI_INT, actualHostnameCStrLength.data(), 1, MPI_INT, ROOT_RANK,
+                   MPI_COMM_WORLD);
+        // Per-rank start offsets/displacements in our hostname strings gather buffer.
+        std::vector<int> recvDisplacements(mpi_num_procs);
+        int totalLength = 0;
+        for (int i = 0; i < mpi_num_procs; ++i) {
+            // Displace each rank's string by the sum of the length of the previous rank strings
+            recvDisplacements[i] = totalLength;
+            // Adding the extra to make space for the \0
+            actualHostnameCStrLength[i] += 1;
+            // Then update the total length
+            totalLength += actualHostnameCStrLength[i];
+
+        }
+        // Now we can create our buffer array and gather the hostname strings into it
+        char hostnames[totalLength];
+        MPI_Gatherv(myhostname, actualHostnameCStrLength[mpi_rank], MPI_CHAR, hostnames, actualHostnameCStrLength.data(),
+                    recvDisplacements.data(), MPI_CHAR, ROOT_RANK, MPI_COMM_WORLD);
+
+        if (mpi_rank == ROOT_RANK) {
+            host_array[0] = 0;
+            int next_host_id = 1;
+
+            int rank_with_matching_hostname;
+            char *checked_rank_hostname, *known_rank_hostname;
+
+            for (int rank_being_check = 0; rank_being_check < mpi_num_procs; ++rank_being_check) {
+                // Set this as negative initially for each rank check to indicate no match found (at least yet)
+                rank_with_matching_hostname = -1;
+                // Get a C-string pointer for this rank's hostname, offset by the appropriate displacement
+                checked_rank_hostname = &hostnames[recvDisplacements[rank_being_check]];
+
+                // Assume that hostnames for any ranks less than the current rank being check are already known
+                for (int known_rank = 0; known_rank < rank_being_check; ++known_rank) {
+                    // Get the right C-string pointer for the current known rank's hostname also
+                    known_rank_hostname = &hostnames[recvDisplacements[known_rank]];
+                    // Compare the hostnames, setting and breaking if a match is found
+                    if (std::strcmp(known_rank_hostname, checked_rank_hostname) == 0) {
+                        rank_with_matching_hostname = known_rank;
+                        break;
+                    }
+                }
+                // This indicates this rank had no earlier rank with a matching hostname.
+                if (rank_with_matching_hostname < 0) {
+                    // Assign new host id, then increment what the next id will be
+                    host_array[rank_being_check] = next_host_id++;
+                }
+                else {
+                    host_array[rank_being_check] = host_array[rank_with_matching_hostname];
+                }
+            }
+        }
+        // Now, broadcast the results out
+        MPI_Bcast(host_array, mpi_num_procs, MPI_INT, 0, MPI_COMM_WORLD);
+    }
+
+    bool mpi_send_text_file(const char *fileName, const int mpi_rank, const int destRank) {
+        int bufSize = 4096;
+        std::vector<char> buf(bufSize);
+        int code;
+        // How much has been transferred so far
+        int totalNumTransferred = 0;
+
+        FILE *file = fopen(fileName, "r");
+
+        // Transmit error code instead of expected size and return false if file can't be opened
+        if (file == NULL) {
+            // TODO: output error message
+            code = -1;
+            MPI_Send(&code, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+            return false;
+        }
+
+        // Send expected size to start
+        MPI_Send(&bufSize, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+
+        // Then get back expected size to infer other side is good to go
+        MPI_Recv(&code, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        if (code != bufSize) {
+            // TODO: output error message
+            fclose(file);
+            return false;
+        }
+        int continueCode = 1;
+        // Then while there is more of the file to read and send, read the next batch and ...
+        while (fgets(buf.data(), bufSize, file) != NULL) {
+            // Indicate we are ready to continue sending data
+            MPI_Send(&continueCode, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+
+            // Send this batch
+            MPI_Send(buf.data(), bufSize, MPI_CHAR, destRank, NGEN_MPI_DATA_TAG, MPI_COMM_WORLD);
+
+            // Then get back a code, which will be -1 if bad and need to exit and otherwise good
+            MPI_Recv(&code, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            if (code < 0) {
+                // TODO: output error message
+                fclose(file);
+                return false;
+            }
+        }
+        // Once there is no more file to read and send, we should stop continuing
+        continueCode = 0;
+        MPI_Send(&continueCode, 1, MPI_INT, destRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+        // Expect to get back a code of 0
+        MPI_Recv(&code, 1, MPI_INT, destRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        fclose(file);
+        return code == 0;
+    }
+
+    bool mpi_recv_text_file(const char *fileName, const int mpi_rank, const int srcRank) {
+        int bufSize, writeCode;
+        // Receive expected buffer size to start
+        MPI_Recv(&bufSize, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+        // If the sending side couldn't open the file, then immediately return false
+        if (bufSize == -1) {
+            // TODO: output error
+            return false;
+        }
+
+        // Try to open recv file ...
+        FILE *file = fopen(fileName, "w");
+        // ... and let sending size know whether this was successful by sending error code if not ...
+        if (file == NULL) {
+            // TODO: output error message
+            bufSize = -1;
+            MPI_Send(&bufSize, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+            return false;
+        }
+
+        // Send back the received buffer it if file opened, confirming things are good to go for transfer
+        MPI_Send(&bufSize, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+
+        // How much has been transferred so far
+        int totalNumTransferred = 0;
+        std::vector<char> buf(bufSize);
+
+        int continueCode;
+
+        while (true) {
+            // Make sure the other side wants to continue sending data
+            MPI_Recv(&continueCode, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            if (continueCode <= 0)
+                break;
+
+            MPI_Recv(buf.data(), bufSize, MPI_CHAR, srcRank, NGEN_MPI_DATA_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+            writeCode = fputs(buf.data(), file);
+            MPI_Send(&writeCode, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+
+            if (writeCode < 0) {
+                fclose(file);
+                return false;
+            }
+        }
+
+        fclose(file);
+        MPI_Send(&continueCode, 1, MPI_INT, srcRank, NGEN_MPI_PROTOCOL_TAG, MPI_COMM_WORLD);
+        return true;
+    }
+
+    bool distribute_subdivided_hydrofabric_files(const std::string &baseCatchmentFile, const std::string &baseNexusFile,
+                                                 const int sendingRank, const int mpi_rank, const int mpi_num_procs,
+                                                 const int *hostIdForRank, bool syncReturnStatus, bool blockAll)
+    {
+        // Start with status as good
+        bool isGood = true;
+        // FIXME: For now, just have rank 0 send everything, but optimize with multiple procs or threads later
+        // Only need to process this if sending rank or a receiving ranks (i.e., not on same host as sending rank)
+        if (mpi_rank == sendingRank || hostIdForRank[mpi_rank] != hostIdForRank[sendingRank]) {
+            // Have the sending rank send out all files
+            if (mpi_rank == sendingRank) {
+                // In rank 0, for all the other ranks ...
+                for (int otherRank = 0; otherRank < mpi_num_procs; ++otherRank) {
+                    // If another rank is on a different host (note that this covers otherRank == sendingRank case) ...
+                    if (hostIdForRank[otherRank] != hostIdForRank[mpi_rank]) {
+                        // ... then send that rank its rank-specific catchment and nexus files
+                        std::string catFileToSend = baseCatchmentFile + "." + std::to_string(otherRank);
+                        std::string nexFileToSend = baseNexusFile + "." + std::to_string(otherRank);
+                        // Note that checking previous isGood is necessary here because of loop
+                        isGood = isGood && mpi_send_text_file(catFileToSend.c_str(), mpi_rank, otherRank);
+                        isGood = isGood && mpi_send_text_file(nexFileToSend.c_str(), mpi_rank, otherRank);
+                    }
+                }
+            }
+            else {
+                // For a rank not on the same host as the sending rank, receive the transmitted file
+                std::string catFileToReceive = baseCatchmentFile + "." + std::to_string(mpi_rank);
+                std::string nexFileToReceive = baseNexusFile + "." + std::to_string(mpi_rank);
+                // Note that, unlike a bit earlier, don't need to check prior isGood in 1st receive, because not in loop
+                isGood = mpi_recv_text_file(catFileToReceive.c_str(), mpi_rank, sendingRank);
+                isGood = isGood && mpi_recv_text_file(nexFileToReceive.c_str(), mpi_rank, sendingRank);
+            }
+        }
+
+        // Wait when appropriate
+        if (blockAll) { MPI_Barrier(MPI_COMM_WORLD); }
+
+        // Sync status among the ranks also, if appropriate
+        if (syncReturnStatus) {
+            return mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "distributing subdivided hydrofabric files");
+        }
+        // Otherwise, just return the local status value
+        else {
+            return isGood;
+        }
+    }
+
+    bool subdivide_hydrofabric(int mpi_rank, int mpi_num_procs, const std::string &catchmentDataFile,
+                               const std::string &nexusDataFile, const std::string &partitionConfigFile)
+    {
+        // Track whether things are good, meaning ok to continue and, at the end, whether successful
+        // Start with a value of true
+        bool isGood = true;
+
+        #if !NGEN_WITH_PYTHON
+        // We can't be good to proceed with this, because Python is not active
+        isGood = false;
+        std::cerr  << "Driver is unable to perform required hydrofabric subdividing when Python integration is not active." << std::endl;
+
+        // Sync with the rest of the ranks and bail if any aren't ready to proceed for any reason
+        if (!mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "initializing hydrofabric subdivider")) {
+            return false;
+        }
+        #else // i.e., #if NGEN_WITH_PYTHON
+        // Have rank 0 handle the generation task for all files/partitions
+        std::unique_ptr<utils::ngenPy::HydrofabricSubsetter> subdivider;
+        // Have rank 0 handle the generation task for all files/partitions
+        if (mpi_rank == 0) {
+            try {
+                subdivider = std::make_unique<utils::ngenPy::HydrofabricSubsetter>(catchmentDataFile, nexusDataFile,
+                                                                                   partitionConfigFile);
+            }
+            catch (const std::exception &e) {
+                std::cerr  << e.what() << std::endl;
+                // Set not good if the subdivider object couldn't be instantiated
+                isGood = false;
+            }
+        }
+        // Sync ranks and bail if any aren't ready to proceed for any reason
+        if (!mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "initializing hydrofabric subdivider")) {
+            return false;
+        }
+
+        if (mpi_rank == 0) {
+            // Try to perform the subdividing
+            try {
+                isGood = subdivider->execSubdivision();
+            }
+            catch (const std::exception &e) {
+                std::cerr  << e.what() << std::endl;
+                // Set not good if the subdivider object couldn't be instantiated
+                isGood = false;
+            }
+        }
+        // Sync ranks again here on whether subdividing was successful, having them all exit at this point if not
+        if (!mpiSyncStatusAnd(isGood, mpi_rank, mpi_num_procs, "executing hydrofabric subdivision")) {
+            return false;
+        }
+        // But if the subdividing went fine ...
+        else {
+            // ... figure out what ranks are on hosts with each other by getting an id for host of each rank
+            std::vector<int> hostIdForRank(mpi_num_procs);
+            get_hosts_array(mpi_rank, mpi_num_procs, hostIdForRank.data());
+
+            // ... then (when necessary) transferring files around
+            return distribute_subdivided_hydrofabric_files(catchmentDataFile, nexusDataFile, 0, mpi_rank,
+                                                           mpi_num_procs, hostIdForRank.data(), true, true);
+
+        }
+        #endif // NGEN_WITH_PYTHON
+    }
+
+    std::vector<std::string> gather_strings(const std::vector<std::string>& local_strings, int mpi_rank, int mpi_num_procs) {
+        int root_rank = 0;
+
+        // 1. Determine local string data size
+        int local_data_size = 0;
+        for (const auto& s : local_strings) {
+            local_data_size += s.length() + 1; // +1 for null terminator
+        }
+
+        // 2. Gather all data sizes to root
+        std::vector<int> all_data_sizes(mpi_num_procs); // Only significant at root
+        MPI_Gather(&local_data_size, 1, MPI_INT, all_data_sizes.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+        // 3. Calculate displacements and total size at root
+        std::vector<int> displs(mpi_num_procs); // Only significant at root
+        int total_recv_size = 0;
+        if (mpi_rank == root_rank) {
+            displs[0] = 0;
+            total_recv_size = all_data_sizes[0];
+            for (int i = 1; i < mpi_num_procs; ++i) {
+                displs[i] = displs[i-1] + all_data_sizes[i-1];
+                total_recv_size += all_data_sizes[i];
+            }
+        }
+
+        // 4. Allocate receive buffer at root
+        std::vector<char> recv_buffer; // Only significant at root
+        if (mpi_rank == root_rank) {
+            recv_buffer.resize(total_recv_size);
+        }
+
+        // 5. Serialize local strings
+        std::vector<char> send_buffer(local_data_size);
+        int current_offset = 0;
+        for (const auto& s : local_strings) {
+            std::copy(s.begin(), s.end(), send_buffer.begin() + current_offset);
+            send_buffer[current_offset + s.length()] = '\0'; // Null terminator
+            current_offset += s.length() + 1;
+        }
+
+        // 6. Perform MPI_Gatherv
+        MPI_Gatherv(send_buffer.data(), local_data_size, MPI_CHAR,
+                    recv_buffer.data(), all_data_sizes.data(), displs.data(), MPI_CHAR,
+                    root_rank, MPI_COMM_WORLD);
+
+        // 7. Deserialize at root
+        std::vector<std::string> gathered_strings;
+        if (mpi_rank == root_rank) {
+            int current_read_offset = 0;
+            for (int i = 0; i < mpi_num_procs; ++i) {
+                int proc_data_size = all_data_sizes[i];
+                int start_idx = displs[i];
+                int end_idx = start_idx + proc_data_size;
+
+                // Extract strings from this process's data
+                int string_start = start_idx;
+                for (int j = start_idx; j < end_idx; ++j) {
+                    if (recv_buffer[j] == '\0') {
+                        gathered_strings.emplace_back(recv_buffer.data() + string_start,
+                                                      recv_buffer.data() + j);
+                        string_start = j + 1; // Start of next string
+                    }
+                }
+            }
+            // gathered_strings now contains all strings
+        }
+        return gathered_strings;
+    }
+
+    std::vector<std::string> broadcast_strings(const std::vector<std::string>& strings, int mpi_rank, int mpi_num_procs) {
+        int root_rank = 0;
+
+        // 1. Broadcast the size of the vector
+        int vector_size = strings.size();
+        MPI_Bcast(&vector_size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+        std::vector<std::string> out_strings(vector_size);
+
+        // 2. Broadcast the size of each individual string
+        std::vector<int> string_lengths(vector_size);
+        if (mpi_rank == root_rank) {
+            for (int i = 0; i < vector_size; ++i) {
+                string_lengths[i] = strings[i].length() + 1; // +1 for null terminator
+            }
+        }
+        MPI_Bcast(string_lengths.data(), vector_size, MPI_INT, 0, MPI_COMM_WORLD);
+
+        // 3. Broadcast each string individually
+        for (int i = 0; i < vector_size; ++i) {
+            std::vector<char> buffer(string_lengths[i]);
+            if (mpi_rank == root_rank) {
+                std::strcpy(buffer.data(), strings[i].c_str());
+            }
+            MPI_Bcast(buffer.data(), string_lengths[i], MPI_CHAR, 0, MPI_COMM_WORLD);
+            out_strings[i] = buffer.data();
+        }
+
+        return out_strings;
+    }
+} // namespace parallel
+
+#endif // NGEN_WITH_MPI


### PR DESCRIPTION
Move parallel utils source code down to a `.cpp` file, and privatize some variables into NGen `main()` to support later state-saving modifications

## Testing

1. `ctest` and CI passing


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
