### PR TITLE
Extract a NgenSimulation class encapsulating the time-dependent logic from main()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ cmake_dependent_option(NGEN_WITH_ROUTING "Build with t-route integration" ON "NG
 cmake_dependent_option(NGEN_UPDATE_GIT_SUBMODULES "Update submodules on configure" ON "GIT_FOUND;NGEN_HAS_GIT_DIR" OFF)
 cmake_dependent_option(NGEN_WITH_COVERAGE "Build with test coverage" OFF "NGEN_WITH_TESTS" OFF)
 cmake_dependent_option(NGEN_WITH_PARALLEL_NETCDF "Build with NetCDF using HDF5-parallel support" OFF "NGEN_WITH_NETCDF" OFF)
+cmake_dependent_option(NGEN_WITH_ROUTING_TROUTE_BMI "Build with t-route integration called through a BMI implementation" OFF "NGEN_WITH_ROUTING" OFF)
 
 option(BMI_FORTRAN_ISO_C_LIB_DIR "Directory hint for middleware Fortran shared lib handling iso_c_binding" "${NGEN_ROOT_DIR}/extern/iso_c_fortran_bmi/cmake_build")
 option(BMI_FORTRAN_ISO_C_LIB_NAME "Name for middleware Fortran shared lib handling iso_c_binding" "iso_c_bmi")
@@ -439,6 +440,7 @@ ngen_multiline_message(
 "    NGEN_WITH_BMI_C: ${NGEN_WITH_BMI_C}"
 "    NGEN_WITH_PYTHON: ${NGEN_WITH_PYTHON}"
 "    NGEN_WITH_ROUTING: ${NGEN_WITH_ROUTING}"
+"    NGEN_WITH_ROUTING_TROUTE_BMI: ${NGEN_WITH_ROUTING_TROUTE_BMI}"
 "    NGEN_WITH_TESTS: ${NGEN_WITH_TESTS}"
 "    NGEN_WITH_COVERAGE: ${NGEN_WITH_COVERAGE}"
 "    NGEN_QUIET: ${NGEN_QUIET}"

--- a/include/NGenConfig.h.in
+++ b/include/NGenConfig.h.in
@@ -17,6 +17,7 @@
 #cmakedefine01 NGEN_WITH_BMI_C
 #cmakedefine01 NGEN_WITH_PYTHON
 #cmakedefine01 NGEN_WITH_ROUTING
+#cmakedefine01 NGEN_WITH_ROUTING_TROUTE_BMI
 #cmakedefine01 NGEN_WITH_TESTS
 #cmakedefine01 NGEN_QUIET
 
@@ -32,15 +33,16 @@ namespace exec_info
 
     // Compile-time feature flags
 
-    static constexpr bool with_mpi         = NGEN_WITH_MPI;
-    static constexpr bool with_netcdf      = NGEN_WITH_NETCDF;
-    static constexpr bool with_sqlite      = NGEN_WITH_SQLITE;
-    static constexpr bool with_udunits     = NGEN_WITH_UDUNITS;
-    static constexpr bool with_bmi_fortran = NGEN_WITH_BMI_FORTRAN;
-    static constexpr bool with_bmi_c       = NGEN_WITH_BMI_C;
-    static constexpr bool with_python      = NGEN_WITH_PYTHON;
-    static constexpr bool with_routing     = NGEN_WITH_ROUTING;
-    static constexpr bool with_quiet       = NGEN_QUIET;
+    static constexpr bool with_mpi                 = NGEN_WITH_MPI;
+    static constexpr bool with_netcdf              = NGEN_WITH_NETCDF;
+    static constexpr bool with_sqlite              = NGEN_WITH_SQLITE;
+    static constexpr bool with_udunits             = NGEN_WITH_UDUNITS;
+    static constexpr bool with_bmi_fortran         = NGEN_WITH_BMI_FORTRAN;
+    static constexpr bool with_bmi_c               = NGEN_WITH_BMI_C;
+    static constexpr bool with_python              = NGEN_WITH_PYTHON;
+    static constexpr bool with_routing             = NGEN_WITH_ROUTING;
+    static constexpr bool with_routing_troute_bmi  = NGEN_WITH_ROUTING_TROUTE_BMI;
+    static constexpr bool with_quiet               = NGEN_QUIET;
 
     //! Compile-time build summary
     static constexpr const char* build_summary = R"(@NGEN_CONF_SUMMARY@)";

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -22,7 +22,8 @@ public:
                    std::shared_ptr<realization::Formulation_Manager> formulation_manager,
                    std::vector<std::shared_ptr<ngen::Layer>> layers,
                    std::unordered_map<std::string, int> catchment_indexes,
-                   std::unordered_map<std::string, int> nexus_indexes
+                   std::unordered_map<std::string, int> nexus_indexes,
+                   int mpi_rank
                    );
     NgenSimulation() = delete;
 
@@ -46,6 +47,8 @@ public:
     std::vector<double> catchment_outflows_;
     std::unordered_map<std::string, int> nexus_indexes_;
     std::vector<double> nexus_downstream_flows_;
+
+    int mpi_rank_;
 
 #if NGEN_WITH_ROUTING
     std::unique_ptr<routing_py_adapter::Routing_Py_Adapter> router_;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -1,0 +1,56 @@
+#ifndef NGENSIMULATION_HPP
+#define NGENSIMULATION_HPP
+
+#include <Simulation_Time.hpp>
+#include <realizations/catchment/Formulation_Manager.hpp>
+#include <Layer.hpp>
+
+namespace routing_py_adapter {
+    class Routing_Py_Adapter;
+}
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+#include <string>
+
+// Contains all of the dynamic state and logic to run a NextGen hydrologic simulation
+class NgenSimulation
+{
+public:
+    NgenSimulation(
+                   std::shared_ptr<realization::Formulation_Manager> formulation_manager,
+                   std::vector<std::shared_ptr<ngen::Layer>> layers,
+                   std::unordered_map<std::string, int> catchment_indexes,
+                   std::vector<double> catchment_outflows,
+                   std::unordered_map<std::string, int> nexus_indexes,
+                   std::vector<double> nexus_downstream_flows
+                   );
+    NgenSimulation() = delete;
+
+    void run_catchments();
+    void run_routing();
+    void advance_one_output_step();
+
+    std::shared_ptr<Simulation_Time> sim_time_;
+    
+    // Catchment data
+    std::shared_ptr<realization::Formulation_Manager> catchment_formulation_manager_;
+    std::vector<std::shared_ptr<ngen::Layer>> layers_;
+
+    // Routing data structured for t-route
+    std::unordered_map<std::string, int> catchment_indexes_;
+    std::vector<double> catchment_outflows_;
+    std::unordered_map<std::string, int> nexus_indexes_;
+    std::vector<double> nexus_downstream_flows_;
+
+#if NGEN_WITH_ROUTING
+    std::unique_ptr<routing_py_adapter::Routing_Py_Adapter> router_;
+#endif
+
+    // Serialization template will be defined and instantiated in the .cpp file
+    template <class Archive>
+    void serialize(Archive& ar);
+};
+
+#endif

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -26,6 +26,8 @@ public:
                    );
     NgenSimulation() = delete;
 
+    ~NgenSimulation();
+
     void run_catchments();
     void run_routing();
     void advance_one_output_step();

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -31,7 +31,8 @@ public:
     void advance_one_output_step();
 
     std::shared_ptr<Simulation_Time> sim_time_;
-    
+    size_t get_num_output_times();
+
     // Catchment data
     std::shared_ptr<realization::Formulation_Manager> catchment_formulation_manager_;
     std::vector<std::shared_ptr<ngen::Layer>> layers_;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -30,6 +30,8 @@ public:
     void run_routing();
     void advance_one_output_step();
 
+    int simulation_step_;
+
     std::shared_ptr<Simulation_Time> sim_time_;
     size_t get_num_output_times();
 

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -22,9 +22,7 @@ public:
                    std::shared_ptr<realization::Formulation_Manager> formulation_manager,
                    std::vector<std::shared_ptr<ngen::Layer>> layers,
                    std::unordered_map<std::string, int> catchment_indexes,
-                   std::vector<double> catchment_outflows,
-                   std::unordered_map<std::string, int> nexus_indexes,
-                   std::vector<double> nexus_downstream_flows
+                   std::unordered_map<std::string, int> nexus_indexes
                    );
     NgenSimulation() = delete;
 

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -1,9 +1,17 @@
 #ifndef NGENSIMULATION_HPP
 #define NGENSIMULATION_HPP
 
+#include <NGenConfig.h>
+
 #include <Simulation_Time.hpp>
 #include <realizations/catchment/Formulation_Manager.hpp>
 #include <Layer.hpp>
+
+namespace hy_features
+{
+    class HY_Features;
+    class HY_Features_MPI;
+}
 
 #include <memory>
 #include <vector>
@@ -25,8 +33,14 @@ public:
 
     ~NgenSimulation();
 
+#if NGEN_WITH_MPI
+    using hy_features_t = hy_features::HY_Features_MPI;
+#else
+    using hy_features_t = hy_features::HY_Features;
+#endif
+
     void run_catchments();
-    void run_routing();
+    void run_routing(hy_features_t &features);
     void advance_one_output_step();
 
     int simulation_step_;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -4,7 +4,6 @@
 #include <NGenConfig.h>
 
 #include <Simulation_Time.hpp>
-#include <realizations/catchment/Formulation_Manager.hpp>
 #include <Layer.hpp>
 
 namespace hy_features
