### PR TITLE
Netcdf Time unit parsing for cf "since" convention support

### DIFF
--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -56,15 +56,14 @@ namespace data_access
         {
             TimeUnit unit;                  //the unit raw time values are stored in
             double scale_factor;            //multiplier converting a raw value to seconds
-            std::time_t epoch_start_time;   //reference epoch, in seconds since the Unix epoch
+            std::optional<std::time_t> epoch_start_time;   //reference epoch, in seconds since the Unix epoch, if specified
         };
 
         /**
          * @brief Interpret a NetCDF time `units` string as a time unit and scale factor.
          *
-         * The returned @ref TimeInfo carries the matched unit and scale factor; its
-         * @ref TimeInfo::epoch_start_time is left at the Unix epoch (0) since a bare units
-         * string does not, on its own, specify a reference epoch.
+         * Handles both bare units and the CF form "<unit> since <date>", in which case
+         * the parsed reference epoch is returned in the result.
          *
          * @param units_str the raw `units` attribute value (e.g. "ns", "hours")
          * @return the parsed @ref TimeInfo, or std::nullopt if @p units_str is unrecognized

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -18,6 +18,8 @@
 #include <mutex>
 #include "assert.h"
 #include <iomanip>
+#include <optional>
+#include <ctime>
 #include <boost/compute/detail/lru_cache.hpp>
 
 #include <UnitsHelper.hpp>
@@ -46,6 +48,37 @@ namespace data_access
             TIME_MICROSECONDS,
             TIME_NANOSECONDS
         };
+
+        /**
+         * @brief Time metadata for netcdf time units.
+         */
+        struct TimeInfo
+        {
+            TimeUnit unit;                  //the unit raw time values are stored in
+            double scale_factor;            //multiplier converting a raw value to seconds
+            std::time_t epoch_start_time;   //reference epoch, in seconds since the Unix epoch
+        };
+
+        /**
+         * @brief Interpret a NetCDF time `units` string as a time unit and scale factor.
+         *
+         * The returned @ref TimeInfo carries the matched unit and scale factor; its
+         * @ref TimeInfo::epoch_start_time is left at the Unix epoch (0) since a bare units
+         * string does not, on its own, specify a reference epoch.
+         *
+         * @param units_str the raw `units` attribute value (e.g. "ns", "hours")
+         * @return the parsed @ref TimeInfo, or std::nullopt if @p units_str is unrecognized
+         */
+        static std::optional<TimeInfo> interpret_time_units(const std::string& units_str);
+
+        /**
+         * @brief Parse a reference-epoch timestamp into seconds since the Unix epoch.
+         *
+         * @param epoch_str the timestamp text (e.g. "01/01/1970 00:00:00")
+         * @param format a std::get_time / strptime style format string
+         * @return seconds since the Unix epoch
+         */
+        static std::time_t parse_epoch(const std::string& epoch_str, const std::string& format);
 
         /**
          * @brief Factory method that creates or returns an existing provider for the provided path.
@@ -143,6 +176,19 @@ namespace data_access
         const std::string& get_ncvar_units(const std::string& name);
 
         void test_data_is_readable();
+
+        /**
+         * @brief Read the time unit, scale factor and reference epoch from a `Time` variable.
+         *
+         * Reads the `units` and `epoch_start` attributes and resolves them via
+         * @ref interpret_time_units and @ref parse_epoch, warning and falling back to
+         * sensible defaults (seconds, Unix epoch) when an attribute is absent or
+         * unrecognized.
+         *
+         * @param time_var the file's `Time` variable
+         * @return the resolved time metadata
+         */
+        TimeInfo get_time_metadata(const netCDF::NcVar& time_var);
 
     };
 }

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -77,9 +77,10 @@ std::time_t NetCDFPerFeatureDataProvider::parse_epoch(const std::string& epoch_s
     std::tm tm{};
     std::stringstream s(epoch_str);
     s >> std::get_time(&tm, format.c_str());
-    //std::time_t epoch_start_time = mktime(&tm);
-    // See also comments in Simulation_Time.h .. timegm is not available on Windows at least (elsewhere?)
-    //TODO: Probably make the default string above explicit to UTC and interpret TZ from the string in all cases?
+    if (s.fail()) {
+        throw std::runtime_error("Could not parse epoch '" + epoch_str + "' with format '" + format + "'");
+    }
+    // timegm is not available on Windows; see Simulation_Time.h
     return timegm(&tm);
 }
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -34,33 +34,46 @@ std::optional<NetCDFPerFeatureDataProvider::TimeInfo>
 NetCDFPerFeatureDataProvider::interpret_time_units(const std::string& units_str)
 {
     TimeInfo info;
-    info.epoch_start_time = 0; // a bare units string carries no reference epoch
-    if ( units_str == "h" || units_str == "hours" )
+    info.epoch_start_time = std::nullopt;
+
+    std::string time_unit_str = units_str;
+    std::string unit_epoch_str = "";
+
+    // CF conventions may have units of the form "<unit> since <date>"
+    size_t pos = time_unit_str.find(" since ");
+    if(pos != std::string::npos)
+    {
+        unit_epoch_str = time_unit_str.substr(pos + 7); // 7 is length of " since "
+        time_unit_str.erase(pos);
+    }
+
+    // set time unit and scale factor
+    if ( time_unit_str == "h" || time_unit_str == "hours")
     {
         info.unit = TIME_HOURS;
         info.scale_factor = 3600;
     }
-    else if ( units_str == "m" || units_str == "minutes" )
+    else if ( time_unit_str == "m" || time_unit_str == "minutes" )
     {
         info.unit = TIME_MINUTES;
         info.scale_factor = 60;
     }
-    else if ( units_str == "s" || units_str == "seconds" )
+    else if ( time_unit_str ==  "s" || time_unit_str == "seconds" )
     {
         info.unit = TIME_SECONDS;
         info.scale_factor = 1;
     }
-    else if ( units_str == "ms" || units_str == "milliseconds" )
+    else if ( time_unit_str ==  "ms" || time_unit_str == "milliseconds" )
     {
         info.unit = TIME_MILLISECONDS;
         info.scale_factor = .001;
     }
-    else if ( units_str == "us" || units_str == "microseconds" )
+    else if ( time_unit_str ==  "us" || time_unit_str == "microseconds" )
     {
         info.unit = TIME_MICROSECONDS;
         info.scale_factor = .000001;
     }
-    else if ( units_str == "ns" || units_str == "nanoseconds" )
+    else if ( time_unit_str ==  "ns" || time_unit_str == "nanoseconds" )
     {
         info.unit = TIME_NANOSECONDS;
         info.scale_factor = .000000001;
@@ -69,6 +82,13 @@ NetCDFPerFeatureDataProvider::interpret_time_units(const std::string& units_str)
     {
         return std::nullopt;
     }
+
+    if(!unit_epoch_str.empty())
+    {
+        //CF convention in time units formats as "YYYY-MM-DD HH:MM:SS"
+        info.epoch_start_time = parse_epoch(unit_epoch_str, "%Y-%m-%d %H:%M:%S");
+    }
+
     return info;
 }
 
@@ -88,7 +108,7 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
 {
     // read the meta data to get the time_unit
     // if absent, assume seconds
-    TimeInfo info{TIME_SECONDS, 1, 0};
+    TimeInfo info{TIME_SECONDS, 1, std::nullopt};
     try {
         auto time_unit_att = time_var.getAtt("units");
 
@@ -96,20 +116,15 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
         // TODO determine how this should be handled
         std::string time_unit_str;
 
-        if ( time_unit_att.isNull() )
-        {
-            log_stream << "Warning using defualt time units\n";
-        }
-        else
+        if ( !time_unit_att.isNull() )
         {
             time_unit_att.getValues(time_unit_str);
         }
 
-        // set time unit and scale factor
+        // set time unit, scale factor, and (for CF units) the reference epoch
         if ( auto parsed = interpret_time_units(time_unit_str) )
         {
-            info.unit = parsed->unit;
-            info.scale_factor = parsed->scale_factor;
+            info = *parsed;
         }
         else {
             log_stream << "Warning using defualt time units\n";
@@ -117,30 +132,32 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
     }
     catch(const netCDF::exceptions::NcException& e){
         std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning using defualt time units\n";
+        log_stream << "Warning: Couldn't read time unit attribute, using defualt time unit of Seconds\n";
     }
     assert(info.scale_factor != 0); // This should not happen.
 
-    std::string epoch_start_str = "01/01/1970 00:00:00";
-    try {
-        // read the meta data to get the epoc start
-        auto epoch_att = time_var.getAtt("epoch_start");
+    // fall back to the epoch_start attribute only when the units string didn't supply an epoch
+    if ( !info.epoch_start_time.has_value() )
+    {
+        try {
+            auto epoch_att = time_var.getAtt("epoch_start");
 
-        if ( epoch_att.isNull() )
-        {
+            if ( epoch_att.isNull() )
+            {
+                log_stream << "Warning using defualt epoc string\n";
+            }
+            else
+            {
+                std::string epoch_start_str;
+                epoch_att.getValues(epoch_start_str);
+                info.epoch_start_time = parse_epoch(epoch_start_str, "%D %T");
+            }
+        }
+        catch(const netCDF::exceptions::NcException& e) {
+            std::cerr<<e.what()<<std::endl;
             log_stream << "Warning using defualt epoc string\n";
         }
-        else
-        {
-            epoch_att.getValues(epoch_start_str);
-        }
     }
-    catch(const netCDF::exceptions::NcException& e) {
-        std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning using defualt epoc string\n";
-    }
-
-    info.epoch_start_time = parse_epoch(epoch_start_str, "%D %T");
 
     return info;
 }
@@ -279,7 +296,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     // TODO make sure this happens with a FMA instruction
     time_vals.resize(raw_time.size());
     std::transform(raw_time.begin(), raw_time.end(), time_vals.begin(),
-        [&](const auto& n){return n * time_info.scale_factor + time_info.epoch_start_time; });
+        [&](const auto& n){return n * time_info.scale_factor + time_info.epoch_start_time.value_or(0); });
         
 
     // determine the stride of the time array

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -40,11 +40,18 @@ NetCDFPerFeatureDataProvider::interpret_time_units(const std::string& units_str)
     std::string unit_epoch_str = "";
 
     // CF conventions may have units of the form "<unit> since <date>"
-    size_t pos = time_unit_str.find(" since ");
-    if(pos != std::string::npos)
+    std::string since = " since ";
+    size_t since_pos = units_str.find(since);
+    if(since_pos != std::string::npos)
     {
-        unit_epoch_str = time_unit_str.substr(pos + 7); // 7 is length of " since "
-        time_unit_str.erase(pos);
+        time_unit_str = units_str.substr(0, since_pos);
+        unit_epoch_str = units_str.substr(since_pos + since.length());
+    }
+
+    if(!unit_epoch_str.empty())
+    {
+        //CF convention in time units formats as "YYYY-MM-DD HH:MM:SS"
+        info.epoch_start_time = parse_epoch(unit_epoch_str, "%Y-%m-%d %H:%M:%S");
     }
 
     // set time unit and scale factor
@@ -66,27 +73,21 @@ NetCDFPerFeatureDataProvider::interpret_time_units(const std::string& units_str)
     else if ( time_unit_str ==  "ms" || time_unit_str == "milliseconds" )
     {
         info.unit = TIME_MILLISECONDS;
-        info.scale_factor = .001;
+        info.scale_factor = 1.0e-3;
     }
     else if ( time_unit_str ==  "us" || time_unit_str == "microseconds" )
     {
         info.unit = TIME_MICROSECONDS;
-        info.scale_factor = .000001;
+        info.scale_factor = 1.0e-6;
     }
     else if ( time_unit_str ==  "ns" || time_unit_str == "nanoseconds" )
     {
         info.unit = TIME_NANOSECONDS;
-        info.scale_factor = .000000001;
+        info.scale_factor = 1.0e-9;
     }
     else
     {
         return std::nullopt;
-    }
-
-    if(!unit_epoch_str.empty())
-    {
-        //CF convention in time units formats as "YYYY-MM-DD HH:MM:SS"
-        info.epoch_start_time = parse_epoch(unit_epoch_str, "%Y-%m-%d %H:%M:%S");
     }
 
     return info;
@@ -127,12 +128,12 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
             info = *parsed;
         }
         else {
-            log_stream << "Warning using defualt time units\n";
+            log_stream << "Warning using default time units\n";
         }
     }
     catch(const netCDF::exceptions::NcException& e){
         std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning: Couldn't read time unit attribute, using defualt time unit of Seconds\n";
+        log_stream << "Warning: Couldn't read time unit attribute, using default time unit of Seconds\n";
     }
     assert(info.scale_factor != 0); // This should not happen.
 
@@ -144,7 +145,7 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
 
             if ( epoch_att.isNull() )
             {
-                log_stream << "Warning using defualt epoc string\n";
+                log_stream << "Warning using default epoch string\n";
             }
             else
             {
@@ -155,7 +156,7 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
         }
         catch(const netCDF::exceptions::NcException& e) {
             std::cerr<<e.what()<<std::endl;
-            log_stream << "Warning using defualt epoc string\n";
+            log_stream << "Warning using default epoch string\n";
         }
     }
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -30,6 +30,120 @@ void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
     shared_providers.clear();
 }
 
