### PR TITLE
Import NGWPC Python InterpreterUtil changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ add_subdirectory("src/utilities/mdframe")
 add_subdirectory("src/utilities/logging")
 add_subdirectory("src/utilities/bmi")
 add_subdirectory("src/utilities/output")
+add_subdirectory("src/utilities/python")
 
 target_link_libraries(ngen
     PUBLIC

--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -5,7 +5,6 @@
 
 #if NGEN_WITH_PYTHON
 
-#include <cstdlib>
 #include <map>
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
@@ -32,7 +31,6 @@ namespace utils {
         class InterpreterUtil {
 
         public:
-            static std::shared_ptr<InterpreterUtil> getInstance() {
                 /**
                  * @brief Singleton instance of embedded python interpreter.
                  * 
@@ -54,20 +52,7 @@ namespace utils {
                  * https://github.com/pybind/pybind11/issues/1598
                  * 
                  */
-                //Functionally, a global instance variable
-                //This can be made a class attribute, but would need to find a place to put a single definition
-                //e.g. make a .cpp file
-                static std::weak_ptr<InterpreterUtil> _instance;
-                std::shared_ptr<InterpreterUtil> instance = _instance.lock();
-                if(!instance){
-                    //instance is null
-                    InterpreterUtil* pt = new InterpreterUtil();
-                    instance = std::shared_ptr<InterpreterUtil>(pt, Deleter{});
-                    //update the weak ref
-                    _instance = instance;
-                }
-                return instance;
-            }
+            static std::shared_ptr<InterpreterUtil> getInstance();
 
             struct Deleter {
                 /**
@@ -82,41 +67,7 @@ namespace utils {
             friend Deleter;
 
         private:
-            InterpreterUtil() {
-                guardPtr = std::make_shared<py::scoped_interpreter>();
-                // Go ahead and do these
-                importTopLevelModule("pathlib");
-                importTopLevelModule("sys");
-                Path = importedTopLevelModules["pathlib"].attr("Path");
-
-                py::list venv_package_dirs = getVenvPackagesDirOptions();
-                // Add any found options
-                for (auto &opt : venv_package_dirs) {
-                    addToPath(std::string(py::str(opt.attr("parent"))));
-                    addToPath(std::string(py::str(opt)));
-                }
-
-                py::object python_version_info = importedTopLevelModules["sys"].attr("version_info");
-                py::str runtime_python_version = importedTopLevelModules["sys"].attr("version");
-                int major = py::int_(python_version_info.attr("major"));
-                int minor = py::int_(python_version_info.attr("minor"));
-                int patch = py::int_(python_version_info.attr("micro"));
-                if (major != python_major
-                    || minor != python_minor
-                    || patch != python_patch) {
-                    throw std::runtime_error("Python version mismatch between configure/build ("
-                                             + std::string(python_version)
-                                             + ") and runtime (" + std::string(runtime_python_version) + ")");
-                }
-
-                importTopLevelModule("numpy");
-                py::str runtime_numpy_version = importedTopLevelModules["numpy"].attr("version").attr("version");
-                if(std::string(runtime_numpy_version) != numpy_version) {
-                    throw std::runtime_error("NumPy version mismatch between configure/build ("
-                                             + std::string(numpy_version)
-                                             + ") and runtime (" + std::string(runtime_numpy_version) + ")");
-                }
-            }
+            InterpreterUtil();
 
             ~InterpreterUtil() = default;
 
@@ -131,35 +82,14 @@ namespace utils {
              *
              * @param directoryPath The desired directory to add to the Python system path.
              */
-            static void addToPyPath(const std::string &directoryPath) {
-                getInstance()->addToPath(directoryPath);
-            }
+            static void addToPyPath(const std::string &directoryPath);
 
             /**
              * Add to the Python system path of this instance.
              *
              * @param directoryPath The desired directory to add to the Python system path.
              */
-            void addToPath(const std::string &directoryPath) {
-                std::tuple<py::list, std::vector<std::string>> sysPathTuple = getSystemPath();
-                py::list sys_path = std::get<0>(sysPathTuple);
-                std::vector<std::string> sys_path_vector = std::get<1>(sysPathTuple);
-
-                py::object requestedDirPath = Path(directoryPath);
-                if (py::bool_(requestedDirPath.attr("is_dir")())) {
-                    if (std::find(sys_path_vector.begin(), sys_path_vector.end(), directoryPath) == sys_path_vector.end()) {
-#ifdef __APPLE__
-                        sys_path.attr("insert")(1, py::str(directoryPath));
-#else
-                        sys_path.attr("insert")(sys_path_vector.size(), py::str(directoryPath));
-#endif
-                    }
-                }
-                else {
-                    std::string dirPath = py::str(requestedDirPath);
-                    throw std::runtime_error("Cannot add non-existing directory '" + dirPath + "' to Python PATH");
-                }
-            }
+            void addToPath(const std::string &directoryPath);
 
             /**
              * Return bound Python top level module handle from the singleton instance, importing the module if needed.
@@ -171,9 +101,7 @@ namespace utils {
              * @param name Name of the desired top level module or package.
              * @return Handle to the desired top level Python module.
              */
-            static py::object getPyModule(const std::string &name) {
-                return getInstance()->getModule(name);
-            }
+            static py::object getPyModule(const std::string &name);
 
             /**
              * Return bound Python module handle from the singleton instance, importing a top-level module if necessary.
@@ -189,9 +117,7 @@ namespace utils {
              *                         and (when applicable) submodules.
              * @return Handle to the desired Python module or type.
              */
-            static py::object getPyModule(const std::vector<std::string> &moduleLevelNames) {
-                return getInstance()->getModule(moduleLevelNames);
-            }
+            static py::object getPyModule(const std::vector<std::string> &moduleLevelNames);
 
             /**
              * Return a bound handle to a top-level Python module, importing the module if necessary.
@@ -203,12 +129,7 @@ namespace utils {
              * @param name Name of the desired top level module or namespace package.
              * @return Handle to the desired top level Python module.
              */
-            py::object getModule(const std::string &name) {
-                if (!isImported(name)) {
-                    importTopLevelModule(name);
-                }
-                return importedTopLevelModules.find(name)->second;
-            }
+            py::object getModule(const std::string &name);
 
             /**
              * Return a bound handle to a Python module or type, importing the top-level module if necessary.
@@ -220,14 +141,7 @@ namespace utils {
              *                         and (when applicable) submodules.
              * @return Handle to the desired Python module or type.
              */
-            py::object getModule(const std::vector<std::string> &moduleLevelNames) {
-                // Start with top-level module name, then descend through attributes as needed
-                py::object module = getModule(moduleLevelNames[0]);
-                for (size_t i = 1; i < moduleLevelNames.size(); ++i) {
-                    module = module.attr(moduleLevelNames[i].c_str());
-                }
-                return module;
-            }
+            py::object getModule(const std::vector<std::string> &moduleLevelNames);
 
         protected:
 
@@ -236,21 +150,7 @@ namespace utils {
              *
              * @return The absolute path of the site packages directory, as a string.
              */
-            py::list getVenvPackagesDirOptions() {
-                // Look for a local virtual environment directory also, if there is one
-                const char* env_var_venv = std::getenv("VIRTUAL_ENV");
-                py::object venv_dir = env_var_venv != nullptr ? Path(env_var_venv): py::none();
-
-                if (!venv_dir.is_none() && py::bool_(venv_dir.attr("is_dir")())) {
-                    // Resolve the full path
-                    venv_dir = venv_dir.attr("resolve")();
-                    // Get options for the packages dir
-                    py::list site_packages_options = py::list(venv_dir.attr("glob")("**/site-packages/"));
-                    return site_packages_options;
-                }
-
-                return py::list();
-            }
+            py::list getVenvPackagesDirOptions();
 
         public:
             /**
@@ -259,29 +159,14 @@ namespace utils {
              * @return A tuple containing the Python list object and a C++ vector of strings, each representing the
              *         current Python system path.
              */
-            inline std::tuple<py::list, std::vector<std::string>> getSystemPath() {
-                py::list sys_path = importedTopLevelModules.find("sys")->second.attr("path");
-                std::vector<std::string> sys_path_vector(sys_path.size());
-                size_t i = 0;
-                for (auto item : sys_path) {
-                    sys_path_vector[i++] = py::str(item);
-                }
-                return std::make_tuple(sys_path, sys_path_vector);
-            }
+            std::tuple<py::list, std::vector<std::string>> getSystemPath();
+
             /**
              * Find any virtual environment site packages directory, starting from options under the current directory.
              *
              * @return The absolute path of the site packages directory, as a string.
              */
-            std::string getDiscoveredVenvPath() {
-                // Look for a local virtual environment directory also, if there is one
-                const char* env_var_venv = std::getenv("VIRTUAL_ENV");
-                if(env_var_venv != nullptr){
-                    //std::string r(env_var_venv);
-                    return std::string(env_var_venv);
-                }
-                return std::string("None");
-            }
+            std::string getDiscoveredVenvPath();
 
         protected:
             /**
@@ -295,9 +180,7 @@ namespace utils {
              *                         and (when applicable) submodules.
              * @return Whether an Python module is imported.
              */
-            inline bool isImported(const std::vector<std::string> &moduleLevelNames) {
-                return isImported(moduleLevelNames[0]);
-            }
+            bool isImported(const std::vector<std::string> &moduleLevelNames);
 
             /**
              * Get whether a top level Python module is imported.
@@ -305,9 +188,7 @@ namespace utils {
              * @param name The name of the module/package.
              * @return Whether an Python module is imported.
              */
-            inline bool isImported(const std::string &name) {
-                return importedTopLevelModules.find(name) != importedTopLevelModules.end();
-            }
+            bool isImported(const std::string &name);
 
         private:
             //List this FIRST, to ensure it isn't destroyed before anything else (e.g. Path) that might
@@ -334,24 +215,8 @@ namespace utils {
              *
              * @param topLevelName The name of the desired top level Python module to import.
              */
-            inline void importTopLevelModule(const std::string &topLevelName) {
-                try {
-                    auto module = py::module_::import(topLevelName.c_str());
-                    importedTopLevelModules[topLevelName] = std::move(module);
-                }
-                catch (std::exception &e) {
-                    std::stringstream ss;
-                    ss << "importTopLevelModule: " << topLevelName << ": " << e.what() << std::endl;
-                    ss << "Already imported modules: " <<
-                    for (const auto& module : importedTopLevelModules) {
-                        ss << module.first << ", ";
-                    }
-                    LOG(ss.str(), LogLevel::WARNING);
-                    throw;
-                }
-            }
-
-        };
+            void importTopLevelModule(const std::string &topLevelName);
+        }; // class InterpreterUtil
     }
 }
 

--- a/include/utilities/python/InterpreterUtil.hpp
+++ b/include/utilities/python/InterpreterUtil.hpp
@@ -335,7 +335,20 @@ namespace utils {
              * @param topLevelName The name of the desired top level Python module to import.
              */
             inline void importTopLevelModule(const std::string &topLevelName) {
-                importedTopLevelModules[topLevelName] = py::module_::import(topLevelName.c_str());
+                try {
+                    auto module = py::module_::import(topLevelName.c_str());
+                    importedTopLevelModules[topLevelName] = std::move(module);
+                }
+                catch (std::exception &e) {
+                    std::stringstream ss;
+                    ss << "importTopLevelModule: " << topLevelName << ": " << e.what() << std::endl;
+                    ss << "Already imported modules: " <<
+                    for (const auto& module : importedTopLevelModules) {
+                        ss << module.first << ", ";
+                    }
+                    LOG(ss.str(), LogLevel::WARNING);
+                    throw;
+                }
             }
 
         };

--- a/src/bmi/CMakeLists.txt
+++ b/src/bmi/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 if(NGEN_WITH_PYTHON)
     target_sources(ngen_bmi PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Bmi_Py_Adapter.cpp")
-    target_link_libraries(ngen_bmi PUBLIC pybind11::embed)
+    target_link_libraries(ngen_bmi PUBLIC NGen::python)
 endif()
 
 if(NGEN_WITH_BMI_FORTRAN)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,7 @@ dynamic_sourced_cxx_library(core "${CMAKE_CURRENT_SOURCE_DIR}")
 add_library(NGen::core ALIAS core)
 target_link_libraries(core PUBLIC
                            NGen::config_header
+                           Boost::boost                # Headers-only Boost
                            )
 
 target_include_directories(core PUBLIC
@@ -18,52 +19,12 @@ target_include_directories(core PUBLIC
         ${PROJECT_SOURCE_DIR}/include/geojson
         ${PROJECT_SOURCE_DIR}/include/forcing
         ${PROJECT_SOURCE_DIR}/include/utilities
-        ${PROJECT_SOURCE_DIR}/extern/pybind11/include
         ${PROJECT_SOURCE_DIR}/include/realizations/catchment
         ${PROJECT_SOURCE_DIR}/include/bmi
         )
 
 if (NGEN_WITH_PYTHON)
-    target_include_directories(core PUBLIC
-            ${PROJECT_SOURCE_DIR}/include
-            ${PROJECT_SOURCE_DIR}/include/simulation_time
-            ${PROJECT_SOURCE_DIR}/include/core
-            ${PROJECT_SOURCE_DIR}/include/core/catchment
-            ${PROJECT_SOURCE_DIR}/include/core/nexus
-            ${PROJECT_SOURCE_DIR}/include/core/hydrolocation
-            ${PROJECT_SOURCE_DIR}/include/core/mediator
-            ${PROJECT_SOURCE_DIR}/include/realizations/catchment
-            ${PROJECT_SOURCE_DIR}/include/geojson
-            ${PROJECT_SOURCE_DIR}/include/forcing
-            ${PROJECT_SOURCE_DIR}/include/utilities
-            ${PROJECT_SOURCE_DIR}/extern/pybind11/include
-            )
-    configure_file(
-        ${PROJECT_SOURCE_DIR}/src/core/NGen_Python_Build_Versions.in
-        ${CMAKE_CURRENT_BINARY_DIR}/src/core/NGen_Python_Build_Versions.cpp
-    )
-    target_sources(core PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src/core/NGen_Python_Build_Versions.cpp)
-    target_link_libraries(core PUBLIC
-            Boost::boost                # Headers-only Boost
-            pybind11::embed
-            )
-else ()
-    target_include_directories(core PUBLIC
-            ${PROJECT_SOURCE_DIR}/include
-            ${PROJECT_SOURCE_DIR}/include/simulation_time
-            ${PROJECT_SOURCE_DIR}/include/core
-            ${PROJECT_SOURCE_DIR}/include/core/catchment
-            ${PROJECT_SOURCE_DIR}/include/core/nexus
-            ${PROJECT_SOURCE_DIR}/include/core/hydrolocation
-            ${PROJECT_SOURCE_DIR}/include/core/mediator
-            ${PROJECT_SOURCE_DIR}/include/realizations/catchment
-            ${PROJECT_SOURCE_DIR}/include/geojson
-            ${PROJECT_SOURCE_DIR}/include/forcing
-            ${PROJECT_SOURCE_DIR}/include/utilities
-            )
-    target_link_libraries(core PUBLIC
-            Boost::boost                # Headers-only Boost
-            )
+    target_link_libraries(core PUBLIC NGen::python)
 endif ()
 
 if(NGEN_WITH_MPI)

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -33,5 +33,5 @@ if(NGEN_WITH_PYTHON)
         "${CMAKE_CURRENT_LIST_DIR}/ForcingsEngineDataProvider.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/ForcingsEngineLumpedDataProvider.cpp"
     )
-    target_link_libraries(forcing PUBLIC pybind11::embed NGen::ngen_bmi)
+    target_link_libraries(forcing PUBLIC NGen::ngen_bmi)
 endif()

--- a/src/routing/CMakeLists.txt
+++ b/src/routing/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(routing PUBLIC
         )
         
 target_link_libraries(routing PUBLIC
-                              pybind11::embed
+                              NGen::python
                               NGen::config_header
                               )
 

--- a/src/utilities/python/CMakeLists.txt
+++ b/src/utilities/python/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(ngen_python InterpreterUtil.cpp)
+add_library(NGen::python ALIAS ngen_python)
+
+target_include_directories(ngen_python PUBLIC ${PROJECT_SOURCE_DIR}/include/)
+
+target_link_libraries(ngen_python PUBLIC
+                          NGen::config_header
+                      )
+
+if (NGEN_WITH_PYTHON)
+    target_link_libraries(ngen_python PUBLIC pybind11::embed)
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/src/utilities/python/NGen_Python_Build_Versions.in
+        ${CMAKE_CURRENT_BINARY_DIR}/NGen_Python_Build_Versions.cpp
+    )
+    target_sources(ngen_python PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/NGen_Python_Build_Versions.cpp)
+endif ()

--- a/src/utilities/python/CMakeLists.txt
+++ b/src/utilities/python/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(ngen_python PUBLIC ${PROJECT_SOURCE_DIR}/include/)
 
 target_link_libraries(ngen_python PUBLIC
                           NGen::config_header
+                          NGen::logging
                       )
 
 if (NGEN_WITH_PYTHON)

--- a/src/utilities/python/InterpreterUtil.cpp
+++ b/src/utilities/python/InterpreterUtil.cpp
@@ -1,0 +1,211 @@
+#include <NGenConfig.h>
+
+
+#if NGEN_WITH_PYTHON
+
+#include <utilities/python/InterpreterUtil.hpp>
+#include <utilities/Logger.hpp>
+
+#include <pybind11/embed.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+#include <cstdlib>
+#include <map>
+#include <vector>
+#include <tuple>
+
+namespace py = pybind11;
+
+namespace utils {
+    namespace ngenPy {
+
+        using namespace pybind11::literals; // to bring in the `_a` literal
+
+        /* static */ std::shared_ptr<InterpreterUtil> InterpreterUtil::getInstance() {
+                /**
+                 * @brief Singleton instance of embedded python interpreter.
+                 * 
+                 * Note that if no client holds a current reference to this singleton, it will get destroyed
+                 * and the next call to getInstance will create and initialize a new scoped interpreter
+                 * 
+                 * This is required for the simple reason that a traditional static singleton instance has no guarantee
+                 * about the destruction order of resources across multiple compilation units,
+                 * and this will cause seg faults if the python interpreter is torn down before the destruction of bound modules
+                 * (such as this class' Path module).  If the interpreter is not available when those destructors are called,
+                 * a seg fault will occur.  With this implementation, the interpreter is guaranteed to exist as long as anything
+                 * referencing it needs it, and then can cleanly clean up internal references before the `py::scoped_interpreter`
+                 * guard is destroyed, removing the python interpreter.
+                 * 
+                 * See the following issues and links for reference:
+                 * 
+                 * https://cplusplus.com/forum/general/37113/
+                 * https://stackoverflow.com/questions/60100922/keeping-python-interpreter-alive-only-during-the-life-of-an-object-instance
+                 * https://github.com/pybind/pybind11/issues/1598
+                 * 
+                 */
+                //Functionally, a global instance variable
+                //This can be made a class attribute, but would need to find a place to put a single definition
+                //e.g. make a .cpp file
+                static std::weak_ptr<InterpreterUtil> _instance;
+                std::shared_ptr<InterpreterUtil> instance = _instance.lock();
+                if(!instance){
+                    //instance is null
+                    InterpreterUtil* pt = new InterpreterUtil();
+                    instance = std::shared_ptr<InterpreterUtil>(pt, Deleter{});
+                    //update the weak ref
+                    _instance = instance;
+                }
+                return instance;
+            }
+
+        InterpreterUtil::InterpreterUtil() {
+                guardPtr = std::make_shared<py::scoped_interpreter>();
+                // Go ahead and do these
+                importTopLevelModule("pathlib");
+                importTopLevelModule("sys");
+                Path = importedTopLevelModules["pathlib"].attr("Path");
+
+                py::list venv_package_dirs = getVenvPackagesDirOptions();
+                // Add any found options
+                for (auto &opt : venv_package_dirs) {
+                    addToPath(std::string(py::str(opt.attr("parent"))));
+                    addToPath(std::string(py::str(opt)));
+                }
+
+                py::object python_version_info = importedTopLevelModules["sys"].attr("version_info");
+                py::str runtime_python_version = importedTopLevelModules["sys"].attr("version");
+                int major = py::int_(python_version_info.attr("major"));
+                int minor = py::int_(python_version_info.attr("minor"));
+                int patch = py::int_(python_version_info.attr("micro"));
+                if (major != python_major
+                    || minor != python_minor
+                    || patch != python_patch) {
+                    throw std::runtime_error("Python version mismatch between configure/build ("
+                                             + std::string(python_version)
+                                             + ") and runtime (" + std::string(runtime_python_version) + ")");
+                }
+
+                importTopLevelModule("numpy");
+                py::str runtime_numpy_version = importedTopLevelModules["numpy"].attr("version").attr("version");
+                if(std::string(runtime_numpy_version) != numpy_version) {
+                    throw std::runtime_error("NumPy version mismatch between configure/build ("
+                                             + std::string(numpy_version)
+                                             + ") and runtime (" + std::string(runtime_numpy_version) + ")");
+                }
+            }
+
+
+            /* static */ void InterpreterUtil::addToPyPath(const std::string &directoryPath) {
+                getInstance()->addToPath(directoryPath);
+            }
+
+            void InterpreterUtil::addToPath(const std::string &directoryPath) {
+                std::tuple<py::list, std::vector<std::string>> sysPathTuple = getSystemPath();
+                py::list sys_path = std::get<0>(sysPathTuple);
+                std::vector<std::string> sys_path_vector = std::get<1>(sysPathTuple);
+
+                py::object requestedDirPath = Path(directoryPath);
+                if (py::bool_(requestedDirPath.attr("is_dir")())) {
+                    if (std::find(sys_path_vector.begin(), sys_path_vector.end(), directoryPath) == sys_path_vector.end()) {
+#ifdef __APPLE__
+                        sys_path.attr("insert")(1, py::str(directoryPath));
+#else
+                        sys_path.attr("insert")(sys_path_vector.size(), py::str(directoryPath));
+#endif
+                    }
+                }
+                else {
+                    std::string dirPath = py::str(requestedDirPath);
+                    throw std::runtime_error("Cannot add non-existing directory '" + dirPath + "' to Python PATH");
+                }
+            }
+
+            /* static */ py::object InterpreterUtil::getPyModule(const std::string &name) {
+                return getInstance()->getModule(name);
+            }
+
+            /* static */ py::object InterpreterUtil::getPyModule(const std::vector<std::string> &moduleLevelNames) {
+                return getInstance()->getModule(moduleLevelNames);
+            }
+
+            py::object InterpreterUtil::getModule(const std::string &name) {
+                if (!isImported(name)) {
+                    importTopLevelModule(name);
+                }
+                return importedTopLevelModules.find(name)->second;
+            }
+
+            py::object InterpreterUtil::getModule(const std::vector<std::string> &moduleLevelNames) {
+                // Start with top-level module name, then descend through attributes as needed
+                py::object module = getModule(moduleLevelNames[0]);
+                for (size_t i = 1; i < moduleLevelNames.size(); ++i) {
+                    module = module.attr(moduleLevelNames[i].c_str());
+                }
+                return module;
+            }
+
+            py::list InterpreterUtil::getVenvPackagesDirOptions() {
+                // Look for a local virtual environment directory also, if there is one
+                const char* env_var_venv = std::getenv("VIRTUAL_ENV");
+                py::object venv_dir = env_var_venv != nullptr ? Path(env_var_venv): py::none();
+
+                if (!venv_dir.is_none() && py::bool_(venv_dir.attr("is_dir")())) {
+                    // Resolve the full path
+                    venv_dir = venv_dir.attr("resolve")();
+                    // Get options for the packages dir
+                    py::list site_packages_options = py::list(venv_dir.attr("glob")("**/site-packages/"));
+                    return site_packages_options;
+                }
+
+                return py::list();
+            }
+
+            std::tuple<py::list, std::vector<std::string>> InterpreterUtil::getSystemPath() {
+                py::list sys_path = importedTopLevelModules.find("sys")->second.attr("path");
+                std::vector<std::string> sys_path_vector(sys_path.size());
+                size_t i = 0;
+                for (auto item : sys_path) {
+                    sys_path_vector[i++] = py::str(item);
+                }
+                return std::make_tuple(sys_path, sys_path_vector);
+            }
+
+            std::string InterpreterUtil::getDiscoveredVenvPath() {
+                // Look for a local virtual environment directory also, if there is one
+                const char* env_var_venv = std::getenv("VIRTUAL_ENV");
+                if(env_var_venv != nullptr){
+                    //std::string r(env_var_venv);
+                    return std::string(env_var_venv);
+                }
+                return std::string("None");
+            }
+
+            bool InterpreterUtil::isImported(const std::vector<std::string> &moduleLevelNames) {
+                return isImported(moduleLevelNames[0]);
+            }
+
+            bool InterpreterUtil::isImported(const std::string &name) {
+                return importedTopLevelModules.find(name) != importedTopLevelModules.end();
+            }
+
+            void InterpreterUtil::importTopLevelModule(const std::string &topLevelName) {
+                try {
+                    auto module = py::module_::import(topLevelName.c_str());
+                    importedTopLevelModules[topLevelName] = std::move(module);
+                }
+                catch (std::exception &e) {
+                    std::stringstream ss;
+                    ss << "importTopLevelModule: " << topLevelName << ": " << e.what() << std::endl;
+                    ss << "Already imported modules: ";
+                    for (const auto& module : importedTopLevelModules) {
+                        ss << module.first << ", ";
+                    }
+                    LOG(ss.str(), LogLevel::WARNING);
+                    throw;
+                }
+            }
+    }
+}
+
+#endif // NGEN_WITH_PYTHON

--- a/src/utilities/python/InterpreterUtil.cpp
+++ b/src/utilities/python/InterpreterUtil.cpp
@@ -4,7 +4,7 @@
 #if NGEN_WITH_PYTHON
 
 #include <utilities/python/InterpreterUtil.hpp>
-#include <utilities/Logger.hpp>
+#include <utilities/logging_utils.h>
 
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
@@ -201,7 +201,8 @@ namespace utils {
                     for (const auto& module : importedTopLevelModules) {
                         ss << module.first << ", ";
                     }
-                    LOG(ss.str(), LogLevel::WARNING);
+                    ss << std::endl;
+                    logging::warning(ss.str().c_str());
                     throw;
                 }
             }

--- a/src/utilities/python/NGen_Python_Build_Versions.in
+++ b/src/utilities/python/NGen_Python_Build_Versions.in
@@ -2,7 +2,7 @@
 
 #if NGEN_WITH_PYTHON
 
-#include "python/InterpreterUtil.hpp"
+#include <utilities/python/InterpreterUtil.hpp>
 
 namespace utils {
     namespace ngenPy {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -406,6 +406,7 @@ ngen_add_test(
     OBJECTS
         bmi/Bmi_Py_Adapter_Test.cpp
         realizations/catchments/Bmi_Py_Formulation_Test.cpp
+        utils/python/InterpreterUtil_Test.cpp
     LIBRARIES
         NGen::core
         NGen::realizations_catchment

--- a/test/utils/python/InterpreterUtil_Test.cpp
+++ b/test/utils/python/InterpreterUtil_Test.cpp
@@ -1,0 +1,67 @@
+#ifdef NGEN_BMI_PY_TESTS_ACTIVE
+
+#include "gtest/gtest.h"
+
+#include <exception>
+#include <memory>
+#include <string>
+
+#include "utilities/python/InterpreterUtil.hpp"
+
+using utils::ngenPy::InterpreterUtil;
+
+class InterpreterUtilTest : public ::testing::Test {
+private:
+    // Keep the embedded Python interpreter alive across all tests in this
+    // fixture; the interpreter is reference-counted and torn down once the
+    // last shared_ptr is dropped.
+    static std::shared_ptr<InterpreterUtil> interpreter;
+};
+std::shared_ptr<InterpreterUtil> InterpreterUtilTest::interpreter =
+    InterpreterUtil::getInstance();
+
+// Regression test for commit c928aa98: importTopLevelModule() exception safety.
+//
+// Old behavior:
+//   importedTopLevelModules[name] = py::module_::import(name.c_str());
+// operator[] inserted a default-constructed (NULL-pointered) py::object under
+// `name` before the right-hand side was evaluated. When import() threw, the
+// map kept that NULL entry. A subsequent getModule(name) call saw the key,
+// took the "already imported" branch in isImported(), and returned the NULL
+// handle silently -- masking the original failure and primed to crash the
+// first time anything dereferenced it.
+//
+// New behavior: the map is mutated only after import() succeeds, so a repeat
+// import of a bad name fails the same way every time.
+//
+// NOTE: The test will not actually fail over the old behavior when
+// InterpreterUtil is built as C++17 or later, due to P0145 specifying
+// evaluation order such that the older single-statement
+// implementation of InterpreterUtil::importTopLevelModule() becomes
+// exception-safe
+TEST_F(InterpreterUtilTest, FailedImportDoesNotPoisonModuleMap) {
+    auto interp = InterpreterUtil::getInstance();
+    const std::string bogus_name = "ngen_definitely_not_a_real_module_xyzzy";
+
+    // First attempt: the import must fail.
+    ASSERT_THROW(interp->getModule(bogus_name), py::error_already_set);
+
+    // Set up for the second attempt, by ensuring that `module` is not
+    // going to be nullptr, and allowing us to better assert that
+    // getModule() should not have returned nullptr
+    py::object module;
+    ASSERT_NO_THROW(module = interp->getModule("numpy"));
+    ASSERT_NE(module.ptr(), nullptr);
+    py::object module_saved = module;
+
+    // Second attempt:
+    //   - With the bug, the map carries a NULL entry for bogus_name,
+    //     getModule() short-circuits via isImported(), returns silently,
+    //     and this expectation fails (red).
+    //   - With the fix, the map is untouched, getModule() re-attempts the
+    //     import, and the exception is raised again (green).
+    EXPECT_THROW(module = interp->getModule(bogus_name), py::error_already_set);
+    EXPECT_EQ(module.ptr(), module_saved.ptr());
+}
+
+#endif  // NGEN_BMI_PY_TESTS_ACTIVE


### PR DESCRIPTION
We encountered a bug resulting from an exception safety deficiency in the `InterpreterUtil`, where it would create `NULL` module map entries when loading something failed, and later attempts would then dereference those invalid entries.

## Additions

- Introduce a regression test that is confirmed to actually fail under the original conditions in which the bug was observed

## Changes

- Fix the exception safety bug
- Shift code from the header to a separate source file in its own library target

## Notes

I suggest reviewing each commit separately, since the test and fix are small and substantive, while the last is larger and just a structural refactoring.

The bugfix and code reorganization are as in the NGWPC `development` branch, while the other commits are new to this PR.

The bug reproduction and subsequent fix are only strictly applicable when the code is built as C++14 rather than C++17. The latter specified expression evaluation order such that the existing code became safe as written. As noted in the commit messages, I think it's still preferable to make this case explicit.

## Testing

1. Introduced test fails without the subsequent fix, if the codebase is forcibly built as C++14 rather than C++17, and passes with it
2. Github CI

## Screenshots

Before:
```
[----------] 1 test from InterpreterUtilTest
[ RUN      ] InterpreterUtilTest.FailedImportDoesNotPoisonModuleMap
/Users/phil/Code/noaa/ngen/test/utils/python/InterpreterUtil_Test.cpp:63: Failure
Expected: module = interp->getModule(bogus_name) throws an exception of type py::error_already_set.
  Actual: it throws nothing.
/Users/phil/Code/noaa/ngen/test/utils/python/InterpreterUtil_Test.cpp:64: Failure
Expected equality of these values:
  module.ptr()
    Which is: NULL
  module_saved.ptr()
    Which is: 0x1053fb6f0
[  FAILED  ] InterpreterUtilTest.FailedImportDoesNotPoisonModuleMap (0 ms)
[----------] 1 test from InterpreterUtilTest (0 ms total)
```

After:
```
[----------] 1 test from InterpreterUtilTest
[ RUN      ] InterpreterUtilTest.FailedImportDoesNotPoisonModuleMap
WARNING: importTopLevelModule: ngen_definitely_not_a_real_module_xyzzy: ModuleNotFoundError: No module named 'ngen_definitely_not_a_real_module_xyzzy'
Already imported modules: numpy, pathlib, sys, test_bmi_py, 
WARNING: importTopLevelModule: ngen_definitely_not_a_real_module_xyzzy: ModuleNotFoundError: No module named 'ngen_definitely_not_a_real_module_xyzzy'
Already imported modules: numpy, pathlib, sys, test_bmi_py, 
[       OK ] InterpreterUtilTest.FailedImportDoesNotPoisonModuleMap (0 ms)
[----------] 1 test from InterpreterUtilTest (0 ms total)
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: