### PR TITLE
Netcdf Forcing Provider QoL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ include(CMakeDependentOption)
 
 option(NGEN_WITH_MPI         "Build with MPI support"             OFF)
 option(NGEN_WITH_NETCDF      "Build with NetCDF support"          OFF)
+option(NGEN_WITH_HDF5        "Build with HDF5 support"            OFF)
 option(NGEN_WITH_SQLITE      "Build with SQLite3 support"         OFF)
 option(NGEN_WITH_UDUNITS     "Build with UDUNITS2 support"        ON)
 option(NGEN_WITH_BMI_FORTRAN "Build with Fortran BMI support"     OFF)
@@ -209,6 +210,12 @@ if(NGEN_WITH_NETCDF)
     endif()
 endif()
 
+# -----------------------------------------------------------------------------
+if(NGEN_WITH_HDF5)
+    find_package(HDF5 REQUIRED COMPONENTS C CXX)
+    add_compile_definitions(NGEN_WITH_HDF5)
+endif()
+
 if(NGEN_WITH_EXTERN_SLOTH)
     # This is set because SLOTH will link to gtest by default,
     # which causes a configure error.
@@ -353,6 +360,10 @@ target_link_libraries(ngen
         NGen::parallel
 )
 
+if(NGEN_WITH_HDF5)
+    target_link_libraries(ngen PUBLIC hdf5::hdf5 hdf5::hdf5_cpp)
+endif()
+
 if(NGEN_WITH_SQLITE)
     add_subdirectory("src/geopackage")
     target_link_libraries(ngen PUBLIC NGen::geopackage)
@@ -434,6 +445,7 @@ ngen_multiline_message(
 "    NGEN_WITH_MPI: ${NGEN_WITH_MPI}"
 "    NGEN_WITH_NETCDF: ${NGEN_WITH_NETCDF}"
 "    NGEN_WITH_PARALLEL_NETCDF: ${NGEN_WITH_PARALLEL_NETCDF}"
+"    NGEN_WITH_HDF5: ${NGEN_WITH_HDF5}"
 "    NGEN_WITH_SQLITE: ${NGEN_WITH_SQLITE}"
 "    NGEN_WITH_UDUNITS: ${NGEN_WITH_UDUNITS}"
 "    NGEN_WITH_BMI_FORTRAN: ${NGEN_WITH_BMI_FORTRAN}"
@@ -473,6 +485,12 @@ ngen_dependent_multiline_message(NGEN_WITH_NETCDF
 "    Include: ${NetCDF_INCLUDE_DIR}"
 "    Include (CXX): ${NetCDF_CXX_INCLUDE_DIR}"
 "    Parallel: ${NetCDF_HAS_PARALLEL}")
+ngen_dependent_multiline_message(NGEN_WITH_HDF5
+"  HDF5:"
+"    Version: ${HDF5_VERSION}"
+"    Libraries: ${HDF5_LIBRARIES}"
+"    Include: ${HDF5_INCLUDE_DIRS}"
+"    Is Parallel: ${HDF5_IS_PARALLEL}")
 ngen_dependent_multiline_message(NGEN_WITH_SQLITE
 "  SQLite:"
 "    Version: ${SQLite3_VERSION}"

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -142,6 +142,8 @@ namespace data_access
 
         const std::string& get_ncvar_units(const std::string& name);
 
+        void test_data_is_readable();
+
     };
 }
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -47,6 +47,10 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         std::cerr<<e.what()<<std::endl;
         throw;
     }
+    // do a quick test of the netcdf variables to ensure
+    // they are readable, especially if compressed with HDF5 filters
+    // This also has the added benefit of warming up the chunk cache
+    test_data_is_readable();
 
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
@@ -466,6 +470,57 @@ const std::string& NetCDFPerFeatureDataProvider::get_ncvar_units(const std::stri
     }
 
     throw std::runtime_error("Got units request for variable " + name + " but it was not found in the cache. This should not happen." + SOURCE_LOC);