+std::optional<NetCDFPerFeatureDataProvider::TimeInfo>
+NetCDFPerFeatureDataProvider::interpret_time_units(const std::string& units_str)
+{
+    TimeInfo info;
+    info.epoch_start_time = 0; // a bare units string carries no reference epoch
+    if ( units_str == "h" || units_str == "hours" )
+    {
+        info.unit = TIME_HOURS;
+        info.scale_factor = 3600;
+    }
+    else if ( units_str == "m" || units_str == "minutes" )
+    {
+        info.unit = TIME_MINUTES;
+        info.scale_factor = 60;
+    }
+    else if ( units_str == "s" || units_str == "seconds" )
+    {
+        info.unit = TIME_SECONDS;
+        info.scale_factor = 1;
+    }
+    else if ( units_str == "ms" || units_str == "milliseconds" )
+    {
+        info.unit = TIME_MILLISECONDS;
+        info.scale_factor = .001;
+    }
+    else if ( units_str == "us" || units_str == "microseconds" )
+    {
+        info.unit = TIME_MICROSECONDS;
+        info.scale_factor = .000001;
+    }
+    else if ( units_str == "ns" || units_str == "nanoseconds" )
+    {
+        info.unit = TIME_NANOSECONDS;
+        info.scale_factor = .000000001;
+    }
+    else
+    {
+        return std::nullopt;
+    }
+    return info;
+}
+
+std::time_t NetCDFPerFeatureDataProvider::parse_epoch(const std::string& epoch_str, const std::string& format)
+{
+    std::tm tm{};
+    std::stringstream s(epoch_str);
+    s >> std::get_time(&tm, format.c_str());
+    //std::time_t epoch_start_time = mktime(&tm);
+    // See also comments in Simulation_Time.h .. timegm is not available on Windows at least (elsewhere?)
+    //TODO: Probably make the default string above explicit to UTC and interpret TZ from the string in all cases?
+    return timegm(&tm);
+}
+
+NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_metadata(const netCDF::NcVar& time_var)
+{
+    // read the meta data to get the time_unit
+    // if absent, assume seconds
+    TimeInfo info{TIME_SECONDS, 1, 0};
+    try {
+        auto time_unit_att = time_var.getAtt("units");
+
+        // if time att is not encoded
+        // TODO determine how this should be handled
+        std::string time_unit_str;
+
+        if ( time_unit_att.isNull() )
+        {
+            log_stream << "Warning using defualt time units\n";
+        }
+        else
+        {
+            time_unit_att.getValues(time_unit_str);
+        }
+
+        // set time unit and scale factor
+        if ( auto parsed = interpret_time_units(time_unit_str) )
+        {
+            info.unit = parsed->unit;
+            info.scale_factor = parsed->scale_factor;
+        }
+        else {
+            log_stream << "Warning using defualt time units\n";
+        }
+    }
+    catch(const netCDF::exceptions::NcException& e){
+        std::cerr<<e.what()<<std::endl;
+        log_stream << "Warning using defualt time units\n";
+    }
+    assert(info.scale_factor != 0); // This should not happen.
+
+    std::string epoch_start_str = "01/01/1970 00:00:00";
+    try {
+        // read the meta data to get the epoc start
+        auto epoch_att = time_var.getAtt("epoch_start");
+
+        if ( epoch_att.isNull() )
+        {
+            log_stream << "Warning using defualt epoc string\n";
+        }
+        else
+        {
+            epoch_att.getValues(epoch_start_str);
+        }
+    }
+    catch(const netCDF::exceptions::NcException& e) {
+        std::cerr<<e.what()<<std::endl;
+        log_stream << "Warning using defualt epoc string\n";
+    }
+
+    info.epoch_start_time = parse_epoch(epoch_start_str, "%D %T");
+
+    return info;
+}
+
 NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
     sim_start_date_time_epoch(sim_start),
     sim_end_date_time_epoch(sim_end)