@@ -23,7 +22,7 @@ class NgenSimulation
 {
 public:
     NgenSimulation(
-                   std::shared_ptr<realization::Formulation_Manager> formulation_manager,
+                   Simulation_Time const& sim_time,
                    std::vector<std::shared_ptr<ngen::Layer>> layers,
                    std::unordered_map<std::string, int> catchment_indexes,
                    std::unordered_map<std::string, int> nexus_indexes,
@@ -40,7 +39,7 @@ public:
 #endif
 
     void run_catchments();
-    void run_routing(hy_features_t &features);
+    void run_routing(hy_features_t &features, std::string const& t_route_config_file_with_path);
 
     int get_nexus_index(std::string const& nexus_id) const;
     double get_nexus_outflow(int nexus_index, int timestep_index) const;
@@ -56,7 +55,6 @@ private:
     std::shared_ptr<Simulation_Time> sim_time_;
 
     // Catchment data
-    std::shared_ptr<realization::Formulation_Manager> catchment_formulation_manager_;
     std::vector<std::shared_ptr<ngen::Layer>> layers_;
 
     // Routing data structured for t-route

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -29,7 +29,8 @@ public:
                    std::vector<std::shared_ptr<ngen::Layer>> layers,
                    std::unordered_map<std::string, int> catchment_indexes,
                    std::unordered_map<std::string, int> nexus_indexes,
-                   int mpi_rank
+                   int mpi_rank,
+                   int mpi_num_procs
                    );
     NgenSimulation() = delete;
 
@@ -85,6 +86,7 @@ private:
     std::vector<double> nexus_downstream_flows_;
 
     int mpi_rank_;
+    int mpi_num_procs_;
 
 #if NGEN_WITH_ROUTING
     std::unique_ptr<routing_py_adapter::Routing_Py_Adapter> router_;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -46,7 +46,10 @@ public:
     int simulation_step_;
 
     std::shared_ptr<Simulation_Time> sim_time_;
-    size_t get_num_output_times();
+    size_t get_num_output_times() const;
+
+    int get_nexus_index(std::string const& nexus_id) const;
+    double get_nexus_outflow(int nexus_index, int timestep_index) const;
 
     // Catchment data
     std::shared_ptr<realization::Formulation_Manager> catchment_formulation_manager_;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -48,7 +48,7 @@ public:
     std::string get_timestamp_for_step(int step) const;
 
 private:
-    void advance_one_output_step();
+    void advance_models_one_output_step();
 
     int simulation_step_;
 

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -38,7 +38,18 @@ public:
     using hy_features_t = hy_features::HY_Features;
 #endif
 
+    /**
+     * Run the catchment formulations for the full configured duration of the simulation
+     *
+     * Captures calculated runoff values in `catchment_outflows_` and
+     * `nexus_downstream_flows_` for subsequent output and consumption
+     * by `run_routing()`
+     */
     void run_catchments();
+
+    /**
+     * Run t-route on the stored nexus outflow values for the full configured duration of the simulation
+     */
     void run_routing(hy_features_t &features, std::string const& t_route_config_file_with_path);
 
     int get_nexus_index(std::string const& nexus_id) const;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -11,6 +11,9 @@ namespace hy_features
     class HY_Features;
     class HY_Features_MPI;
 }
+namespace routing_py_adapter {
+    class Routing_Py_Adapter;
+}
 
 #include <memory>
 #include <vector>
@@ -41,16 +44,23 @@ public:
     /**
      * Run the catchment formulations for the full configured duration of the simulation
      *
-     * Captures calculated runoff values in `catchment_outflows_` and
+     * Can be configured to capture calculated runoff values in `catchment_outflows_` and
      * `nexus_downstream_flows_` for subsequent output and consumption
-     * by `run_routing()`
+     * by `run_routing_bmi()`
      */
     void run_catchments();
 
     /**
-     * Run t-route on the stored nexus outflow values for the full configured duration of the simulation
+     * Run t-route on nexus outflow values written to files during
+     * run_catchments() for the full configured duration of the
+     * simulation
      */
-    void run_routing(hy_features_t &features, std::string const& t_route_config_file_with_path);
+    void run_routing(std::string const& t_route_config_file_with_path);
+
+    /**
+     * Run t-route via BMI on the stored nexus outflow values for the full configured duration of the simulation
+     */
+    void run_routing_bmi(hy_features_t &features, std::string const& t_route_config_file_with_path);
 
     int get_nexus_index(std::string const& nexus_id) const;
     double get_nexus_outflow(int nexus_index, int timestep_index) const;
@@ -75,6 +85,10 @@ private:
     std::vector<double> nexus_downstream_flows_;
 
     int mpi_rank_;
+
+#if NGEN_WITH_ROUTING
+    std::unique_ptr<routing_py_adapter::Routing_Py_Adapter> router_;
+#endif
 
     // Serialization template will be defined and instantiated in the .cpp file
     template <class Archive>

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -5,10 +5,6 @@
 #include <realizations/catchment/Formulation_Manager.hpp>
 #include <Layer.hpp>
 
-namespace routing_py_adapter {
-    class Routing_Py_Adapter;
-}
-
 #include <memory>
 #include <vector>
 #include <unordered_map>
@@ -49,10 +45,6 @@ public:
     std::vector<double> nexus_downstream_flows_;
 
     int mpi_rank_;
-
-#if NGEN_WITH_ROUTING
-    std::unique_ptr<routing_py_adapter::Routing_Py_Adapter> router_;
-#endif
 
     // Serialization template will be defined and instantiated in the .cpp file
     template <class Archive>

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -41,15 +41,19 @@ public:
 
     void run_catchments();
     void run_routing(hy_features_t &features);
+
+    int get_nexus_index(std::string const& nexus_id) const;
+    double get_nexus_outflow(int nexus_index, int timestep_index) const;
+
+    size_t get_num_output_times() const;
+    std::string get_timestamp_for_step(int step) const;
+
+private:
     void advance_one_output_step();
 
     int simulation_step_;
 
     std::shared_ptr<Simulation_Time> sim_time_;
-    size_t get_num_output_times() const;
-
-    int get_nexus_index(std::string const& nexus_id) const;
-    double get_nexus_outflow(int nexus_index, int timestep_index) const;
 
     // Catchment data
     std::shared_ptr<realization::Formulation_Manager> catchment_formulation_manager_;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -20,6 +20,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/range/algorithm/sort.hpp>
 
+#include <NgenSimulation.hpp>
+
 #ifdef WRITE_PID_FILE_FOR_GDB_SERVER
 #include <unistd.h>
 #endif // WRITE_PID_FILE_FOR_GDB_SERVER
