### PR TITLE
geojson::FeatureCollection: Broaden const-correctness to all possible members

### DIFF
--- a/include/geojson/FeatureCollection.hpp
+++ b/include/geojson/FeatureCollection.hpp
@@ -87,12 +87,12 @@ namespace geojson {
             /**
              * @return The number of elements within the collection
              */
-            int get_size();
+            int get_size() const;
 
             /**
              * @return Whether or not the collection is empty
              */
-            bool is_empty();
+            bool is_empty() const;
 
             std::vector<double> get_bounding_box() const;
 
@@ -110,7 +110,7 @@ namespace geojson {
              * @param feature The feature to look for
              * @return -1 if the feature isn't in the collection, the numerical index otherwise
              */
-            int find(Feature feature);
+            int find(Feature feature) const;
 
             /**
              * Finds the index of a Feature with the given ID
@@ -118,7 +118,7 @@ namespace geojson {
              * @param ID The ID of the Feature to look for
              * @return -1 if the feature isn't in the collection, the numerical index otherwise
              */
-            int find(std::string ID);
+            int find(std::string ID) const;
 
             /**
              * Removes a feature from the collection based on index

--- a/src/geojson/FeatureCollection.cpp
+++ b/src/geojson/FeatureCollection.cpp
@@ -10,7 +10,7 @@ Feature FeatureCollection::get_feature(int index) const {
       return nullptr;
 }
 
-int FeatureCollection::find(Feature feature) {
+int FeatureCollection::find(Feature feature) const {
     for(int feature_index = 0; feature_index < this->get_size(); feature_index++) {
         if (*this->features[feature_index] == *feature) {
             return feature_index;
@@ -20,7 +20,7 @@ int FeatureCollection::find(Feature feature) {
     return -1;
 }
 
-int FeatureCollection::find(std::string ID) {
+int FeatureCollection::find(std::string ID) const {
     for (int feature_index = 0; feature_index < this->get_size(); feature_index++) {
         if (this->features[feature_index]->get_id() == ID) {
             return feature_index;
@@ -62,11 +62,11 @@ Feature FeatureCollection::remove_feature_by_id(std::string ID) {
     return popped_feature;
 }
 
-int FeatureCollection::get_size() {
+int FeatureCollection::get_size() const {
     return features.size();
 }
 
-bool FeatureCollection::is_empty() {
+bool FeatureCollection::is_empty() const {
     return features.size() == 0;
 }
 


### PR DESCRIPTION
Just qualify a few more members as `const`, to make it easier to pass this around and use it as such.

Note that this is normally referred to via 
```
include/geojson/FeatureBuilder.hpp:    typedef std::shared_ptr<FeatureCollection> GeoJSON;
```

I'm maybe going to try to change that to be a pointer to a `const` instance, that can come out of a builder function fully-formed.

## Testing

1. CI builds passes - no functionality changes

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