@@ -156,99 +270,15 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     count.push_back(num_times);
     time_var.getVar(start, count, &raw_time[0]);
 
-    // read the meta data to get the time_unit
-    // if absent, assume seconds
-    double time_scale_factor = 1;
-    time_unit = TIME_SECONDS;
-    try {
-        auto time_unit_att = time_var.getAtt("units");
-
-        // if time att is not encoded 
-        // TODO determine how this should be handled
-        std::string time_unit_str;
-
-        if ( time_unit_att.isNull() )
-        {
-            log_stream << "Warning using defualt time units\n";
-        }
-        else
-        {  
-            time_unit_att.getValues(time_unit_str);
-        }
-
-        // set time unit and scale factor
-        if ( time_unit_str == "h" || time_unit_str == "hours")
-        {
-            time_unit = TIME_HOURS;
-            time_scale_factor = 3600;
-        }
-        else if ( time_unit_str == "m" || time_unit_str == "minutes" )
-        {
-            time_unit = TIME_MINUTES;
-            time_scale_factor = 60;
-        }
-        else if ( time_unit_str ==  "s" || time_unit_str == "seconds" )
-        {
-            time_unit = TIME_SECONDS;
-            time_scale_factor = 1;
-        }
-        else if ( time_unit_str ==  "ms" || time_unit_str == "milliseconds" )
-        {
-            time_unit = TIME_MILLISECONDS;
-            time_scale_factor = .001;
-        }
-        else if ( time_unit_str ==  "us" || time_unit_str == "microseconds" )
-        {
-            time_unit = TIME_MICROSECONDS;
-            time_scale_factor = .000001;
-        }
-        else if ( time_unit_str ==  "ns" || time_unit_str == "nanoseconds" )
-        {
-            time_unit = TIME_NANOSECONDS;
-            time_scale_factor = .000000001;
-        }
-        else {
-            log_stream << "Warning using defualt time units\n";
-        }
-    }
-    catch(const netCDF::exceptions::NcException& e){
-        std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning using defualt time units\n";
-    }
-    assert(time_scale_factor != 0); // This should not happen.
-
-    std::string epoch_start_str = "01/01/1970 00:00:00";
-    try {
-        // read the meta data to get the epoc start
-        auto epoch_att = time_var.getAtt("epoch_start");
-
-        if ( epoch_att.isNull() )
-        {
-            log_stream << "Warning using defualt epoc string\n";
-        }
-        else
-        {  
-            epoch_att.getValues(epoch_start_str);
-        }
-    }
-    catch(const netCDF::exceptions::NcException& e) {
-        std::cerr<<e.what()<<std::endl;
-        log_stream << "Warning using defualt epoc string\n";
-    }
-    
-    std::tm tm{};
-    std::stringstream s(epoch_start_str);
-    s >> std::get_time(&tm, "%D %T");
-    //std::time_t epoch_start_time = mktime(&tm);
-    // See also comments in Simulation_Time.h .. timegm is not available on Windows at least (elsewhere?)
-    //TODO: Probably make the default string above explicit to UTC and interpret TZ from the string in all cases?
-    std::time_t epoch_start_time = timegm(&tm);
+    // read the time metadata (unit, scale factor and reference epoch)
+    TimeInfo time_info = get_time_metadata(time_var);
+    time_unit = time_info.unit;
 
     // scale the time to account for time units and epoch_start
     // TODO make sure this happens with a FMA instruction
     time_vals.resize(raw_time.size());