@@ -602,9 +604,6 @@ int main(int argc, char* argv[]) {
     auto time_done_init                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
-    // Now loop some time, iterate catchments, do stuff for total number of output times
-    auto num_times = sim_time->get_total_output_times();
-
     // T-ROUTE data storage
     std::vector<double> catchment_outflows;
     std::unordered_map<std::string, int> catchment_indexes;
@@ -620,67 +619,15 @@ int main(int argc, char* argv[]) {
     nexus_downstream_flows.resize(nexus_indexes.size() * num_times, 0.0);
 #endif // NGEN_WITH_ROUTING
 
-    for (int count = 0; count < num_times; count++) {
-        // The Inner loop will advance all layers unless doing so will break one of two constraints
-        // 1) A layer may not proceed ahead of the master simulation object's current time
-        // 2) A layer may not proceed ahead of any layer that is computed before it
-        // The do while loop ensures that all layers are tested at least once while allowing
-        // layers with small time steps to be updated more than once
-        // If a layer with a large time step is after a layer with a small time step the
-        // layer with the large time step will wait for multiple timesteps from the preceeding
-        // layer.
+    auto simulation = std::make_unique<NgenSimulation>(manager,
+                                                       layers,
+                                                       catchment_indexes,
+                                                       catchment_outflows,
+                                                       nexus_indexes,
+                                                       nexus_downstream_flows);
 
-        // this is the time that layers are trying to reach (or get as close as possible)
-        auto next_time = sim_time->next_timestep_epoch_time();
-
-        // this is the time that the layer above the current layer is at
-        auto prev_layer_time = next_time;
-
-        // this is the time that the least advanced layer is at
-        auto layer_min_next_time = next_time;
-        do {
-            for (auto& layer : layers) {
-                auto layer_next_time = layer->next_timestep_epoch_time();
-
-                // only advance if you would not pass the master next time and the previous layer
-                // next time
-                if (layer_next_time <= next_time && layer_next_time <= prev_layer_time) {
-                    if (count % 100 == 0) {
-		      std::cout << "Updating layer: " << layer->get_name() << "\n";
-                    }
-#if NGEN_WITH_ROUTING && false
-                    boost::span<double> catchment_span(catchment_outflows.data() + (count * catchment_indexes.size()),
-                                                       catchment_indexes.size());
-                    boost::span<double> nexus_span(nexus_downstream_flows.data() + (count * nexus_indexes.size()),
-                                                   nexus_indexes.size());
-#else
-                    boost::span<double> catchment_span;
-                    boost::span<double> nexus_span;
-#endif
-                    layer->update_models(
-                        catchment_span,
-                        catchment_indexes,
-                        nexus_span,
-                        nexus_indexes,
-                        count
-                    ); // assume update_models() calls time->advance_timestep()
-                    prev_layer_time = layer_next_time;
-                } else {
-                    layer_min_next_time = prev_layer_time = layer->current_timestep_epoch_time();
-                }
-
-                if (layer_min_next_time > layer_next_time) {
-                    layer_min_next_time = layer_next_time;
-                }
-            } // done layers
-        } while (layer_min_next_time < next_time
-        ); // rerun the loop until the last layer would pass the master next time
-
-        if (count + 1 < num_times) {
-            sim_time->advance_timestep();
-        }
-
-    } // done time
+    // Currently breaks routing data transfer; will move routing down into this
+    simulation->run_catchments();
 
     // Close nexus output file(s)
     nexus_outputs_mgr->close();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -623,7 +623,8 @@ int main(int argc, char* argv[]) {
     auto simulation = std::make_unique<NgenSimulation>(manager,
                                                        layers,
                                                        catchment_indexes,
-                                                       nexus_indexes);
+                                                       nexus_indexes,
+                                                       mpi_rank);
 
     simulation->run_catchments();
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -646,22 +646,9 @@ int main(int argc, char* argv[]) {
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-#if NGEN_WITH_ROUTING
-    if (mpi_rank == 0)
-    { // Run t-route from single process
-        if(manager->get_using_routing()) {
-          //Note: Currently, delta_time is set in the t-route yaml configuration file, and the
-          //number_of_timesteps is determined from the total number of nexus outputs in t-route.
-          //It is recommended to still pass these values to the routing_py_adapter object in
-          //case a future implmentation needs these two values from the ngen framework.
-          int number_of_timesteps = sim_time->get_total_output_times();
-
-          int delta_time = sim_time->get_output_interval_seconds();
-          
-          router->route(number_of_timesteps, delta_time); 
-        }
+    if (manager->get_using_routing()) {
+        simulation->run_routing();
     }
-#endif
 
     auto time_done_routing = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_routing = time_done_routing - time_done_simulation;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -601,14 +601,6 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    auto time_done_init                             = std::chrono::steady_clock::now();
-    std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
-
-    LOG("[TIMING]: Init: " + std::to_string(time_elapsed_init.count()), LogLevel::INFO);
-
-    // Now loop some time, iterate catchments, do stuff for total number of output times
-    auto num_times = manager->Simulation_Time_Object->get_total_output_times();
-
     // T-ROUTE data storage
     std::unordered_map<std::string, int> catchment_indexes;
 #if NGEN_WITH_ROUTING && false
@@ -625,6 +617,9 @@ int main(int argc, char* argv[]) {
                                                        std::move(catchment_indexes),
                                                        std::move(nexus_indexes),
                                                        mpi_rank);
+
+    auto time_done_init                             = std::chrono::steady_clock::now();
+    std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
     simulation->run_catchments();
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -625,7 +625,6 @@ int main(int argc, char* argv[]) {
                                                        catchment_indexes,
                                                        nexus_indexes);
 
-    // Currently breaks routing data transfer; will move routing down into this
     simulation->run_catchments();
 
     // Close nexus output file(s)

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -647,7 +647,7 @@ int main(int argc, char* argv[]) {
 #endif
 
     if (manager->get_using_routing()) {
-        simulation->run_routing();
+        simulation->run_routing(features);
     }
 
     auto time_done_routing = std::chrono::steady_clock::now();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -601,14 +601,14 @@ int main(int argc, char* argv[]) {
 
     // T-ROUTE data storage
     std::unordered_map<std::string, int> catchment_indexes;
-#if NGEN_WITH_ROUTING && false
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
     size_t catchment_collection_size = catchment_collection->get_size();
     for (int i = 0; i < catchment_collection_size; ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
         catchment_indexes[feature_id] = i;
     }
-#endif // NGEN_WITH_ROUTING
+#endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
 
     auto simulation = std::make_unique<NgenSimulation>(*sim_time,
                                                        layers,
@@ -641,7 +641,11 @@ int main(int argc, char* argv[]) {
 
     if (manager->get_using_routing()) {
         std::string t_route_config_file_with_path = manager->get_t_route_config_file_with_path();
+#if NGEN_WITH_ROUTING_TROUTE_BMI
+        simulation->run_routing_bmi(features, t_route_config_file_with_path);
+#else
         simulation->run_routing(t_route_config_file_with_path);
+#endif // NGEN_WITH_ROUTING_TROUTE_BMI
     }
 
     auto time_done_routing = std::chrono::steady_clock::now();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -614,7 +614,8 @@ int main(int argc, char* argv[]) {
                                                        layers,
                                                        std::move(catchment_indexes),
                                                        std::move(nexus_indexes),
-                                                       mpi_rank);
+                                                       mpi_rank,
+                                                       mpi_num_procs);
 
     auto time_done_init                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -604,27 +604,26 @@ int main(int argc, char* argv[]) {
     auto time_done_init                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
+    LOG("[TIMING]: Init: " + std::to_string(time_elapsed_init.count()), LogLevel::INFO);
+
+    // Now loop some time, iterate catchments, do stuff for total number of output times
+    auto num_times = manager->Simulation_Time_Object->get_total_output_times();
+
     // T-ROUTE data storage
-    std::vector<double> catchment_outflows;
     std::unordered_map<std::string, int> catchment_indexes;
-    std::vector<double> nexus_downstream_flows;
 #if NGEN_WITH_ROUTING && false
     size_t catchment_collection_size = catchment_collection->get_size();
-    catchment_outflows.resize(catchment_collection_size * num_times, 0.0);
     for (int i = 0; i < catchment_collection_size; ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
         catchment_indexes[feature_id] = i;
     }
-    nexus_downstream_flows.resize(nexus_indexes.size() * num_times, 0.0);
 #endif // NGEN_WITH_ROUTING
 
     auto simulation = std::make_unique<NgenSimulation>(manager,
                                                        layers,
                                                        catchment_indexes,
-                                                       catchment_outflows,
-                                                       nexus_indexes,
-                                                       nexus_downstream_flows);
+                                                       nexus_indexes);
 
     // Currently breaks routing data transfer; will move routing down into this
     simulation->run_catchments();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -438,8 +438,6 @@ int main(int argc, char* argv[]) {
     { // Run t-route from single process
     if(manager->get_using_routing()) {
       std::cout<<"Using Routing"<<std::endl;
-      std::string t_route_config_file_with_path = manager->get_t_route_config_file_with_path();
-      router = std::make_unique<routing_py_adapter::Routing_Py_Adapter>(t_route_config_file_with_path);
     }
     else {
       std::cout<<"Not Using Routing"<<std::endl;
@@ -642,7 +640,8 @@ int main(int argc, char* argv[]) {
 #endif
 
     if (manager->get_using_routing()) {
-        simulation->run_routing(features, manager->get_t_route_config_file_with_path());
+        std::string t_route_config_file_with_path = manager->get_t_route_config_file_with_path();
+        simulation->run_routing(t_route_config_file_with_path);
     }
 
     auto time_done_routing = std::chrono::steady_clock::now();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -612,7 +612,7 @@ int main(int argc, char* argv[]) {
     }
 #endif // NGEN_WITH_ROUTING
 
-    auto simulation = std::make_unique<NgenSimulation>(manager,
+    auto simulation = std::make_unique<NgenSimulation>(*sim_time,
                                                        layers,
                                                        std::move(catchment_indexes),
                                                        std::move(nexus_indexes),
@@ -642,7 +642,7 @@ int main(int argc, char* argv[]) {
 #endif
 
     if (manager->get_using_routing()) {
-        simulation->run_routing(features);
+        simulation->run_routing(features, manager->get_t_route_config_file_with_path());
     }
 
     auto time_done_routing = std::chrono::steady_clock::now();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -622,8 +622,8 @@ int main(int argc, char* argv[]) {
 
     auto simulation = std::make_unique<NgenSimulation>(manager,
                                                        layers,
-                                                       catchment_indexes,
-                                                       nexus_indexes,
+                                                       std::move(catchment_indexes),
+                                                       std::move(nexus_indexes),
                                                        mpi_rank);
 
     simulation->run_catchments();

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -47,7 +47,7 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
         }
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         int results_index = catchment_indexes[id];
-	// XXX: This is currently accumulating in meters of depth, which may not be desirable
+        // XXX: This is currently accumulating in meters of depth, which may not be desirable
         catchment_outflows[results_index] += response;
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         std::string output = std::to_string(output_time_index)+","+current_timestamp+","+

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -45,11 +45,11 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
                 +" at feature id "+id;
             throw std::runtime_error(msg);
         }
-#if NGEN_WITH_ROUTING && false
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         int results_index = catchment_indexes[id];
 	// XXX: This is currently accumulating in meters of depth, which may not be desirable
         catchment_outflows[results_index] += response;
-#endif // NGEN_WITH_ROUTING
+#endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
             r_c->get_output_line_for_timestep(output_time_index)+"\n";
         r_c->write_output(output);

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -19,7 +19,8 @@ NgenSimulation::NgenSimulation(
     std::vector<std::shared_ptr<ngen::Layer>> layers,
     std::unordered_map<std::string, int> catchment_indexes,
     std::unordered_map<std::string, int> nexus_indexes,
-    int mpi_rank
+    int mpi_rank,
+    int mpi_num_procs
                                )
     : simulation_step_(0)
     , sim_time_(std::make_shared<Simulation_Time>(sim_time))
@@ -27,6 +28,7 @@ NgenSimulation::NgenSimulation(
     , catchment_indexes_(std::move(catchment_indexes))
     , nexus_indexes_(std::move(nexus_indexes))
     , mpi_rank_(mpi_rank)
+    , mpi_num_procs_(mpi_num_procs)
 {
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
     catchment_outflows_.reserve(catchment_indexes_.size() * get_num_output_times());
@@ -167,8 +169,8 @@ void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, st
             local_nexus_ids.push_back(nexus.first);
         }
         // MPI_Gather all nexus IDs into a single vector
-        std::vector<std::string> all_nexus_ids = parallel::gather_strings(local_nexus_ids, mpi_rank, mpi_num_procs);
-        if (mpi_rank == 0) {
+        std::vector<std::string> all_nexus_ids = parallel::gather_strings(local_nexus_ids, mpi_rank_, mpi_num_procs_);
+        if (mpi_rank_ == 0) {
             // filter to only the unique IDs
             std::sort(all_nexus_ids.begin(), all_nexus_ids.end());
             all_nexus_ids.erase(
@@ -177,7 +179,7 @@ void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, st
             );
         }
         // MPI_Broadcast so all processes share the nexus IDs
-        all_nexus_ids = std::move(parallel::broadcast_strings(all_nexus_ids, mpi_rank, mpi_num_procs));
+        all_nexus_ids = std::move(parallel::broadcast_strings(all_nexus_ids, mpi_rank_, mpi_num_procs_));
 
         // MPI_Reduce to collect the results from processes
         if (mpi_rank_ == 0) {
@@ -199,7 +201,7 @@ void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, st
                 std::fill(local_buffer.begin(), local_buffer.end(), 0.0);
             }
             MPI_Reduce(local_buffer.data(), receive_buffer.data(), number_of_timesteps, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-            if (mpi_rank == 0) {
+            if (mpi_rank_ == 0) {
                 // copy reduce values to a combined downflows vector
                 all_nexus_indexes[nexus_id] = i;
                 for (int step = 0; step < number_of_timesteps; ++step) {
@@ -210,7 +212,7 @@ void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, st
             }
         }
 
-        if (mpi_rank == 0) {
+        if (mpi_rank_ == 0) {
             // update root's local data for running t-route below
             routing_nexus_indexes = &all_nexus_indexes;
             routing_nexus_downflows = &all_nexus_downflows;

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -121,12 +121,18 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
     std::vector<double> *routing_nexus_downflows = &nexus_downstream_flows_;
     std::unordered_map<std::string, int> *routing_nexus_indexes = &nexus_indexes_;
 
+    size_t number_of_timesteps = sim_time_->get_total_output_times();
+    if (nexus_downstream_flows_.size() != number_of_timesteps * nexus_indexes_.size()) {
+        std::string msg = "Routing input data in NgenSimulation::nexus_downstream_flows_ does not reflect a full-duration run";
+        LOG(msg, LogLevel::FATAL);
+        throw std::runtime_error(msg);
+    }
+
 #if NGEN_WITH_MPI
     std::vector<double> all_nexus_downflows;
     std::unordered_map<std::string, int> all_nexus_indexes;
 
     if (mpi_num_procs_ > 1) {
-        int number_of_timesteps = sim_time_->get_total_output_times();
         std::vector<std::string> local_nexus_ids;
         for (const auto& nexus : nexus_indexes_) {
             local_nexus_ids.push_back(nexus.first);
@@ -189,9 +195,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
         // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
         // number_of_timesteps is determined from the total number of nexus outputs in t-route.
         // It is recommended to still pass these values to the routing_py_adapter object in
-        // case a future implmentation needs these two values from the ngen framework.
-        int number_of_timesteps = sim_time_->get_total_output_times();
-
+        // case a future implementation needs these two values from the ngen framework.
         int delta_time = sim_time_->get_output_interval_seconds();
 
         // model for routing

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -5,6 +5,8 @@
 #include "bmi/Bmi_Py_Adapter.hpp"
 #endif // NGEN_WITH_ROUTING
 
+#include "parallel_utils.h"
+
 NgenSimulation::NgenSimulation(
     std::shared_ptr<realization::Formulation_Manager> formulation_manager,
     std::vector<std::shared_ptr<ngen::Layer>> layers,
@@ -113,7 +115,7 @@ void NgenSimulation::run_routing()
     if (mpi_num_procs > 1) {
         int number_of_timesteps = manager->Simulation_Time_Object->get_total_output_times();
         std::vector<std::string> local_nexus_ids;
-        for (const auto& nexus : nexus_indexes) {
+        for (const auto& nexus : nexus_indexes_) {
             local_nexus_ids.push_back(nexus.first);
         }
         // MPI_Gather all nexus IDs into a single vector
@@ -164,8 +166,8 @@ void NgenSimulation::run_routing()
 
         if (mpi_rank == 0) {
             // update root's local data for running t-route below
-            nexus_indexes = std::move(all_nexus_indexes);
-            nexus_downstream_flows = std::move(all_nexus_downflows);
+            nexus_indexes_ = std::move(all_nexus_indexes);
+            nexus_downstream_flows_ = std::move(all_nexus_downflows);
         }
 
     }
@@ -189,12 +191,12 @@ void NgenSimulation::run_routing()
             models::bmi::Bmi_Py_Adapter py_troute("T-Route", t_route_config_file_with_path, "troute_nwm_bmi.troute_bmi.BmiTroute", true);
 
             // tell BMI to resize nexus containers
-            int64_t nexus_count = nexus_indexes.size();
+            int64_t nexus_count = nexus_indexes_.size();
             py_troute.SetValue("land_surface_water_source__volume_flow_rate__count", &nexus_count);
             py_troute.SetValue("land_surface_water_source__id__count", &nexus_count);
             // set up nexus id indexes
             std::vector<int> nexus_df_index(nexus_count);
-            for (const auto& key_value : nexus_indexes) {
+            for (const auto& key_value : nexus_indexes_) {
                 int id_index = key_value.second;
 
                 // Convert string ID into numbers for T-route index

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -68,6 +68,7 @@ void NgenSimulation::run_catchments()
                     if (count % 100 == 0) {
                         std::cout << "Updating layer: '" + layer->get_name() + "' at output step " + std::to_string(simulation_step_) << std::endl;
                     }
+
 #if NGEN_WITH_ROUTING && false
                     boost::span<double> catchment_span(catchment_outflows_.data() + (simulation_step_ * catchment_indexes_.size()),
                                                        catchment_indexes_.size());
@@ -102,6 +103,16 @@ void NgenSimulation::run_catchments()
     }
 }
 
+int NgenSimulation::get_nexus_index(std::string const& nexus_id) const
+{
+    auto iter = nexus_indexes_.find(nexus_id);
+    return (iter != nexus_indexes_.end()) ? iter->second : -1;
+}
+
+double NgenSimulation::get_nexus_outflow(int nexus_index, int timestep_index) const
+{
+    return nexus_downstream_flows_[timestep_index * nexus_indexes_.size() + nexus_index];
+}
 
 void NgenSimulation::advance_one_output_step()
 {
@@ -226,7 +237,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
 #endif // NGEN_WITH_ROUTING
 }
 
-size_t NgenSimulation::get_num_output_times()
+size_t NgenSimulation::get_num_output_times() const
 {
     return sim_time_->get_total_output_times();
 }

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -9,19 +9,21 @@ NgenSimulation::NgenSimulation(
     std::shared_ptr<realization::Formulation_Manager> formulation_manager,
     std::vector<std::shared_ptr<ngen::Layer>> layers,
     std::unordered_map<std::string, int> catchment_indexes,
-    std::vector<double> catchment_outflows,
-    std::unordered_map<std::string, int> nexus_indexes,
-    std::vector<double> nexus_downstream_flows
+    std::unordered_map<std::string, int> nexus_indexes
                                )
     : catchment_formulation_manager_(formulation_manager)
     , sim_time_(std::make_shared<Simulation_Time>(*formulation_manager->Simulation_Time_Object))
     , layers_(layers)
     , catchment_indexes_(std::move(catchment_indexes))
-    , catchment_outflows_(std::move(catchment_outflows))
     , nexus_indexes_(std::move(nexus_indexes))
-    , nexus_downstream_flows_(std::move(nexus_downstream_flows))
 {
+    auto num_times = sim_time_->get_total_output_times();
 
+    size_t num_catchments = catchment_indexes_.size();
+    catchment_outflows_.reserve(num_catchments * num_times);
+
+    size_t num_nexuses = nexus_indexes_.size();
+    nexus_downstream_flows_.reserve(num_nexuses * num_times);
 }
 
 void NgenSimulation::run_catchments()
@@ -29,7 +31,7 @@ void NgenSimulation::run_catchments()
     std::stringstream ss;
 
     // Now loop some time, iterate catchments, do stuff for total number of output times
-    auto num_times = catchment_formulation_manager_->Simulation_Time_Object->get_total_output_times();
+    auto num_times = sim_time_->get_total_output_times();
 
     for (int count = 0; count < num_times; count++) {
         // The Inner loop will advance all layers unless doing so will break one of two constraints
@@ -40,6 +42,10 @@ void NgenSimulation::run_catchments()
         // If a layer with a large time step is after a layer with a small time step the
         // layer with the large time step will wait for multiple timesteps from the preceeding
         // layer.
+
+        // Make room for this output step's results
+        catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size());
+        nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size());
 
         // this is the time that layers are trying to reach (or get as close as possible)
         auto next_time = catchment_formulation_manager_->Simulation_Time_Object->next_timestep_epoch_time();

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -1,0 +1,142 @@
+#include <NgenSimulation.hpp>
+#include <NGenConfig.h>
+
+#if NGEN_WITH_ROUTING
+#include "routing/Routing_Py_Adapter.hpp"
+#endif // NGEN_WITH_ROUTING
+
+NgenSimulation::NgenSimulation(
+    std::shared_ptr<realization::Formulation_Manager> formulation_manager,
+    std::vector<std::shared_ptr<ngen::Layer>> layers,
+    std::unordered_map<std::string, int> catchment_indexes,
+    std::vector<double> catchment_outflows,
+    std::unordered_map<std::string, int> nexus_indexes,
+    std::vector<double> nexus_downstream_flows
+                               )
+    : catchment_formulation_manager_(formulation_manager)
+    , sim_time_(std::make_shared<Simulation_Time>(*formulation_manager->Simulation_Time_Object))
+    , layers_(layers)
+    , catchment_indexes_(std::move(catchment_indexes))
+    , catchment_outflows_(std::move(catchment_outflows))
+    , nexus_indexes_(std::move(nexus_indexes))
+    , nexus_downstream_flows_(std::move(nexus_downstream_flows))
+{
+
+}
+
+void NgenSimulation::run_catchments()
+{
+    std::stringstream ss;
+
+    // Now loop some time, iterate catchments, do stuff for total number of output times
+    auto num_times = catchment_formulation_manager_->Simulation_Time_Object->get_total_output_times();
+
+    for (int count = 0; count < num_times; count++) {
+        // The Inner loop will advance all layers unless doing so will break one of two constraints
+        // 1) A layer may not proceed ahead of the master simulation object's current time
+        // 2) A layer may not proceed ahead of any layer that is computed before it
+        // The do while loop ensures that all layers are tested at least once while allowing
+        // layers with small time steps to be updated more than once
+        // If a layer with a large time step is after a layer with a small time step the
+        // layer with the large time step will wait for multiple timesteps from the preceeding
+        // layer.
+
+        // this is the time that layers are trying to reach (or get as close as possible)
+        auto next_time = catchment_formulation_manager_->Simulation_Time_Object->next_timestep_epoch_time();
+        auto next_time_private = sim_time_->next_timestep_epoch_time();
+
+        // this is the time that the layer above the current layer is at
+        auto prev_layer_time = next_time;
+
+        // this is the time that the least advanced layer is at
+        auto layer_min_next_time = next_time;
+        do {
+            for (auto& layer : layers_) {
+                auto layer_next_time = layer->next_timestep_epoch_time();
+
+                // only advance if you would not pass the master next time and the previous layer
+                // next time
+                if (layer_next_time <= next_time && layer_next_time <= prev_layer_time) {
+                    if (count % 100 == 0) {
+                        std::cout << "Updating layer: '" + layer->get_name() + "' at output step " + std::to_string(simulation_step_) << std::endl;
+                    }
+#if NGEN_WITH_ROUTING && false
+                    boost::span<double> catchment_span(catchment_outflows_.data() + (count * catchment_indexes_.size()),
+                                                       catchment_indexes_.size());
+                    boost::span<double> nexus_span(nexus_downstream_flows.data() + (count * nexus_indexes_.size()),
+                                                   nexus_indexes_.size());
+#else
+                boost::span<double> catchment_span;
+                boost::span<double> nexus_span;
+#endif
+                    layer->update_models(
+                        catchment_span,
+                        catchment_indexes_,
+                        nexus_span,
+                        nexus_indexes_,
+                        count
+                    ); // assume update_models() calls time->advance_timestep()
+                    prev_layer_time = layer_next_time;
+                } else {
+                    layer_min_next_time = prev_layer_time = layer->current_timestep_epoch_time();
+                }
+
+                if (layer_min_next_time > layer_next_time) {
+                    layer_min_next_time = layer_next_time;
+                }
+            } // done layers
+        } while (layer_min_next_time < next_time); // rerun the loop until the last layer would pass the master next time
+
+        if (count + 1 < num_times) {
+            sim_time_->advance_timestep();
+            catchment_formulation_manager_->Simulation_Time_Object->advance_timestep();
+        }
+    }
+}
+
+
+void NgenSimulation::advance_one_output_step()
+{
+
+}
+
+void NgenSimulation::run_routing()
+{
+#if NGEN_WITH_ROUTING
+    // Run t-route from single process
+    if (mpi_rank != 0)
+        return;
+
+    if (!catchment_formulation_manager_->get_using_routing())
+        return;
+
+    // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
+    // number_of_timesteps is determined from the total number of nexus outputs in t-route.
+    // It is recommended to still pass these values to the routing_py_adapter object in
+    // case a future implmentation needs these two values from the ngen framework.
+    int number_of_timesteps = catchment_formulation_manager_->Simulation_Time_Object->get_total_output_times();
+
+    int delta_time = catchment_formulation_manager_->Simulation_Time_Object->get_output_interval_seconds();
+
+    router_->route(number_of_timesteps, delta_time);
+#endif
+}
+
+template <class Archive>
+void NgenSimulation::serialize(Archive& ar) {
+    /* Handle `catchment_formulation_manager` specially in the
+     * overall checkpoint/restart logic, so that we can subset
+     * individual catchments and do other tricky things */
+    //ar & catchment_formulation_manager
+
+    ar & sim_time_;
+
+    // Layers will be reconstructed, but their internal time keeping needs to be serialized
+
+    // Nexus and catchment indexes could be re-generated, but only if
+    // the set of catchments remains consistent
+    ar & catchment_indexes_;
+    ar & catchment_outflows_;
+    ar & nexus_indexes_;
+    ar & nexus_downstream_flows_;
+}

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -28,8 +28,10 @@ NgenSimulation::NgenSimulation(
     , nexus_indexes_(std::move(nexus_indexes))
     , mpi_rank_(mpi_rank)
 {
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
     catchment_outflows_.reserve(catchment_indexes_.size() * get_num_output_times());
     nexus_downstream_flows_.reserve(nexus_indexes_.size() * get_num_output_times());
+#endif
 }
 
 NgenSimulation::~NgenSimulation() = default;
@@ -40,9 +42,11 @@ void NgenSimulation::run_catchments()
     auto num_times = get_num_output_times();
 
     for (; simulation_step_ < num_times; simulation_step_++) {
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         // Make room for this output step's results
         catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size(), 0.0);
         nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size(), 0.0);
+#endif
 
         advance_models_one_output_step();
 
@@ -82,7 +86,7 @@ void NgenSimulation::advance_models_one_output_step()
                     std::cout << "Updating layer: '" + layer->get_name() + "' at output step " + std::to_string(simulation_step_) << std::endl;
                 }
 
-#if NGEN_WITH_ROUTING && false
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
                 boost::span<double> catchment_span(catchment_outflows_.data() + (simulation_step_ * catchment_indexes_.size()),
                                                    catchment_indexes_.size());
                 boost::span<double> nexus_span(nexus_downstream_flows_.data() + (simulation_step_ * nexus_indexes_.size()),
@@ -144,7 +148,7 @@ void NgenSimulation::run_routing(std::string const& t_route_config_file_with_pat
 
 void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, std::string const& t_route_config_file_with_path)
 {
-#if NGEN_WITH_ROUTING
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
     std::vector<double> *routing_nexus_downflows = &nexus_downstream_flows_;
     std::unordered_map<std::string, int> *routing_nexus_indexes = &nexus_indexes_;
 
@@ -250,7 +254,7 @@ void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, st
         // Finalize will write the output file
         py_troute.Finalize();
     }
-#endif // NGEN_WITH_ROUTING
+#endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
 }
 
 size_t NgenSimulation::get_num_output_times() const

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -12,6 +12,7 @@ NgenSimulation::NgenSimulation(
     std::unordered_map<std::string, int> nexus_indexes
                                )
     : catchment_formulation_manager_(formulation_manager)
+    , simulation_step_(0)
     , sim_time_(std::make_shared<Simulation_Time>(*formulation_manager->Simulation_Time_Object))
     , layers_(std::move(layers))
     , catchment_indexes_(std::move(catchment_indexes))
@@ -28,7 +29,7 @@ void NgenSimulation::run_catchments()
     // Now loop some time, iterate catchments, do stuff for total number of output times
     auto num_times = get_num_output_times();
 
-    for (int count = 0; count < num_times; count++) {
+    for (; simulation_step_ < num_times; simulation_step_++) {
         // The Inner loop will advance all layers unless doing so will break one of two constraints
         // 1) A layer may not proceed ahead of the master simulation object's current time
         // 2) A layer may not proceed ahead of any layer that is computed before it
@@ -62,9 +63,9 @@ void NgenSimulation::run_catchments()
                         std::cout << "Updating layer: '" + layer->get_name() + "' at output step " + std::to_string(simulation_step_) << std::endl;
                     }
 #if NGEN_WITH_ROUTING && false
-                    boost::span<double> catchment_span(catchment_outflows_.data() + (count * catchment_indexes_.size()),
+                    boost::span<double> catchment_span(catchment_outflows_.data() + (simulation_step_ * catchment_indexes_.size()),
                                                        catchment_indexes_.size());
-                    boost::span<double> nexus_span(nexus_downstream_flows.data() + (count * nexus_indexes_.size()),
+                    boost::span<double> nexus_span(nexus_downstream_flows.data() + (simulation_step_ * nexus_indexes_.size()),
                                                    nexus_indexes_.size());
 #else
                 boost::span<double> catchment_span;
@@ -75,7 +76,7 @@ void NgenSimulation::run_catchments()
                         catchment_indexes_,
                         nexus_span,
                         nexus_indexes_,
-                        count
+                        simulation_step_
                     ); // assume update_models() calls time->advance_timestep()
                     prev_layer_time = layer_next_time;
                 } else {
@@ -88,7 +89,7 @@ void NgenSimulation::run_catchments()
             } // done layers
         } while (layer_min_next_time < next_time); // rerun the loop until the last layer would pass the master next time
 
-        if (count + 1 < num_times) {
+        if (simulation_step_ + 1 < num_times) {
             sim_time_->advance_timestep();
             catchment_formulation_manager_->Simulation_Time_Object->advance_timestep();
         }
@@ -231,6 +232,7 @@ void NgenSimulation::serialize(Archive& ar) {
      * individual catchments and do other tricky things */
     //ar & catchment_formulation_manager
 
+    ar & simulation_step_;
     ar & sim_time_;
 
     // Layers will be reconstructed, but their internal time keeping needs to be serialized

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -2,7 +2,7 @@
 #include <NGenConfig.h>
 
 #if NGEN_WITH_ROUTING
-#include "routing/Routing_Py_Adapter.hpp"
+#include "bmi/Bmi_Py_Adapter.hpp"
 #endif // NGEN_WITH_ROUTING
 
 NgenSimulation::NgenSimulation(

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -69,7 +69,7 @@ void NgenSimulation::run_catchments()
 #if NGEN_WITH_ROUTING && false
                     boost::span<double> catchment_span(catchment_outflows_.data() + (simulation_step_ * catchment_indexes_.size()),
                                                        catchment_indexes_.size());
-                    boost::span<double> nexus_span(nexus_downstream_flows.data() + (simulation_step_ * nexus_indexes_.size()),
+                    boost::span<double> nexus_span(nexus_downstream_flows_.data() + (simulation_step_ * nexus_indexes_.size()),
                                                    nexus_indexes_.size());
 #else
                 boost::span<double> catchment_span;
@@ -139,12 +139,12 @@ void NgenSimulation::run_routing()
         std::vector<double> receive_buffer(number_of_timesteps, 0.0);
         for (int i = 0; i < all_nexus_ids.size(); ++i) {
             std::string nexus_id = all_nexus_ids[i];
-            if (nexus_indexes.find(nexus_id) != nexus_indexes.end() && !features.is_remote_sender_nexus(nexus_id)) {
+            if (nexus_indexes_.find(nexus_id) != nexus_indexes_.end() && !features.is_remote_sender_nexus(nexus_id)) {
                 // if this process has the id and receives/records data, copy the values to the buffer
-                int nexus_index = nexus_indexes[nexus_id];
+                int nexus_index = nexus_indexes_[nexus_id];
                 for (int step = 0; step < number_of_timesteps; ++step) {
-                    int offset = step * nexus_indexes.size() + nexus_index;
-                    local_buffer[step] = nexus_downstream_flows[offset];
+                    int offset = step * nexus_indexes_.size() + nexus_index;
+                    local_buffer[step] = nexus_downstream_flows_[offset];
                 }
             } else {
                 // if this process does not have the id, fill with 0 to make sure it doesn't affect reduce sum
@@ -214,14 +214,14 @@ void NgenSimulation::run_routing()
             py_troute.SetValue("land_surface_water_source__id", nexus_df_index.data());
             for (int i = 0; i < number_of_timesteps; ++i) {
                 py_troute.SetValue("land_surface_water_source__volume_flow_rate",
-                                   nexus_downstream_flows.data() + (i * nexus_count));
+                                   nexus_downstream_flows_.data() + (i * nexus_count));
                 py_troute.Update();
             }
             // Finalize will write the output file
             py_troute.Finalize();
         }
     }
-#endif
+#endif // NGEN_WITH_ROUTING
 }
 
 size_t NgenSimulation::get_num_output_times()

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -108,7 +108,7 @@ void NgenSimulation::advance_one_output_step()
 
 }
 
-void NgenSimulation::run_routing()
+void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
 {
 #if NGEN_WITH_ROUTING
 #if NGEN_WITH_MPI

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -34,8 +34,8 @@ void NgenSimulation::run_catchments()
 
     for (; simulation_step_ < num_times; simulation_step_++) {
         // Make room for this output step's results
-        catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size());
-        nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size());
+        catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size(), 0.0);
+        nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size(), 0.0);
 
         advance_models_one_output_step();
 

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -244,6 +244,11 @@ size_t NgenSimulation::get_num_output_times() const
     return sim_time_->get_total_output_times();
 }
 
+std::string NgenSimulation::get_timestamp_for_step(int step) const
+{
+    return sim_time_->get_timestamp(step);
+}
+
 template <class Archive>
 void NgenSimulation::serialize(Archive& ar) {
     /* Handle `catchment_formulation_manager` specially in the

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -30,77 +30,81 @@ NgenSimulation::~NgenSimulation() = default;
 
 void NgenSimulation::run_catchments()
 {
-    std::stringstream ss;
-
     // Now loop some time, iterate catchments, do stuff for total number of output times
     auto num_times = get_num_output_times();
 
     for (; simulation_step_ < num_times; simulation_step_++) {
-        // The Inner loop will advance all layers unless doing so will break one of two constraints
-        // 1) A layer may not proceed ahead of the master simulation object's current time
-        // 2) A layer may not proceed ahead of any layer that is computed before it
-        // The do while loop ensures that all layers are tested at least once while allowing
-        // layers with small time steps to be updated more than once
-        // If a layer with a large time step is after a layer with a small time step the
-        // layer with the large time step will wait for multiple timesteps from the preceeding
-        // layer.
-
         // Make room for this output step's results
         catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size());
         nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size());
 
-        // this is the time that layers are trying to reach (or get as close as possible)
-        auto next_time = catchment_formulation_manager_->Simulation_Time_Object->next_timestep_epoch_time();
-        auto next_time_private = sim_time_->next_timestep_epoch_time();
-
-        // this is the time that the layer above the current layer is at
-        auto prev_layer_time = next_time;
-
-        // this is the time that the least advanced layer is at
-        auto layer_min_next_time = next_time;
-        do {
-            for (auto& layer : layers_) {
-                auto layer_next_time = layer->next_timestep_epoch_time();
-
-                // only advance if you would not pass the master next time and the previous layer
-                // next time
-                if (layer_next_time <= next_time && layer_next_time <= prev_layer_time) {
-                    if (count % 100 == 0) {
-                        std::cout << "Updating layer: '" + layer->get_name() + "' at output step " + std::to_string(simulation_step_) << std::endl;
-                    }
-
-#if NGEN_WITH_ROUTING && false
-                    boost::span<double> catchment_span(catchment_outflows_.data() + (simulation_step_ * catchment_indexes_.size()),
-                                                       catchment_indexes_.size());
-                    boost::span<double> nexus_span(nexus_downstream_flows_.data() + (simulation_step_ * nexus_indexes_.size()),
-                                                   nexus_indexes_.size());
-#else
-                boost::span<double> catchment_span;
-                boost::span<double> nexus_span;
-#endif
-                    layer->update_models(
-                        catchment_span,
-                        catchment_indexes_,
-                        nexus_span,
-                        nexus_indexes_,
-                        simulation_step_
-                    ); // assume update_models() calls time->advance_timestep()
-                    prev_layer_time = layer_next_time;
-                } else {
-                    layer_min_next_time = prev_layer_time = layer->current_timestep_epoch_time();
-                }
-
-                if (layer_min_next_time > layer_next_time) {
-                    layer_min_next_time = layer_next_time;
-                }
-            } // done layers
-        } while (layer_min_next_time < next_time); // rerun the loop until the last layer would pass the master next time
+        advance_one_output_step();
 
         if (simulation_step_ + 1 < num_times) {
             sim_time_->advance_timestep();
             catchment_formulation_manager_->Simulation_Time_Object->advance_timestep();
         }
     }
+}
+
+void NgenSimulation::advance_one_output_step()
+{
+    // The Inner loop will advance all layers unless doing so will break one of two constraints
+    // 1) A layer may not proceed ahead of the master simulation object's current time
+    // 2) A layer may not proceed ahead of any layer that is computed before it
+    // The do while loop ensures that all layers are tested at least once while allowing
+    // layers with small time steps to be updated more than once
+    // If a layer with a large time step is after a layer with a small time step the
+    // layer with the large time step will wait for multiple timesteps from the preceeding
+    // layer.
+
+    // this is the time that layers are trying to reach (or get as close as possible)
+    auto next_time = catchment_formulation_manager_->Simulation_Time_Object->next_timestep_epoch_time();
+    auto next_time_private = sim_time_->next_timestep_epoch_time();
+
+    // this is the time that the layer above the current layer is at
+    auto prev_layer_time = next_time;
+
+    // this is the time that the least advanced layer is at
+    auto layer_min_next_time = next_time;
+    do {
+        for (auto& layer : layers_) {
+            auto layer_next_time = layer->next_timestep_epoch_time();
+
+            // only advance if you would not pass the master next time and the previous layer
+            // next time
+            if (layer_next_time <= next_time && layer_next_time <= prev_layer_time) {
+                if (simulation_step_ % 100 == 0) {
+                    std::cout << "Updating layer: '" + layer->get_name() + "' at output step " + std::to_string(simulation_step_) << std::endl;
+                }
+
+#if NGEN_WITH_ROUTING && false
+                boost::span<double> catchment_span(catchment_outflows_.data() + (simulation_step_ * catchment_indexes_.size()),
+                                                   catchment_indexes_.size());
+                boost::span<double> nexus_span(nexus_downstream_flows_.data() + (simulation_step_ * nexus_indexes_.size()),
+                                               nexus_indexes_.size());
+#else
+                boost::span<double> catchment_span;
+                boost::span<double> nexus_span;
+#endif
+               layer->update_models(
+                                     catchment_span,
+                                     catchment_indexes_,
+                                     nexus_span,
+                                     nexus_indexes_,
+                                     simulation_step_
+                                     ); // assume update_models() calls time->advance_timestep()
+                prev_layer_time = layer_next_time;
+            } else {
+                layer_min_next_time = prev_layer_time = layer->current_timestep_epoch_time();
+            }
+
+            if (layer_min_next_time > layer_next_time) {
+                layer_min_next_time = layer_next_time;
+            }
+        } // done layers
+    } while (layer_min_next_time < next_time); // rerun the loop until the last layer would pass the master next time
+
 }
 
 int NgenSimulation::get_nexus_index(std::string const& nexus_id) const
@@ -112,11 +116,6 @@ int NgenSimulation::get_nexus_index(std::string const& nexus_id) const
 double NgenSimulation::get_nexus_outflow(int nexus_index, int timestep_index) const
 {
     return nexus_downstream_flows_[timestep_index * nexus_indexes_.size() + nexus_index];
-}
-
-void NgenSimulation::advance_one_output_step()
-{
-
 }
 
 void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -8,15 +8,14 @@
 #include "parallel_utils.h"
 
 NgenSimulation::NgenSimulation(
-    std::shared_ptr<realization::Formulation_Manager> formulation_manager,
+    Simulation_Time const& sim_time,
     std::vector<std::shared_ptr<ngen::Layer>> layers,
     std::unordered_map<std::string, int> catchment_indexes,
     std::unordered_map<std::string, int> nexus_indexes,
     int mpi_rank
                                )
-    : catchment_formulation_manager_(formulation_manager)
-    , simulation_step_(0)
-    , sim_time_(std::make_shared<Simulation_Time>(*formulation_manager->Simulation_Time_Object))
+    : simulation_step_(0)
+    , sim_time_(std::make_shared<Simulation_Time>(sim_time))
     , layers_(std::move(layers))
     , catchment_indexes_(std::move(catchment_indexes))
     , nexus_indexes_(std::move(nexus_indexes))
@@ -42,7 +41,6 @@ void NgenSimulation::run_catchments()
 
         if (simulation_step_ + 1 < num_times) {
             sim_time_->advance_timestep();
-            catchment_formulation_manager_->Simulation_Time_Object->advance_timestep();
         }
     }
 }
@@ -59,8 +57,7 @@ void NgenSimulation::advance_one_output_step()
     // layer.
 
     // this is the time that layers are trying to reach (or get as close as possible)
-    auto next_time = catchment_formulation_manager_->Simulation_Time_Object->next_timestep_epoch_time();
-    auto next_time_private = sim_time_->next_timestep_epoch_time();
+    auto next_time = sim_time_->next_timestep_epoch_time();
 
     // this is the time that the layer above the current layer is at
     auto prev_layer_time = next_time;
@@ -118,7 +115,7 @@ double NgenSimulation::get_nexus_outflow(int nexus_index, int timestep_index) co
     return nexus_downstream_flows_[timestep_index * nexus_indexes_.size() + nexus_index];
 }
 
-void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
+void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::string const& t_route_config_file_with_path)
 {
 #if NGEN_WITH_ROUTING
     std::vector<double> *routing_nexus_downflows = &nexus_downstream_flows_;
@@ -129,7 +126,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
     std::unordered_map<std::string, int> all_nexus_indexes;
 
     if (mpi_num_procs_ > 1) {
-        int number_of_timesteps = catchment_formulation_manager_->Simulation_Time_Object->get_total_output_times();
+        int number_of_timesteps = sim_time_->get_total_output_times();
         std::vector<std::string> local_nexus_ids;
         for (const auto& nexus : nexus_indexes_) {
             local_nexus_ids.push_back(nexus.first);
@@ -187,54 +184,50 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
 #endif // NGEN_WITH_MPI
 
     if (mpi_rank_ == 0) { // Run t-route from single process
-        if (catchment_formulation_manager_->get_using_routing()) {
-            LOG(LogLevel::INFO, "Running T-Route on nexus outflows.");
+        LOG(LogLevel::INFO, "Running T-Route on nexus outflows.");
 
-            // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
-            // number_of_timesteps is determined from the total number of nexus outputs in t-route.
-            // It is recommended to still pass these values to the routing_py_adapter object in
-            // case a future implmentation needs these two values from the ngen framework.
-            int number_of_timesteps = manager->Simulation_Time_Object->get_total_output_times();
+        // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
+        // number_of_timesteps is determined from the total number of nexus outputs in t-route.
+        // It is recommended to still pass these values to the routing_py_adapter object in
+        // case a future implmentation needs these two values from the ngen framework.
+        int number_of_timesteps = sim_time_->get_total_output_times();
 
-            int delta_time = manager->Simulation_Time_Object->get_output_interval_seconds();
+        int delta_time = sim_time_->get_output_interval_seconds();
 
-            std::string t_route_config_file_with_path =
-                manager->get_t_route_config_file_with_path();
-            // model for routing
-            models::bmi::Bmi_Py_Adapter py_troute("T-Route", t_route_config_file_with_path, "troute_nwm_bmi.troute_bmi.BmiTroute", true);
+        // model for routing
+        models::bmi::Bmi_Py_Adapter py_troute("T-Route", t_route_config_file_with_path, "troute_nwm_bmi.troute_bmi.BmiTroute", true);
 
-            // tell BMI to resize nexus containers
-            int64_t nexus_count = routing_nexus_indexes->size();
-            py_troute.SetValue("land_surface_water_source__volume_flow_rate__count", &nexus_count);
-            py_troute.SetValue("land_surface_water_source__id__count", &nexus_count);
-            // set up nexus id indexes
-            std::vector<int> nexus_df_index(nexus_count);
-            for (const auto& key_value : *routing_nexus_indexes) {
-                int id_index = key_value.second;
+        // tell BMI to resize nexus containers
+        int64_t nexus_count = routing_nexus_indexes->size();
+        py_troute.SetValue("land_surface_water_source__volume_flow_rate__count", &nexus_count);
+        py_troute.SetValue("land_surface_water_source__id__count", &nexus_count);
+        // set up nexus id indexes
+        std::vector<int> nexus_df_index(nexus_count);
+        for (const auto& key_value : *routing_nexus_indexes) {
+            int id_index = key_value.second;
 
-                // Convert string ID into numbers for T-route index
-                int id_as_int = -1;
-                size_t sep_index = key_value.first.find(hy_features::identifiers::seperator);
-                if (sep_index != std::string::npos) {
-                    std::string numbers = key_value.first.substr(sep_index + hy_features::identifiers::seperator.length());
-                    id_as_int = std::stoi(numbers);
-                }
-                if (id_as_int == -1) {
-                    std::string error_msg = "Cannot convert the nexus ID to an integer: " + key_value.first;
-                    LOG(LogLevel::FATAL, error_msg);
-                    throw std::runtime_error(error_msg);
-                }
-                nexus_df_index[id_index] = id_as_int;
+            // Convert string ID into numbers for T-route index
+            int id_as_int = -1;
+            size_t sep_index = key_value.first.find(hy_features::identifiers::seperator);
+            if (sep_index != std::string::npos) {
+                std::string numbers = key_value.first.substr(sep_index + hy_features::identifiers::seperator.length());
+                id_as_int = std::stoi(numbers);
             }
-            py_troute.SetValue("land_surface_water_source__id", nexus_df_index.data());
-            for (int i = 0; i < number_of_timesteps; ++i) {
-                py_troute.SetValue("land_surface_water_source__volume_flow_rate",
-                                   routing_nexus_downflows->data() + (i * nexus_count));
-                py_troute.Update();
+            if (id_as_int == -1) {
+                std::string error_msg = "Cannot convert the nexus ID to an integer: " + key_value.first;
+                LOG(LogLevel::FATAL, error_msg);
+                throw std::runtime_error(error_msg);
             }
-            // Finalize will write the output file
-            py_troute.Finalize();
+            nexus_df_index[id_index] = id_as_int;
         }
+        py_troute.SetValue("land_surface_water_source__id", nexus_df_index.data());
+        for (int i = 0; i < number_of_timesteps; ++i) {
+            py_troute.SetValue("land_surface_water_source__volume_flow_rate",
+                               routing_nexus_downflows->data() + (i * nexus_count));
+            py_troute.Update();
+        }
+        // Finalize will write the output file
+        py_troute.Finalize();
     }
 #endif // NGEN_WITH_ROUTING
 }

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -9,6 +9,7 @@
 
 #if NGEN_WITH_ROUTING
 #include "bmi/Bmi_Py_Adapter.hpp"
+#include "routing/Routing_Py_Adapter.hpp"
 #endif // NGEN_WITH_ROUTING
 
 #include "parallel_utils.h"
@@ -121,7 +122,27 @@ double NgenSimulation::get_nexus_outflow(int nexus_index, int timestep_index) co
     return nexus_downstream_flows_[timestep_index * nexus_indexes_.size() + nexus_index];
 }
 
-void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::string const& t_route_config_file_with_path)
+void NgenSimulation::run_routing(std::string const& t_route_config_file_with_path)
+{
+#if NGEN_WITH_ROUTING
+    // Run t-route from single process
+    if (mpi_rank_ != 0)
+        return;
+
+    router_ = std::make_unique<routing_py_adapter::Routing_Py_Adapter>(t_route_config_file_with_path);
+
+    // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
+    // number_of_timesteps is determined from the total number of nexus outputs in t-route.
+    // It is recommended to still pass these values to the routing_py_adapter object in
+    // case a future implmentation needs these two values from the ngen framework.
+    int number_of_timesteps = sim_time_->get_total_output_times();
+    int delta_time = sim_time_->get_output_interval_seconds();
+
+    router_->route(number_of_timesteps, delta_time);
+#endif
+}
+
+void NgenSimulation::run_routing_bmi(NgenSimulation::hy_features_t &features, std::string const& t_route_config_file_with_path)
 {
 #if NGEN_WITH_ROUTING
     std::vector<double> *routing_nexus_downflows = &nexus_downstream_flows_;
@@ -129,9 +150,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
 
     size_t number_of_timesteps = sim_time_->get_total_output_times();
     if (nexus_downstream_flows_.size() != number_of_timesteps * nexus_indexes_.size()) {
-        std::string msg = "Routing input data in NgenSimulation::nexus_downstream_flows_ does not reflect a full-duration run";
-        LOG(msg, LogLevel::FATAL);
-        throw std::runtime_error(msg);
+        throw std::runtime_error("Routing input data in NgenSimulation::nexus_downstream_flows_ does not reflect a full-duration run");
     }
 
 #if NGEN_WITH_MPI
@@ -196,13 +215,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
 #endif // NGEN_WITH_MPI
 
     if (mpi_rank_ == 0) { // Run t-route from single process
-        LOG(LogLevel::INFO, "Running T-Route on nexus outflows.");
-
-        // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
-        // number_of_timesteps is determined from the total number of nexus outputs in t-route.
-        // It is recommended to still pass these values to the routing_py_adapter object in
-        // case a future implementation needs these two values from the ngen framework.
-        int delta_time = sim_time_->get_output_interval_seconds();
+        //LOG(LogLevel::INFO, "Running T-Route on nexus outflows.");
 
         // model for routing
         models::bmi::Bmi_Py_Adapter py_troute("T-Route", t_route_config_file_with_path, "troute_nwm_bmi.troute_bmi.BmiTroute", true);
@@ -224,9 +237,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
                 id_as_int = std::stoi(numbers);
             }
             if (id_as_int == -1) {
-                std::string error_msg = "Cannot convert the nexus ID to an integer: " + key_value.first;
-                LOG(LogLevel::FATAL, error_msg);
-                throw std::runtime_error(error_msg);
+                throw std::runtime_error("Cannot convert the nexus ID to an integer: " + key_value.first);
             }
             nexus_df_index[id_index] = id_as_int;
         }

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -218,9 +218,9 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
 
             // Convert string ID into numbers for T-route index
             int id_as_int = -1;
-            size_t sep_index = key_value.first.find(hy_features::identifiers::seperator);
+            size_t sep_index = key_value.first.find(hy_features::identifiers::separator);
             if (sep_index != std::string::npos) {
-                std::string numbers = key_value.first.substr(sep_index + hy_features::identifiers::seperator.length());
+                std::string numbers = key_value.first.substr(sep_index + hy_features::identifiers::separator.length());
                 id_as_int = std::stoi(numbers);
             }
             if (id_as_int == -1) {

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -22,6 +22,8 @@ NgenSimulation::NgenSimulation(
     nexus_downstream_flows_.reserve(nexus_indexes_.size() * get_num_output_times());
 }
 
+NgenSimulation::~NgenSimulation() = default;
+
 void NgenSimulation::run_catchments()
 {
     std::stringstream ss;

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -1,6 +1,12 @@
 #include <NgenSimulation.hpp>
 #include <NGenConfig.h>
 
+#if NGEN_WITH_MPI
+#include "HY_Features_MPI.hpp"
+#else
+#include "HY_Features.hpp"
+#endif
+
 #if NGEN_WITH_ROUTING
 #include "bmi/Bmi_Py_Adapter.hpp"
 #endif // NGEN_WITH_ROUTING

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -9,7 +9,8 @@ NgenSimulation::NgenSimulation(
     std::shared_ptr<realization::Formulation_Manager> formulation_manager,
     std::vector<std::shared_ptr<ngen::Layer>> layers,
     std::unordered_map<std::string, int> catchment_indexes,
-    std::unordered_map<std::string, int> nexus_indexes
+    std::unordered_map<std::string, int> nexus_indexes,
+    int mpi_rank
                                )
     : catchment_formulation_manager_(formulation_manager)
     , simulation_step_(0)
@@ -17,6 +18,7 @@ NgenSimulation::NgenSimulation(
     , layers_(std::move(layers))
     , catchment_indexes_(std::move(catchment_indexes))
     , nexus_indexes_(std::move(nexus_indexes))
+    , mpi_rank_(mpi_rank)
 {
     catchment_outflows_.reserve(catchment_indexes_.size() * get_num_output_times());
     nexus_downstream_flows_.reserve(nexus_indexes_.size() * get_num_output_times());

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -122,9 +122,15 @@ void NgenSimulation::advance_one_output_step()
 void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
 {
 #if NGEN_WITH_ROUTING
+    std::vector<double> *routing_nexus_downflows = &nexus_downstream_flows_;
+    std::unordered_map<std::string, int> *routing_nexus_indexes = &nexus_indexes_;
+
 #if NGEN_WITH_MPI
-    if (mpi_num_procs > 1) {
-        int number_of_timesteps = manager->Simulation_Time_Object->get_total_output_times();
+    std::vector<double> all_nexus_downflows;
+    std::unordered_map<std::string, int> all_nexus_indexes;
+
+    if (mpi_num_procs_ > 1) {
+        int number_of_timesteps = catchment_formulation_manager_->Simulation_Time_Object->get_total_output_times();
         std::vector<std::string> local_nexus_ids;
         for (const auto& nexus : nexus_indexes_) {
             local_nexus_ids.push_back(nexus.first);
@@ -143,11 +149,9 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
         all_nexus_ids = std::move(parallel::broadcast_strings(all_nexus_ids, mpi_rank, mpi_num_procs));
 
         // MPI_Reduce to collect the results from processes
-        std::vector<double> all_nexus_downflows;
-        if (mpi_rank == 0) {
+        if (mpi_rank_ == 0) {
             all_nexus_downflows.resize(number_of_timesteps * all_nexus_ids.size(), 0.0);
         }
-        std::unordered_map<std::string, int> all_nexus_indexes;
         std::vector<double> local_buffer(number_of_timesteps);
         std::vector<double> receive_buffer(number_of_timesteps, 0.0);
         for (int i = 0; i < all_nexus_ids.size(); ++i) {
@@ -177,15 +181,14 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
 
         if (mpi_rank == 0) {
             // update root's local data for running t-route below
-            nexus_indexes_ = std::move(all_nexus_indexes);
-            nexus_downstream_flows_ = std::move(all_nexus_downflows);
+            routing_nexus_indexes = &all_nexus_indexes;
+            routing_nexus_downflows = &all_nexus_downflows;
         }
-
     }
 #endif // NGEN_WITH_MPI
 
-    if (mpi_rank == 0) { // Run t-route from single process
-        if (manager->get_using_routing()) {
+    if (mpi_rank_ == 0) { // Run t-route from single process
+        if (catchment_formulation_manager_->get_using_routing()) {
             LOG(LogLevel::INFO, "Running T-Route on nexus outflows.");
 
             // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
@@ -202,12 +205,12 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
             models::bmi::Bmi_Py_Adapter py_troute("T-Route", t_route_config_file_with_path, "troute_nwm_bmi.troute_bmi.BmiTroute", true);
 
             // tell BMI to resize nexus containers
-            int64_t nexus_count = nexus_indexes_.size();
+            int64_t nexus_count = routing_nexus_indexes->size();
             py_troute.SetValue("land_surface_water_source__volume_flow_rate__count", &nexus_count);
             py_troute.SetValue("land_surface_water_source__id__count", &nexus_count);
             // set up nexus id indexes
             std::vector<int> nexus_df_index(nexus_count);
-            for (const auto& key_value : nexus_indexes_) {
+            for (const auto& key_value : *routing_nexus_indexes) {
                 int id_index = key_value.second;
 
                 // Convert string ID into numbers for T-route index
@@ -227,7 +230,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features)
             py_troute.SetValue("land_surface_water_source__id", nexus_df_index.data());
             for (int i = 0; i < number_of_timesteps; ++i) {
                 py_troute.SetValue("land_surface_water_source__volume_flow_rate",
-                                   nexus_downstream_flows_.data() + (i * nexus_count));
+                                   routing_nexus_downflows->data() + (i * nexus_count));
                 py_troute.Update();
             }
             // Finalize will write the output file

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -13,17 +13,12 @@ NgenSimulation::NgenSimulation(
                                )
     : catchment_formulation_manager_(formulation_manager)
     , sim_time_(std::make_shared<Simulation_Time>(*formulation_manager->Simulation_Time_Object))
-    , layers_(layers)
+    , layers_(std::move(layers))
     , catchment_indexes_(std::move(catchment_indexes))
     , nexus_indexes_(std::move(nexus_indexes))
 {
-    auto num_times = sim_time_->get_total_output_times();
-
-    size_t num_catchments = catchment_indexes_.size();
-    catchment_outflows_.reserve(num_catchments * num_times);
-
-    size_t num_nexuses = nexus_indexes_.size();
-    nexus_downstream_flows_.reserve(num_nexuses * num_times);
+    catchment_outflows_.reserve(catchment_indexes_.size() * get_num_output_times());
+    nexus_downstream_flows_.reserve(nexus_indexes_.size() * get_num_output_times());
 }
 
 void NgenSimulation::run_catchments()
@@ -31,7 +26,7 @@ void NgenSimulation::run_catchments()
     std::stringstream ss;
 
     // Now loop some time, iterate catchments, do stuff for total number of output times
-    auto num_times = sim_time_->get_total_output_times();
+    auto num_times = get_num_output_times();
 
     for (int count = 0; count < num_times; count++) {
         // The Inner loop will advance all layers unless doing so will break one of two constraints
@@ -109,23 +104,124 @@ void NgenSimulation::advance_one_output_step()
 void NgenSimulation::run_routing()
 {
 #if NGEN_WITH_ROUTING
-    // Run t-route from single process
-    if (mpi_rank != 0)
-        return;
+#if NGEN_WITH_MPI
+    if (mpi_num_procs > 1) {
+        int number_of_timesteps = manager->Simulation_Time_Object->get_total_output_times();
+        std::vector<std::string> local_nexus_ids;
+        for (const auto& nexus : nexus_indexes) {
+            local_nexus_ids.push_back(nexus.first);
+        }
+        // MPI_Gather all nexus IDs into a single vector
+        std::vector<std::string> all_nexus_ids = parallel::gather_strings(local_nexus_ids, mpi_rank, mpi_num_procs);
+        if (mpi_rank == 0) {
+            // filter to only the unique IDs
+            std::sort(all_nexus_ids.begin(), all_nexus_ids.end());
+            all_nexus_ids.erase(
+                std::unique(all_nexus_ids.begin(), all_nexus_ids.end()),
+                all_nexus_ids.end()
+            );
+        }
+        // MPI_Broadcast so all processes share the nexus IDs
+        all_nexus_ids = std::move(parallel::broadcast_strings(all_nexus_ids, mpi_rank, mpi_num_procs));
 
-    if (!catchment_formulation_manager_->get_using_routing())
-        return;
+        // MPI_Reduce to collect the results from processes
+        std::vector<double> all_nexus_downflows;
+        if (mpi_rank == 0) {
+            all_nexus_downflows.resize(number_of_timesteps * all_nexus_ids.size(), 0.0);
+        }
+        std::unordered_map<std::string, int> all_nexus_indexes;
+        std::vector<double> local_buffer(number_of_timesteps);
+        std::vector<double> receive_buffer(number_of_timesteps, 0.0);
+        for (int i = 0; i < all_nexus_ids.size(); ++i) {
+            std::string nexus_id = all_nexus_ids[i];
+            if (nexus_indexes.find(nexus_id) != nexus_indexes.end() && !features.is_remote_sender_nexus(nexus_id)) {
+                // if this process has the id and receives/records data, copy the values to the buffer
+                int nexus_index = nexus_indexes[nexus_id];
+                for (int step = 0; step < number_of_timesteps; ++step) {
+                    int offset = step * nexus_indexes.size() + nexus_index;
+                    local_buffer[step] = nexus_downstream_flows[offset];
+                }
+            } else {
+                // if this process does not have the id, fill with 0 to make sure it doesn't affect reduce sum
+                std::fill(local_buffer.begin(), local_buffer.end(), 0.0);
+            }
+            MPI_Reduce(local_buffer.data(), receive_buffer.data(), number_of_timesteps, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+            if (mpi_rank == 0) {
+                // copy reduce values to a combined downflows vector
+                all_nexus_indexes[nexus_id] = i;
+                for (int step = 0; step < number_of_timesteps; ++step) {
+                    int offset = step * all_nexus_ids.size() + i;
+                    all_nexus_downflows[offset] = receive_buffer[step];
+                    receive_buffer[step] = 0.0;
+                }
+            }
+        }
 
-    // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
-    // number_of_timesteps is determined from the total number of nexus outputs in t-route.
-    // It is recommended to still pass these values to the routing_py_adapter object in
-    // case a future implmentation needs these two values from the ngen framework.
-    int number_of_timesteps = catchment_formulation_manager_->Simulation_Time_Object->get_total_output_times();
+        if (mpi_rank == 0) {
+            // update root's local data for running t-route below
+            nexus_indexes = std::move(all_nexus_indexes);
+            nexus_downstream_flows = std::move(all_nexus_downflows);
+        }
 
-    int delta_time = catchment_formulation_manager_->Simulation_Time_Object->get_output_interval_seconds();
+    }
+#endif // NGEN_WITH_MPI
 
-    router_->route(number_of_timesteps, delta_time);
+    if (mpi_rank == 0) { // Run t-route from single process
+        if (manager->get_using_routing()) {
+            LOG(LogLevel::INFO, "Running T-Route on nexus outflows.");
+
+            // Note: Currently, delta_time is set in the t-route yaml configuration file, and the
+            // number_of_timesteps is determined from the total number of nexus outputs in t-route.
+            // It is recommended to still pass these values to the routing_py_adapter object in
+            // case a future implmentation needs these two values from the ngen framework.
+            int number_of_timesteps = manager->Simulation_Time_Object->get_total_output_times();
+
+            int delta_time = manager->Simulation_Time_Object->get_output_interval_seconds();
+
+            std::string t_route_config_file_with_path =
+                manager->get_t_route_config_file_with_path();
+            // model for routing
+            models::bmi::Bmi_Py_Adapter py_troute("T-Route", t_route_config_file_with_path, "troute_nwm_bmi.troute_bmi.BmiTroute", true);
+
+            // tell BMI to resize nexus containers
+            int64_t nexus_count = nexus_indexes.size();
+            py_troute.SetValue("land_surface_water_source__volume_flow_rate__count", &nexus_count);
+            py_troute.SetValue("land_surface_water_source__id__count", &nexus_count);
+            // set up nexus id indexes
+            std::vector<int> nexus_df_index(nexus_count);
+            for (const auto& key_value : nexus_indexes) {
+                int id_index = key_value.second;
+
+                // Convert string ID into numbers for T-route index
+                int id_as_int = -1;
+                size_t sep_index = key_value.first.find(hy_features::identifiers::seperator);
+                if (sep_index != std::string::npos) {
+                    std::string numbers = key_value.first.substr(sep_index + hy_features::identifiers::seperator.length());
+                    id_as_int = std::stoi(numbers);
+                }
+                if (id_as_int == -1) {
+                    std::string error_msg = "Cannot convert the nexus ID to an integer: " + key_value.first;
+                    LOG(LogLevel::FATAL, error_msg);
+                    throw std::runtime_error(error_msg);
+                }
+                nexus_df_index[id_index] = id_as_int;
+            }
+            py_troute.SetValue("land_surface_water_source__id", nexus_df_index.data());
+            for (int i = 0; i < number_of_timesteps; ++i) {
+                py_troute.SetValue("land_surface_water_source__volume_flow_rate",
+                                   nexus_downstream_flows.data() + (i * nexus_count));
+                py_troute.Update();
+            }
+            // Finalize will write the output file
+            py_troute.Finalize();
+        }
+    }
 #endif
+}
+
+size_t NgenSimulation::get_num_output_times()
+{
+    return sim_time_->get_total_output_times();
 }
 
 template <class Archive>

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -37,7 +37,7 @@ void NgenSimulation::run_catchments()
         catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size());
         nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size());
 
-        advance_one_output_step();
+        advance_models_one_output_step();
 
         if (simulation_step_ + 1 < num_times) {
             sim_time_->advance_timestep();
@@ -45,7 +45,7 @@ void NgenSimulation::run_catchments()
     }
 }
 
-void NgenSimulation::advance_one_output_step()
+void NgenSimulation::advance_models_one_output_step()
 {
     // The Inner loop will advance all layers unless doing so will break one of two constraints
     // 1) A layer may not proceed ahead of the master simulation object's current time

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -64,10 +64,10 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         //std::cerr << "Requesting water from nexus, id = " << id << " at time = " <<current_time_index << ",  percent = 100, destination = " << cat_id << std::endl;
         double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
 
-#if NGEN_WITH_ROUTING && false
+#if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         int nexus_index = nexus_indexes[id];
         nexus_downstream_flows[nexus_index] += contribution_at_t;
-#endif // NGEN_WITH_ROUTING
+#endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
 
         // TODO: (later) eventually may want to use this form, if we support multiple formulations per catchment
         //nexus_outputs_mgr->receive_data_entry(form_id, id, current_time_index, current_timestamp, contribution_at_t);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -503,6 +503,19 @@ ngen_add_test(
         NGen::geojson
 )
 
+########################## NgenSimulation Class Tests
+ngen_add_test(
+    test_ngen_simulation
+    OBJECTS
+        core/NgenSimulationTests.cpp
+    LIBRARIES
+        NGen::core
+        NGen::geojson
+        NGen::logging
+        NGen::core_mediator
+        NGen::ngen_bmi
+)
+
 ########################### Netcdf Forcing Tests
 ngen_add_test(
     test_netcdf_forcing

--- a/test/core/NgenSimulationTests.cpp
+++ b/test/core/NgenSimulationTests.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include <NgenSimulation.hpp>
+
+//! Test that an instance of NgenSimulation can be created.
+TEST(NgenSimulation_Test, Construction)
+{
+    simulation_time_params time_params("2025-10-15 08:00:00", "2025-11-13 15:00:00", 3600);
+    Simulation_Time sim_time(time_params);
+    std::vector<std::shared_ptr<ngen::Layer>> layers;
+    std::unordered_map<std::string, int> catchment_indexes;
+    std::unordered_map<std::string, int> nexus_indexes;
+    int mpi_rank = 0;
+    int mpi_num_procs = 1;
+
+    std::unique_ptr<NgenSimulation> simulation{
+        new NgenSimulation(
+                           sim_time,
+                           layers,
+                           catchment_indexes,
+                           nexus_indexes,
+                           mpi_rank,
+                           mpi_num_procs
+                           )};
+}


### PR DESCRIPTION
This is one step along a path toward both modularizing the NGen codebase. This serves multiple development goals, including state saving and an eventual ability to load and drive NGen as a library, from a server or a variety of different UIs.

## Additions

- `class NgenSimulation`

## Changes

- Move a bunch of code from `main()` into member functions of `NgenSimulation`
- Move ownership of master `Simulation_Time` instance out of `Formulation_Manager`

## Testing

1. Local ctest
2. Github CI
3. A VPU for a month, with confirmation that results are identical

## Notes

- There's routing logic for driving t-route via the NGWPC-developed BMI implementation. It's conditionalized under `NGEN_WITH_ROUTING_TROUTE_BMI`. It sits alongside the existing implementation that just executes t-route as if it were a standalone script. The data retention in the BMI form is potentially problematic for large-scale, long-duration simulations. This could be broken into some sort of chunked or incremental execution, but that's not been developed yet on the t-route side, and implementing it here is out of scope.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
