### PR TITLE
Minor fixes

### DIFF
--- a/include/core/HY_Features_Ids.hpp
+++ b/include/core/HY_Features_Ids.hpp
@@ -8,7 +8,7 @@ namespace hy_features {
        * Namespace constants, define the string prefixes for various hydrofabric
        * identifier types.
       */
-      static const std::string seperator = "-";
+      static const std::string separator = "-";
       static const std::string nexus = "nex";
       static const std::string coastal = "cnx";
       static const std::string terminal = "tnx";

--- a/include/core/network.hpp
+++ b/include/core/network.hpp
@@ -211,7 +211,7 @@ namespace network {
                         | boost::adaptors::transformed([this](int const& i) { return get_id(i); })
                         | boost::adaptors::filtered([type](std::string const& s) { 
                           //seperate the prefix from the numeric id
-                          std::string id_type = s.substr(0, s.find(hy_features::identifiers::seperator) );
+                          std::string id_type = s.substr(0, s.find(hy_features::identifiers::separator) );
                           //Allow subtypes, e.g. inx, tnx, cnx, to be pass the filter for a generic nexus type
                           if(type == hy_features::identifiers::nexus){
                             return hy_features::identifiers::isNexus(id_type);
@@ -252,7 +252,7 @@ namespace network {
                         | boost::adaptors::transformed([this](int const& i) { return get_id(i); })
                         | boost::adaptors::filtered([this,type,target_layer](std::string const& s) { 
                           //seperate the prefix from the numeric id
-                          std::string id_type = s.substr(0, s.find(hy_features::identifiers::seperator) );
+                          std::string id_type = s.substr(0, s.find(hy_features::identifiers::separator) );
 
                           bool type_matches;
 

--- a/include/core/nexus/HY_PointHydroNexusRemote.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemote.hpp
@@ -42,7 +42,7 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
         void add_upstream_flow(double val, std::string catchment_id, time_step_t t) override;
 
         /** extract a numeric id from the catchment id for use as a mpi tag */
-        static long extract(std::string s) {  return std::stoi( s.substr( s.find(hy_features::identifiers::seperator)+1 ) ); }
+        static long extract(std::string s) {  return std::stoi( s.substr( s.find(hy_features::identifiers::separator)+1 ) ); }
         
         const Catchments& get_local_contributing_catchments(){
             return local_contributers;

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -22,18 +22,18 @@
 namespace realization {
     using constructor = std::shared_ptr<Catchment_Formulation> (*)(std::string, std::shared_ptr<data_access::GenericDataProvider>, utils::StreamHandler);
 
-    extern std::map<std::string, constructor> formulations;
+    extern std::map<std::string, constructor> formulation_constructors;
 
     static std::string valid_formulation_keys(){
         std::string keys = "";
-        for(const auto& kv : formulations){
+        for(const auto& kv : formulation_constructors){
             keys.append(kv.first+" ");
         }
         return keys;
     }
 
     static bool formulation_exists(std::string formulation_type) {
-        return formulations.count(formulation_type) > 0;
+        return formulation_constructors.count(formulation_type) > 0;
     }
 
     static std::shared_ptr<Catchment_Formulation> construct_formulation(
@@ -42,7 +42,8 @@ namespace realization {
         forcing_params &forcing_config,
         utils::StreamHandler output_stream
     ) {
-        constructor formulation_constructor = formulations.at(formulation_type);
+        constructor formulation_constructor = formulation_constructors.at(formulation_type);
+
         std::shared_ptr<data_access::GenericDataProvider> fp;
         if (forcing_config.provider == "CsvPerFeature" || forcing_config.provider == ""){
             fp = std::make_shared<CsvPerFeatureForcingProvider>(forcing_config);

--- a/include/utilities/StreamHandler.hpp
+++ b/include/utilities/StreamHandler.hpp
@@ -32,7 +32,7 @@ namespace utils
             {
             }
 
-            /** Create a Stream Handler given a pointer to a ostream object and the seperator to be used in serialization */
+            /** Create a Stream Handler given a pointer to a ostream object and the separator to be used in serialization */
 
             StreamHandler(std::shared_ptr<std::ostream> s) : sep(", ")
             {
@@ -107,7 +107,7 @@ namespace utils
         protected:
 
         std::shared_ptr<std::ostream> output_stream;    /**< The shared pointer to the managed stream object*/
-        std::string sep;                                /**< The seperator string to be used in serialization */
+        std::string sep;                                /**< The separator string to be used in serialization */
 
 
     };

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -26,7 +26,7 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
 
       for(const auto& feat_idx : network){
         feat_id = network.get_id(feat_idx);//feature->get_id();
-        feat_type = feat_id.substr(0, feat_id.find(hy_features::identifiers::seperator) );
+        feat_type = feat_id.substr(0, feat_id.find(hy_features::identifiers::separator) );
 
         destinations  = network.get_destination_ids(feat_id);
         if(hy_features::identifiers::isCatchment(feat_type))

--- a/src/core/nexus/HY_PointHydroNexusRemote.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemote.cpp
@@ -235,7 +235,7 @@ void HY_PointHydroNexusRemote::add_upstream_flow(double val, std::string catchme
 
 		    // fill the message buffer
 		    stored_sends.back().buffer->time_step = t;
-		    stored_sends.back().buffer->catchment_id = std::stoi( id.substr( id.find(hy_features::identifiers::seperator)+1 ) );
+		    stored_sends.back().buffer->catchment_id = std::stoi( id.substr( id.find(hy_features::identifiers::separator)+1 ) );
 
 		    // get the correct amount of flow using the inherted function this means are local bookkeeping is accurate
 		    stored_sends.back().buffer->flow = HY_PointHydroNexus::get_downstream_flow(id, t, 100.0);;

--- a/src/realizations/catchment/Formulation_Constructors.cpp
+++ b/src/realizations/catchment/Formulation_Constructors.cpp
@@ -29,7 +29,7 @@ namespace realization {
         };
     }
 
-    std::map<std::string, constructor> formulations = {
+    std::map<std::string, constructor> formulation_constructors = {
         {"bmi_c++", create_formulation_constructor<Bmi_Cpp_Formulation>()},
 #if NGEN_WITH_BMI_C
         {"bmi_c", create_formulation_constructor<Bmi_C_Formulation>()},


### PR DESCRIPTION
Last lingering minor changes in the patch series that results in the refactoring to extract the dynamic simulation logic from `main()` into a separate `class NgenSimulation`.

## Changes

- Rename to `formulation_constructors`
- Typo fix

## Testing

1. Local `ctest`
2. Github CI


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