-    std::transform(raw_time.begin(), raw_time.end(), time_vals.begin(), 
-        [&](const auto& n){return n * time_scale_factor + epoch_start_time; });
+    std::transform(raw_time.begin(), raw_time.end(), time_vals.begin(),
+        [&](const auto& n){return n * time_info.scale_factor + time_info.epoch_start_time; });
         
 
     // determine the stride of the time array

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -163,5 +163,7 @@ TEST(NetCDFTimeMetadata, ParseEpoch)
     EXPECT_EQ(P::parse_epoch("2000-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"), 946684800);
     // the provider's default epoch string and format
     EXPECT_EQ(P::parse_epoch("01/01/1970 00:00:00", "%D %T"), 0);
+    // a timestamp that doesn't match the format is an error, not a silent zero
+    EXPECT_THROW(P::parse_epoch("not a date", "%Y-%m-%d %H:%M:%S"), std::runtime_error);
 }
 #endif

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -140,8 +140,27 @@ TEST(NetCDFTimeMetadata, InterpretTimeUnitsRecognized)
         ASSERT_TRUE(info.has_value()) << "expected to recognize unit '" << c.str << "'";
         EXPECT_EQ(info->unit, c.unit) << "unit mismatch for '" << c.str << "'";
         EXPECT_DOUBLE_EQ(info->scale_factor, c.scale) << "scale mismatch for '" << c.str << "'";
