### PR TITLE
Privatize global variables in NGen.cpp main

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -49,7 +49,6 @@ int mpi_rank = 0;
 
 #include "core/Partition_One.hpp"
 
-std::string PARTITION_PATH = "";
 int mpi_num_procs;
 #endif // NGEN_WITH_MPI
 
@@ -138,6 +137,7 @@ int main(int argc, char* argv[]) {
     std::string nexusDataFile             = "";
     std::string REALIZATION_CONFIG_PATH   = "";
     bool is_subdivided_hydrofabric_wanted = false;
+    std::string PARTITION_PATH = "";
 
     if (argc > 1 && std::string{argv[1]} == "--info") {
         #if NGEN_WITH_MPI

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -33,9 +33,6 @@
 #include "routing/Routing_Py_Adapter.hpp"
 #endif // NGEN_WITH_ROUTING
 
-// Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
-int mpi_rank = 0;
-
 #if NGEN_WITH_MPI
 
 #ifndef MPI_HF_SUB_CLI_FLAG
@@ -49,7 +46,6 @@ int mpi_rank = 0;
 
 #include "core/Partition_One.hpp"
 
-int mpi_num_procs;
 #endif // NGEN_WITH_MPI
 
 #include <Layer.hpp>
@@ -65,12 +61,6 @@ void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept
 {
     stream << "Runtime configuration summary:\n";
 
-#if NGEN_WITH_MPI
-    stream << "  MPI:\n"
-           << "    Rank: " << mpi_rank << "\n"
-           << "    Processors: " << mpi_num_procs << "\n";
-#endif // NGEN_WITH_MPI
-  
 #if NGEN_WITH_PYTHON // -------------------------------------------------------
     { // START RAII
         py::scoped_interpreter guard{};
@@ -138,6 +128,10 @@ int main(int argc, char* argv[]) {
     std::string REALIZATION_CONFIG_PATH   = "";
     bool is_subdivided_hydrofabric_wanted = false;
     std::string PARTITION_PATH = "";
+    int mpi_num_procs;
+
+    // Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
+    int mpi_rank = 0;
 
     if (argc > 1 && std::string{argv[1]} == "--info") {
         #if NGEN_WITH_MPI
@@ -151,6 +145,12 @@ int main(int argc, char* argv[]) {
             std::ostringstream output;
             output << ngen::exec_info::build_summary;
             ngen::exec_info::runtime_summary(output);
+#if NGEN_WITH_MPI
+            output << "  MPI:\n"
+                   << "    Rank: " << mpi_rank << "\n"
+                   << "    Processors: " << mpi_num_procs << "\n";
+#endif // NGEN_WITH_MPI
+
             std::cout << output.str() << std::endl;
         } // if (mpi_rank == 0)
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -128,8 +128,9 @@ int main(int argc, char* argv[]) {
     std::string REALIZATION_CONFIG_PATH   = "";
     bool is_subdivided_hydrofabric_wanted = false;
     std::string PARTITION_PATH = "";
-    int mpi_num_procs;
 
+    // This default value should lead to behavior matching the single-process case in the standalone or non-MPI case
+    int mpi_num_procs = 1;
     // Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
     int mpi_rank = 0;
 


### PR DESCRIPTION
Eliminate global variables to better parameterize lower-level functionality.

## Changes

- Move variable declarations in `NGen.cpp` from global scope to the body of `main()`

## Testing

1. Local ctest
2. Github CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: