### PR TITLE
fix(routing): syntax error at isNexus() call in nexus indexing

### DIFF
--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -69,7 +69,10 @@ jobs:
       - name: Build Ngen
         uses: ./.github/actions/ngen-build
         with:
-          targets: "test_routing_pybind"
+          # Build `ngen` alongside `test_routing_pybind` so this job covers
+          # the routing-enabled compilation of src/NGen.cpp — pybind-only
+          # builds skip everything gated by NGEN_WITH_ROUTING.
+          targets: "test_routing_pybind ngen"
           build-cores: ${{ env.LINUX_NUM_PROC_CORES }}
           #is this required for this test?
           use_python: 'ON'

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -455,7 +455,7 @@ int main(int argc, char* argv[]) {
     for (int i = 0; i < nexus_collection->get_size(); ++i) {
         auto feature = nexus_collection->get_feature(i);
         std::string feature_id = feature->get_id();
-        if (hy_features::identifiers::isNexus(feature_id.substr(0, 3)) {
+        if (hy_features::identifiers::isNexus(feature_id.substr(0, 3))) {
             nexus_indexes[feature_id] = nexus_index;
             ++nexus_index;
         }


### PR DESCRIPTION
Commit 03c86a52e from PR #967 has a syntax error that only shows up when building with routing.  This is the fix for that syntax error.