-        EXPECT_EQ(info->epoch_start_time, 0) << "bare units must not set an epoch for '" << c.str << "'";
+        EXPECT_FALSE(info->epoch_start_time.has_value()) << "bare units must not set an epoch for '" << c.str << "'";
     }
+}
+
+// CF "<unit> since <date>" units yield the base unit plus the embedded reference epoch.
+TEST(NetCDFTimeMetadata, InterpretTimeUnitsCFSinceEpoch)
+{
+    using P = NetCDFPerFeatureDataProvider;
+    auto secs = P::interpret_time_units("seconds since 1970-01-01 00:00:00");
+    ASSERT_TRUE(secs.has_value());
+    EXPECT_EQ(secs->unit, P::TIME_SECONDS);
+    EXPECT_DOUBLE_EQ(secs->scale_factor, 1);
+    ASSERT_TRUE(secs->epoch_start_time.has_value());
+    EXPECT_EQ(*secs->epoch_start_time, 0);
+
+    auto hrs = P::interpret_time_units("hours since 2000-01-01 00:00:00");
+    ASSERT_TRUE(hrs.has_value());
+    EXPECT_EQ(hrs->unit, P::TIME_HOURS);
+    EXPECT_DOUBLE_EQ(hrs->scale_factor, 3600);
+    ASSERT_TRUE(hrs->epoch_start_time.has_value());
+    EXPECT_EQ(*hrs->epoch_start_time, 946684800);
 }
 
 // Unrecognized or empty unit strings yield no value, so callers keep their defaults.

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -110,8 +110,58 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
 
     // read exactly one time step correctly aligned but with a incorrect variable
     EXPECT_THROW(
-        double val4 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);, 
+        double val4 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);,
         std::runtime_error);
