### PR TITLE
Replace an exit() call in a utility function with an exception

### DIFF
--- a/include/simulation_time/Simulation_Time.hpp
+++ b/include/simulation_time/Simulation_Time.hpp
@@ -119,8 +119,7 @@ class Simulation_Time
         const char* time_format = "%Y-%m-%d %T";
 
         if (strftime(current_timestamp, sizeof(current_timestamp), time_format, temp_gmtime_struct) == 0) { 
-            fprintf(stderr, "ERROR: strftime returned 0");
-            exit(EXIT_FAILURE); 
+            throw std::runtime_error("ERROR: strftime returned 0");
         }
 
         return current_timestamp;


### PR DESCRIPTION
Stray calls to `exit()` on a local failure are not great for code that may be useful to call in a library. This is the only instance in the ngen codebase.

## Changes

- In `Simulation_Time`, a formatting error now throws an exception rather than calling `exit()`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
