### PR TITLE
Formulation_Manager refactor

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -30,9 +30,6 @@ namespace realization {
 
     class Formulation_Manager {
         public:
-
-            std::shared_ptr<Simulation_Time> Simulation_Time_Object;
-
             Formulation_Manager(std::stringstream &data) {
                 boost::property_tree::ptree loaded_tree;
                 boost::property_tree::json_parser::read_json(data, loaded_tree);
@@ -51,7 +48,8 @@ namespace realization {
 
             ~Formulation_Manager() = default;
 
-            void read(geojson::GeoJSON fabric, utils::StreamHandler output_stream) {
+            void read(simulation_time_params &simulation_time_config,
+                      geojson::GeoJSON fabric, utils::StreamHandler output_stream) {
                 //TODO seperate the parsing of configuration options like time
                 //and routing and other non feature specific tasks from this main function
                 //which has to iterate the entire hydrofabric.
@@ -75,22 +73,9 @@ namespace realization {
                     global_config = realization::config::Config(*possible_global_config);
                 }
 
-                auto possible_simulation_time = tree.get_child_optional("time");
-
-                if (!possible_simulation_time) {
-                    throw std::runtime_error("ERROR: No simulation time period defined.");
-                }
-                config::Time time = config::Time(*possible_simulation_time);
-                auto simulation_time_config = time.make_params();
-                /**
-                 * Call constructor to construct a Simulation_Time object
-                 */ 
-                this->Simulation_Time_Object = std::make_shared<Simulation_Time>(simulation_time_config);
-
                 /**
                  * Read the layer descriptions
                 */
-
                 // try to get the json node
                 auto layers_json_array = tree.get_child_optional("layers");
                 //Create the default surface layer
@@ -110,10 +95,7 @@ namespace realization {
 
                         // add the layer to storage
                         layer_storage.put_layer(layer_desc, layer_desc.id);
-                        if(layer.has_formulation() && layer.get_domain()=="catchments"){
-                            double c_value = UnitsHelper::get_converted_value(layer_desc.time_step_units,layer_desc.time_step,"s");
-                            // make a new simulation time object with a different output interval
-                            Simulation_Time sim_time(*Simulation_Time_Object, c_value);
+                        if (layer.has_formulation() && layer.get_domain() == "catchments") {
                             domain_formulations.emplace(
                                 layer_desc.id,
                                 construct_formulation_from_config(simulation_time_config,

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -407,9 +407,26 @@ int main(int argc, char* argv[]) {
     //Update the feature ids for the combined collection, using the alternative property 'id'
     //to map features to their primary id as well as the alternative property
     nexus_collection->update_ids("id");
+
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(REALIZATION_CONFIG_PATH, realization_config);
+
+    std::shared_ptr<Simulation_Time> sim_time;
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
+    sim_time = std::make_shared<Simulation_Time>(simulation_time_config);
+
     std::cout<<"Initializing formulations" << std::endl;
-    std::shared_ptr<realization::Formulation_Manager> manager = std::make_shared<realization::Formulation_Manager>(REALIZATION_CONFIG_PATH);
-    manager->read(catchment_collection, utils::StreamHandler::getNullStream());
+
+    std::shared_ptr<realization::Formulation_Manager> manager =
+        std::make_shared<realization::Formulation_Manager>(realization_config);
+    manager->read(simulation_time_config, catchment_collection, utils::getStdOut());
 
     //TODO refactor manager->read so certain configs can be queried before the entire
     //realization collection is created
@@ -482,7 +499,7 @@ int main(int argc, char* argv[]) {
         // TODO: (later) use nullptr for now, until full support for multiple formulations per catchment is available
         std::shared_ptr<std::vector<std::string>> formulation_ids = nullptr;
 
-        size_t timesteps = manager->Simulation_Time_Object->get_total_output_times();
+        size_t timesteps = sim_time->get_total_output_times();
         #if NGEN_WITH_MPI
         int local_nexus_write_offset, total_nexus_count;
         int local_nexus_count = nexus_ids.size();
@@ -549,12 +566,12 @@ int main(int argc, char* argv[]) {
         std::vector<std::string> cat_ids;
 
         // make a new simulation time object with a different output interval
-        Simulation_Time sim_time(*manager->Simulation_Time_Object, time_steps[i]);
+        Simulation_Time layer_sim_time(*sim_time, time_steps[i]);
         if (manager->has_domain_formulation(keys[i])) {
             // create a domain wide layer
             auto formulation = manager->get_domain_formulation(keys[i]);
             layers[i] =
-                std::make_shared<ngen::DomainLayer>(desc, sim_time, features, 0, formulation);
+                std::make_shared<ngen::DomainLayer>(desc, layer_sim_time, features, 0, formulation);
         } else {
             for (std::string id : features.catchments(keys[i])) {
                 cat_ids.push_back(id);
@@ -563,7 +580,7 @@ int main(int argc, char* argv[]) {
                 layers[i] = std::make_shared<ngen::Layer>(
                     desc,
                     cat_ids,
-                    sim_time,
+                    layer_sim_time,
                     features,
                     catchment_collection,
                     0
@@ -572,7 +589,7 @@ int main(int argc, char* argv[]) {
                 layers[i] = std::make_shared<ngen::SurfaceLayer>(
                     desc,
                     cat_ids,
-                    sim_time,
+                    layer_sim_time,
                     features,
                     catchment_collection,
                     0,
@@ -586,7 +603,7 @@ int main(int argc, char* argv[]) {
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
     // Now loop some time, iterate catchments, do stuff for total number of output times
-    auto num_times = manager->Simulation_Time_Object->get_total_output_times();
+    auto num_times = sim_time->get_total_output_times();
 
     // T-ROUTE data storage
     std::vector<double> catchment_outflows;
@@ -614,7 +631,7 @@ int main(int argc, char* argv[]) {
         // layer.
 
         // this is the time that layers are trying to reach (or get as close as possible)
-        auto next_time = manager->Simulation_Time_Object->next_timestep_epoch_time();
+        auto next_time = sim_time->next_timestep_epoch_time();
 
         // this is the time that the layer above the current layer is at
         auto prev_layer_time = next_time;
@@ -660,7 +677,7 @@ int main(int argc, char* argv[]) {
         ); // rerun the loop until the last layer would pass the master next time
 
         if (count + 1 < num_times) {
-            manager->Simulation_Time_Object->advance_timestep();
+            sim_time->advance_timestep();
         }
 
     } // done time
@@ -672,9 +689,8 @@ int main(int argc, char* argv[]) {
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    if (mpi_rank == 0)
-    {
-        std::cout << "Finished " << manager->Simulation_Time_Object->get_total_output_times() << " timesteps." << std::endl;
+    if (mpi_rank == 0) {
+        std::cout << "Finished " << sim_time->get_total_output_times() << " timesteps." << std::endl;
     }
 
     auto time_done_simulation = std::chrono::steady_clock::now();
@@ -692,9 +708,9 @@ int main(int argc, char* argv[]) {
           //number_of_timesteps is determined from the total number of nexus outputs in t-route.
           //It is recommended to still pass these values to the routing_py_adapter object in
           //case a future implmentation needs these two values from the ngen framework.
-          int number_of_timesteps = manager->Simulation_Time_Object->get_total_output_times();
+          int number_of_timesteps = sim_time->get_total_output_times();
 
-          int delta_time = manager->Simulation_Time_Object->get_output_interval_seconds();
+          int delta_time = sim_time->get_output_interval_seconds();
           
           router->route(number_of_timesteps, delta_time); 
         }

--- a/test/core/multilayer/MultiLayerParserTest.cpp
+++ b/test/core/multilayer/MultiLayerParserTest.cpp
@@ -70,8 +70,20 @@ TEST_F(MultiLayerParserTest, TestInit0)
 
 TEST_F(MultiLayerParserTest, TestRead0)
 {
-    manager = std::make_shared<realization::Formulation_Manager>(realization_config_path.c_str());
-    manager->read(catchment_collection, utils::getStdOut());
+    std::ifstream stream(realization_config_path);
+
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
+    manager = std::make_shared<realization::Formulation_Manager>(realization_config);
+    manager->read(simulation_time_config, catchment_collection, utils::getStdOut());
 
     ASSERT_TRUE(true);
 }

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -887,17 +887,27 @@ TEST_F(Formulation_Manager_Test, basic_reading_1) {
 
     stream << fix_paths(EXAMPLE_1);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-52");
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 2);
 
@@ -910,17 +920,27 @@ TEST_F(Formulation_Manager_Test, basic_reading_2) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_2);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-52");
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 2);
 
@@ -933,15 +953,25 @@ TEST_F(Formulation_Manager_Test, basic_run_1) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_1);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     this->add_feature("cat-52");
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 2);
 
@@ -968,14 +998,24 @@ TEST_F(Formulation_Manager_Test, basic_run_3) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_3);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 1);
     ASSERT_TRUE(manager.contains("cat-67"));
@@ -1003,16 +1043,26 @@ TEST_F(Formulation_Manager_Test, read_extra) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_3);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
     
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 1);
     ASSERT_TRUE(manager.contains("cat-67"));
@@ -1022,16 +1072,26 @@ TEST_F(Formulation_Manager_Test, init_config_pattern_match_global) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_7);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 1);
     ASSERT_TRUE(manager.contains("cat-67"));
@@ -1041,16 +1101,26 @@ TEST_F(Formulation_Manager_Test, init_config_pattern_match_specific) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_8);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 1);
     ASSERT_TRUE(manager.contains("cat-67"));
@@ -1060,15 +1130,25 @@ TEST_F(Formulation_Manager_Test, forcing_provider_specification) {
     std::stringstream stream;
     stream << fix_paths(EXAMPLE_4);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     this->add_feature("cat-67");
     this->add_feature("cat-27115");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 2);
     ASSERT_TRUE(manager.contains("cat-67"));
@@ -1147,7 +1227,17 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
         }
     };
 
-    auto manager = realization::Formulation_Manager(stream_a);
+    boost::property_tree::ptree realization_config_a;
+    boost::property_tree::json_parser::read_json(stream_a, realization_config_a);
+
+    auto possible_simulation_time_a = realization_config_a.get_child_optional("time");
+    if (!possible_simulation_time_a) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config_a = realization::config::Time(*possible_simulation_time_a).make_params();
+
+    auto manager = realization::Formulation_Manager(realization_config_a);
   
     add_and_check_feature("cat-67", geojson::PropertyMap{
       { "MODEL_VAR_2", geojson::JSONProperty{"MODEL_VAR_2", 10 } },
@@ -1164,7 +1254,7 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
       { "e",           geojson::JSONProperty{"e",           2.71828 } }
     });
 
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config_a, this->fabric, catchment_output);
 
     ASSERT_EQ(manager.get_size(), 3);
     check_formulation_values(manager, "cat-67",    { 1.70352, 10.0 });
@@ -1175,7 +1265,17 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
     this->fabric->remove_feature_by_id("cat-52");
     this->fabric->remove_feature_by_id("cat-27115");
 
-    manager = realization::Formulation_Manager(stream_b);
+    boost::property_tree::ptree realization_config_b;
+    boost::property_tree::json_parser::read_json(stream_b, realization_config_b);
+
+    auto possible_simulation_time_b = realization_config_b.get_child_optional("time");
+    if (!possible_simulation_time_b) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config_b = realization::config::Time(*possible_simulation_time_b).make_params();
+
+    manager = realization::Formulation_Manager(realization_config_b);
    
     //Test that two hydrofabric features, using global formulation (EXAMPLE_5_b)
     //end up with unique hydrofabric parameters in the formulations after they
@@ -1192,7 +1292,7 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
       { "val",          geojson::JSONProperty{"val", 3} }
     });
     
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config_b, this->fabric, catchment_output);
     
     check_formulation_values(manager, "cat-27",    { 3.00000, 18.0 });
     check_formulation_values(manager, "cat-67", { 7.41722, 9231 });
@@ -1204,17 +1304,27 @@ TEST_F(Formulation_Manager_Test, test_is_disable_catchment_output_1_a) {
 
     stream << fix_paths(EXAMPLE_1);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-52");
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_TRUE(manager.is_disable_catchment_output());
 }
@@ -1225,17 +1335,27 @@ TEST_F(Formulation_Manager_Test, test_is_disable_catchment_output_2_a) {
 
     stream << fix_paths(EXAMPLE_2);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-52");
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_FALSE(manager.is_disable_catchment_output());
 }
@@ -1246,17 +1366,27 @@ TEST_F(Formulation_Manager_Test, test_is_disable_catchment_output_6_a) {
 
     stream << fix_paths(EXAMPLE_6);
 
+    boost::property_tree::ptree realization_config;
+    boost::property_tree::json_parser::read_json(stream, realization_config);
+
+    auto possible_simulation_time = realization_config.get_child_optional("time");
+    if (!possible_simulation_time) {
+        throw std::runtime_error("ERROR: No simulation time period defined.");
+    }
+
+    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
+
     std::ostream* raw_pointer = &std::cout;
     std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
     utils::StreamHandler catchment_output(s_ptr);
 
-    realization::Formulation_Manager manager = realization::Formulation_Manager(stream);
+    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
 
     ASSERT_TRUE(manager.is_empty());
 
     this->add_feature("cat-52");
     this->add_feature("cat-67");
-    manager.read(this->fabric, catchment_output);
+    manager.read(simulation_time_config, this->fabric, catchment_output);
 
     ASSERT_FALSE(manager.is_disable_catchment_output());
 }


### PR DESCRIPTION
Preparatory for the `NgenSimulation` refactoring.

## Changes

- Pull `Simulation_Time_Object` out of `Formulation_Manager` to a local variable in `main()`

## Testing

1. Local ctest
2. Github CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