-    
+
+}
+
+// Each recognized time `units` token maps to the expected unit and scale factor,
+// and a bare units string reports no reference epoch.
+TEST(NetCDFTimeMetadata, InterpretTimeUnitsRecognized)
+{
+    using P = NetCDFPerFeatureDataProvider;
+    struct Case { const char* str; P::TimeUnit unit; double scale; };
+    const std::vector<Case> cases = {
+        {"h",            P::TIME_HOURS,        3600},
+        {"hours",        P::TIME_HOURS,        3600},
+        {"m",            P::TIME_MINUTES,      60},
+        {"minutes",      P::TIME_MINUTES,      60},
+        {"s",            P::TIME_SECONDS,      1},
+        {"seconds",      P::TIME_SECONDS,      1},
+        {"ms",           P::TIME_MILLISECONDS, .001},
+        {"milliseconds", P::TIME_MILLISECONDS, .001},
+        {"us",           P::TIME_MICROSECONDS, .000001},
+        {"microseconds", P::TIME_MICROSECONDS, .000001},
+        {"ns",           P::TIME_NANOSECONDS,  .000000001},
+        {"nanoseconds",  P::TIME_NANOSECONDS,  .000000001},
+    };
+    for (const auto& c : cases) {
+        auto info = P::interpret_time_units(c.str);
+        ASSERT_TRUE(info.has_value()) << "expected to recognize unit '" << c.str << "'";
+        EXPECT_EQ(info->unit, c.unit) << "unit mismatch for '" << c.str << "'";
+        EXPECT_DOUBLE_EQ(info->scale_factor, c.scale) << "scale mismatch for '" << c.str << "'";
+        EXPECT_EQ(info->epoch_start_time, 0) << "bare units must not set an epoch for '" << c.str << "'";
+    }
+}
+
+// Unrecognized or empty unit strings yield no value, so callers keep their defaults.
+TEST(NetCDFTimeMetadata, InterpretTimeUnitsUnrecognized)
+{
+    using P = NetCDFPerFeatureDataProvider;
+    EXPECT_FALSE(P::interpret_time_units("").has_value());
+    EXPECT_FALSE(P::interpret_time_units("days").has_value());
+    EXPECT_FALSE(P::interpret_time_units("fortnights").has_value());
+}
+
+// parse_epoch converts a timestamp to UTC epoch seconds and honors the supplied format.
+TEST(NetCDFTimeMetadata, ParseEpoch)
+{
+    using P = NetCDFPerFeatureDataProvider;
+    // unambiguous 4-digit-year format
+    EXPECT_EQ(P::parse_epoch("1970-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"), 0);
+    EXPECT_EQ(P::parse_epoch("1970-01-02 00:00:00", "%Y-%m-%d %H:%M:%S"), 86400);
+    EXPECT_EQ(P::parse_epoch("2000-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"), 946684800);
+    // the provider's default epoch string and format
+    EXPECT_EQ(P::parse_epoch("01/01/1970 00:00:00", "%D %T"), 0);
 }
 #endif


### PR DESCRIPTION
PR #944 (commit 
https://github.com/NOAA-OWP/ngen/pull/944/changes/fbfce108ba62c668e0ca7a81e77a731abfea0a6d) introduced this feature on that branch.  Based on review in that PR, this functionality was pulled into its own PR. 

This refactors the meta data parsing and handling from the constructor into some helper functions, then applies the logic from the original commit to enable support for "unit since epoch" time units.

## Additions

- New helper functions which simplify construction logic

## Removals

- Dropped a duplicate warning

## Changes

- Can parse time units as a unit string *or* a "unit since epoch" string.

## Testing

1. Helper functions have tests for the parsing and the conventions being applied.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1. All netcdf tests passing locally

### Target Environment support

- [x] Linux
- [x] MacOS