+}
+
+void NetCDFPerFeatureDataProvider::test_data_is_readable() {
+    // Try to read one element from each variable to test if NetCDF/HDF5 linking works for compressed data
+    auto var_set = nc_file->getVars();
+    for (const auto& var_pair : var_set) {
+        const std::string& var_name = var_pair.first;
+        auto var = var_pair.second;
+        // Skip scalar variables
+        if (var.getDimCount() == 0) continue;
+        std::vector<size_t> start(var.getDimCount(), 0);
+        std::vector<size_t> count(var.getDimCount(), 1);
+        try {
+            if (var.getType().getTypeClass() == NC_STRING) {
+                // Handle string variable
+                std::vector<char*> buffer(1);
+                var.getVar(start, count, buffer.data());
+                nc_free_string(1, buffer.data());
+            } else if (var.getType().getTypeClass() == NC_INT) {
+                // Handle int variable
+                int val;
+                var.getVar(start, count, &val);
+            } else if (var.getType().getTypeClass() == NC_DOUBLE) {
+                // Handle double variable
+                double val;
+                var.getVar(start, count, &val);
+            } else {
+                // Skip other types
+                continue;
+            }
+        } catch (const netCDF::exceptions::NcException& e) {
+            std::string err_str = e.what();
+            // libnetcxx puts a lot of noice in the error message
+            // so filter it out for clarity...
+            size_t file_pos = err_str.find("file:");
+            if (file_pos != std::string::npos) {
+                err_str = err_str.substr(0, file_pos);
+            }
+            std::string msg = "Error reading " + var_name + " variable: " + err_str;
+            // If ngen isn't directly linked against HDF5, then loading hdf5 plugin filters
+            // fails, and compressed data cannot be read.  So check for filter issues
+            // and provide a more helpful error message.
+            if (err_str.find("NetCDF") != std::string::npos && (err_str.find("filter") != std::string::npos || err_str.find("Filter") != std::string::npos)) {
+                msg +=  "This may happen if HDF5 isn't properly linked with ngen. "
+                        "Ensure the build uses NGEN_WITH_HDF5. "
+                        "Also check the $HDF5_PLUGIN_PATH environment variable and/or "
+                        "nc-config --plugindir to ensure filter plugins are available.";
+            }
+            throw std::runtime_error(msg);
+        }
+    }
 }
 
 }

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -114,6 +114,9 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     }
 
     auto num_ids = id_dim.getSize();
+    if (num_ids <= 0){
+        throw std::runtime_error("Provided NetCDF file has no features");
+    }
 
     //TODO: split into smaller slices if num_ids is large.
     cache_slice_c_size = num_ids;

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -39,8 +39,15 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     //nc_set_chunk_cache(sizep, nelemsp, preemptionp);
 
     //open the file
-    nc_file = std::make_shared<netCDF::NcFile>(input_path, netCDF::NcFile::read);
-    
+    try{
+        nc_file = std::make_shared<netCDF::NcFile>(input_path, netCDF::NcFile::read);
+    }
+    catch(const netCDF::exceptions::NcException& e){
+        std::cerr<<"Error opening NetCDF file: "<<input_path<<std::endl;
+        std::cerr<<e.what()<<std::endl;
+        throw;
+    }
+
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -125,7 +125,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     std::vector< char* > string_buffers(num_ids);
 
     // read the id strings
-    ids.getVar(&string_buffers[0]);
+    ids.getVar(string_buffers.data());
 
     // initalize the map of catchment-name to offset location and free the strings allocated by the C library
     size_t loc = 0;


### PR DESCRIPTION
The following commits from [PR #944](https://github.com/NOAA-OWP/ngen/pull/944) were pulled into this branch.

- [optional linking with hdf5 for enhanced netcdf filters](https://github.com/NOAA-OWP/ngen/pull/944/changes/9cc6f4d36c5bf7176aa25bba5947996f1f11e67f) — CMake reworked to link the exported HDF5 target rather than the raw library files
- [error reporting on failed netcdf file open](https://github.com/NOAA-OWP/ngen/pull/944/changes/71f0eaab6071d5473ab87ab3890fcfc577d257d8)
- [ensure netcdf variables are readable](https://github.com/NOAA-OWP/ngen/pull/944/changes/aa81a64578170840c00be42c38cfb3e5868c0d76)
- [improve method name readability (rename to `test_data_is_readable`)](https://github.com/NOAA-OWP/ngen/pull/944/changes/af31de5a9389f8d0e52844b4541dc75361cfa623)
- [throw if no netcdf features](https://github.com/NOAA-OWP/ngen/pull/944/changes/17a21c11fea783f8ac998c6b0eae99e79e41f5df)
- [use simpler syntax for getting vector backing pointer](https://github.com/NOAA-OWP/ngen/pull/944/changes/f498acff3f005fbde6c459112b1bf71f15025eb7)


## Additions

- Optional build flag for linking HDF5
- Runtime check that netcdf vars are readable at construction time

## Changes

- Errors thrown when files are not readable or no features are read

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
