### PR TITLE
Feature: netcdf chunked reads

### DIFF
--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -175,7 +175,10 @@ namespace data_access
         std::map<std::string,netCDF::NcVar> ncvar_cache;
         std::map<std::string,std::string> units_cache;
         boost::compute::detail::lru_cache<std::string, std::shared_ptr<std::vector<double>>> value_cache;
-        size_t cache_slice_t_size = 1;
+        // number of time slices per cache entry
+        // this is a tunable parameter; your mileage may vary
+        // NOTE: it would be nice if this were divisible by 2 and 4
+        size_t cache_slice_t_size = 18;
         size_t cache_slice_c_size = 1;
 
         const netCDF::NcVar& get_ncvar(const std::string& name);

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -178,7 +178,7 @@ namespace data_access
         // number of time slices per cache entry
         // this is a tunable parameter; your mileage may vary
         // NOTE: it would be nice if this were divisible by 2 and 4
-        size_t cache_slice_t_size = 18;
+        size_t cache_slice_t_size = 24;
         size_t cache_slice_c_size = 1;
 
         const netCDF::NcVar& get_ncvar(const std::string& name);
@@ -199,6 +199,19 @@ namespace data_access
          * @return the resolved time metadata
          */
         TimeInfo get_time_metadata(const netCDF::NcVar& time_var);
+
+        /**
+         * @brief Attempts to align the internal cache size with the chunking parameters of
+         * the underlying netCDF variables.
+         * If no chunking is present, the default cache size is used.
+         *
+         * This can have some significant performance implications.
+         * both in terms of memory use and speed of access.
+         * If the variables are chunked too large, then the cache will hold
+         * a lot of data in memory.  If they are too small, then we end up
+         * doing a lot of small reads from the netCDF file.
+         */
+        void align_cache_with_chunks();
 
         /**
          * @brief If applicable, update chunk spans.

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <set>
 #include <sstream>
 #include <exception>
 #include <mutex>
@@ -88,12 +89,17 @@ namespace data_access
         static std::shared_ptr<NetCDFPerFeatureDataProvider> get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s);
 
         /**
+         * @brief Tell provider an id it is expected to provide.
+         */
+        void hint_shared_provider_id(const std::string& id);
+
+        /**
          * @brief Cleanup the shared providers cache, ensuring that the files get closed.
          */
         static void cleanup_shared_providers();
 
         NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s);
-
+        NetCDFPerFeatureDataProvider() = delete;
         // Default implementation defined in the .cpp file so that
         // client code doesn't need to have the full definition of
         // NcFile visible for the compiler to implicitly generate
@@ -154,7 +160,9 @@ namespace data_access
         std::vector<std::string> variable_names;
         std::vector<std::string> loc_ids;
         std::vector<double> time_vals;
-        std::map<std::string, std::size_t> id_pos;
+        std::set<std::string> hinted_ids;
+        std::map<std::string, std::size_t> id_pos;      // map from cat-id to position in vec of nc var values; accounts for chunking
+        std::vector<std::pair<size_t, size_t>> chunks;  // a chunk is the start and length of a span in the "catchment-id" dim of a nc variable
         double start_time;                              // the begining of the first time for which data is stored
         double stop_time;                               // the end of the last time for which data is stored
         TimeUnit time_unit;                             // the unit that time was stored as in the file
@@ -189,6 +197,12 @@ namespace data_access
          */
         TimeInfo get_time_metadata(const netCDF::NcVar& time_var);
 
+        /**
+         * @brief If applicable, update chunk spans.
+         * Note, no hint_shared_provider_id() calls should be made afterwards.
+         * Note, additional calls have no effect.
+         */
+        void maybe_update_chunks_with_hints();
     };
 }
 

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -58,7 +58,12 @@ namespace realization {
             // TODO: this likely needs to be rethought and refactored, but for now, 
             // this allows the NetCDF provider to log to standard output while still allowing
             // formulations to log to their own output streams as needed.
-            fp = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
+            std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> f;
+            f = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
+            // TODO: this is not _ideal_ but implements the idea.
+            // refactor in the future.
+            f->hint_shared_provider_id(identifier);
+            fp = f;
         }
 #endif
         else if (forcing_config.provider == "NullForcingProvider"){

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -23,6 +23,7 @@ std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_
     return p;
 }
 
+
 void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
 {
     const std::lock_guard<std::mutex> lock(shared_providers_mutex);
@@ -251,6 +252,10 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         throw std::runtime_error("Provided NetCDF file has no features");
     }
 
+    // include all catchments in the "default" chunk
+    auto pair = std::pair<size_t, size_t>(0, num_ids);
+    chunks.push_back(pair);
+
     //TODO: split into smaller slices if num_ids is large.
     cache_slice_c_size = num_ids;
 
@@ -267,7 +272,9 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
         loc_ids.push_back(str);
         id_pos[str] = loc++;
     });
-
+    // Make sure we were able to read an actual string type
+    // each id should start with "cat-"
+    assert(loc_ids[0].size() > 4);;
     // correct string release
     nc_free_string(num_ids,&string_buffers[0]);
 
@@ -323,6 +330,103 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     stop_time = time_vals.back() + time_stride;
 
     sim_to_data_time_offset = sim_start_date_time_epoch - start_time;
+}
+
+void NetCDFPerFeatureDataProvider::hint_shared_provider_id(const std::string& id)
+{
+    hinted_ids.emplace(id);
+}
+
+void NetCDFPerFeatureDataProvider::maybe_update_chunks_with_hints()
+{
+    auto ids = hinted_ids;
+    if (hinted_ids.size() == 0){
+        return;
+    }
+
+    // Base cases covered in other ctor
+    if (ids.size() == get_ids().size() || ids.size() == 0) {
+        assert(chunks.size() == 1);
+        hinted_ids.clear();
+        return;
+    }
+    // get rid of "default" chunks, we will build them here
+    chunks.clear();
+
+    // Map from nc cat-id index to cat-id; sorted by index position
+    std::map<std::size_t, std::string> idx_map;
+
+    // remove "id_pos" keys that are not in "ids"
+    {
+        auto it = id_pos.begin();
+        while (it != id_pos.end()) {
+            auto sub = ids.find(it->first);
+            if (sub != ids.end()) {
+                // Here we know the id AND its position in the index
+                idx_map.emplace(it->second, it->first);
+                ++it;
+            } else {
+                it = id_pos.erase(it);
+            }
+        }
+    }
+    if(idx_map.empty()){
+        throw std::runtime_error("NetCDF source has no ids matching the domain hinted ids.");
+    }
+    // Build chunks where a chunk has:
+    // a starting nc index
+    // the length of the chunk relative to its starting index
+    //
+    // While building the chunks, rebase nc indices to now "internal" cache indices
+    auto it = idx_map.begin();
+    std::string& key = it->second;
+
+    std::size_t left, right;
+    left = it->first;
+    right = it->first;
+    //  start nc idx, length
+    std::pair<size_t, size_t> pair(left, 1);
+
+    std::size_t n = 0;
+    id_pos[key] = n;
+    n++;
+
+    // NOTE: not sure if there are dependencies elsewhere on the ordering of this vector.
+    // refill in the expected order just to be on the safe side.
+    loc_ids.clear();
+    loc_ids.push_back(key);
+    for (++it; it != idx_map.end(); ++it) {
+        std::size_t current = it->first;
+        if (right < current-1){
+            pair.second = right-left+1;
+            chunks.push_back(pair);
+
+            left  = current;
+            right = current;
+            pair.first = current;
+        }else{
+            right = current;
+        }
+
+        key = it->second;
+        // NOTE: update "id_pos" with new "internal" index
+        id_pos[key] = n;
+        n++;
+
+        // push key back onto "loc_ids" in its original order
+        loc_ids.push_back(key);
+    }
+    pair.second = right-left+1;
+    chunks.push_back(pair);
+
+    // minor gains
+    loc_ids.shrink_to_fit();
+
+    cache_slice_c_size = loc_ids.size();
+
+    // TODO: improve this; we only want this method to "do something" once.
+    //       invariant is, weakly, enforced by prelude guard clause.
+    hinted_ids.clear();
 }
 
 NetCDFPerFeatureDataProvider::~NetCDFPerFeatureDataProvider() = default;
@@ -396,6 +500,13 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
         idx2 = get_ts_index_for_time(this->stop_time-1); //to the edge
     }
 
+    // update chunks during the first timestep
+    if (hinted_ids.size() > 0){
+        // 'maybe_update_chunks_with_hints' clears 'hinted_ids'
+        // assumes all id's will have been hinted before 'get_value' is called.
+        maybe_update_chunks_with_hints();
+    }
+
     auto stride = idx2 - idx1;
 
     std::vector<std::size_t> start, count;
@@ -428,14 +539,24 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
         if(value_cache.contains(key)){
             cached = value_cache.get(key).get();
         } else {
-            cached = std::make_shared<std::vector<double>>(cache_slice_c_size * cache_slice_t_size);
-            start.clear();
-            start.push_back(0); // only always 0 when cache_slice_c_size = numids!
-            start.push_back(cache_t_idx * cache_slice_t_size);
-            count.clear();
-            count.push_back(cache_slice_c_size);
-            count.push_back(cache_slice_t_size); // Must be 1 for now!...probably...
-            ncvar.getVar(start,count,&(*cached)[0]);
+            cached = std::make_shared<std::vector<double>>(get_ids().size());
+            // read each chunk and add it to "cached"
+            std::size_t next_cache_idx = 0;
+            for(auto const& chunk: chunks){
+                // chunk start index = chunk.first;
+                // chunk length      = chunk.second;
+                start.clear();
+                start.push_back(chunk.first);
+                start.push_back(cache_t_idx);
+
+                count.clear();
+                count.push_back(chunk.second);
+                assert(cache_slice_t_size == 1);
+                count.push_back(cache_slice_t_size); // Must be 1 for now!...probably...
+                ncvar.getVar(start,count,&(*cached)[next_cache_idx]);
+                next_cache_idx += chunk.second;
+            }
+
             value_cache.insert(key, cached);
         }
         for( size_t j = 0; j < cache_slice_t_size; j++){

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -28,7 +28,6 @@ std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_
     return p;
 }
 
-
 void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
 {
     const std::lock_guard<std::mutex> lock(shared_providers_mutex);
@@ -193,7 +192,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
 
     //nc_get_chunk_cache(&sizep, &nelemsp, &preemptionp);
     //std::cout << "Chunk cache parameters: "<<sizep<<", "<<nelemsp<<", "<<preemptionp<<std::endl;
-
+    align_cache_with_chunks();
     //get the listing of all variables
     auto var_set = nc_file->getVars();
 
@@ -726,6 +725,32 @@ void NetCDFPerFeatureDataProvider::test_data_is_readable() {
             throw std::runtime_error(msg);
         }
     }
+}
+
+void NetCDFPerFeatureDataProvider::align_cache_with_chunks()
+{
+    auto num_times = nc_file->getDim("time").getSize();
+
+    auto var_set = nc_file->getVars();
+    for (const auto& var_pair : var_set) {
+        const std::string& var_name = var_pair.first;
+        auto var = var_pair.second;
+        // Skip the Time variable itself and ids, look for data variables with at least 2 dimensions
+        if (var_name == "Time" || var_name == "ids" || var_name == "catchment-id" || var.getDimCount() < 2) continue;
+        netCDF::NcVar::ChunkMode mode;
+        std::vector<size_t> chunk_sizes;
+        var.getChunkingParameters(mode, chunk_sizes);
+        if (mode == netCDF::NcVar::ChunkMode::nc_CHUNKED && chunk_sizes.size() >= 2) {
+            cache_slice_t_size = chunk_sizes[1];  // Assume second dimension is time
+            break;  // Use the first suitable chunk size found
+        }
+    }
+    if (num_times && cache_slice_t_size > num_times){
+        cache_slice_t_size = num_times;
+    }
+    //At this point the time slice cache is either aligned with the chunking of the data variables
+    //or set to the default value.
+    return;
 }
 
 }

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -8,6 +8,11 @@
 std::mutex data_access::NetCDFPerFeatureDataProvider::shared_providers_mutex;
 std::map<std::string, std::shared_ptr<data_access::NetCDFPerFeatureDataProvider>> data_access::NetCDFPerFeatureDataProvider::shared_providers;
 
+// limit access outside of compilation unit.
+namespace {
+    const size_t N_EXPECTED_FORCING_VARS = 8;
+}
+
 namespace data_access {
 
 std::shared_ptr<NetCDFPerFeatureDataProvider> NetCDFPerFeatureDataProvider::get_shared_provider(std::string input_path, time_t sim_start, time_t sim_end, utils::StreamHandler log_s)
@@ -164,7 +169,7 @@ NetCDFPerFeatureDataProvider::TimeInfo NetCDFPerFeatureDataProvider::get_time_me
     return info;
 }
 
-NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
+NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(N_EXPECTED_FORCING_VARS),
     sim_start_date_time_epoch(sim_start),
     sim_end_date_time_epoch(sim_end)
 {
@@ -511,9 +516,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
 
     std::vector<std::size_t> start, count;
 
-    auto cat_pos = id_pos[selector.get_id()];
-
-
+    auto cat_idx = id_pos[selector.get_id()];
 
     double t1 = time_vals[idx1];
     double t2 = time_vals[idx2];
@@ -524,22 +527,41 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
 
     std::string native_units = get_ncvar_units(selector.get_variable_name());
 
-    auto read_len = idx2 - idx1 + 1;
+    const std::size_t read_len = idx2 - idx1 + 1;
 
     std::vector<double> raw_values;
-    raw_values.resize(read_len);
+    raw_values.reserve(read_len);
 
-    //TODO: Currently assuming a whole variable cache slice across all catchments for a single timestep...but some stuff here to support otherwise.
-    size_t cache_slices_t_n = read_len / cache_slice_t_size; // Integer division!
+    std::size_t idx1_cache_slice_start = idx1 - (idx1 % cache_slice_t_size);
+    std::size_t time_idx = idx1 % cache_slice_t_size;
+
+    std::size_t n_cache_slices = (read_len / cache_slice_t_size) + std::min(read_len % cache_slice_t_size, std::size_t(1));
+    size_t value_idx = idx1;
     // For reference: https://stackoverflow.com/a/72030286
-    for( size_t i = 0; i < cache_slices_t_n; i++ ) {
+    for( size_t i = 0; i < n_cache_slices; i++ ) {
+        // rows: catchments; columns: time;
+        // stride between rows is 'cache_slice_t_size'
         std::shared_ptr<std::vector<double>> cached;
-        int cache_t_idx = (idx1 - (idx1 % cache_slice_t_size) + i);
-        std::string key = ncvar.getName() + "|" + std::to_string(cache_t_idx);
+
+        std::size_t cache_slice_start = idx1_cache_slice_start + (i * cache_slice_t_size);
+        std::size_t adjusted_size = cache_slice_t_size;
+        // Read up to the end of the data, but not beyond
+        if(cache_slice_start + cache_slice_t_size > time_vals.size() ){
+            adjusted_size = time_vals.size() - cache_slice_start;
+        }
+        std::string key = ncvar.getName() + "|" + std::to_string(cache_slice_start);
         if(value_cache.contains(key)){
             cached = value_cache.get(key).get();
         } else {
-            cached = std::make_shared<std::vector<double>>(get_ids().size());
+            // NOTE: aaraney: I am leaning towards just 'over allocating'
+            /* size_t last_bucket = get_ts_index_for_time(this->stop_time-1) / bucket_size; */
+            /* assert(bucket_idx <= last_bucket); */
+            /* size_t n_time = bucket_size; */
+            /* if (bucket_idx == last_bucket){ */
+            /*     n_time = (get_ts_index_for_time(this->stop_time-1) % bucket_size) + 1; */
+            /* } */
+            cached = std::make_shared<std::vector<double>>(get_ids().size() *  cache_slice_t_size);
+
             // read each chunk and add it to "cached"
             std::size_t next_cache_idx = 0;
             for(auto const& chunk: chunks){
@@ -547,24 +569,34 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
                 // chunk length      = chunk.second;
                 start.clear();
                 start.push_back(chunk.first);
-                start.push_back(cache_t_idx);
+
+                // NOTE: in the first iteration, we might read more data in the Time
+                // dimension than we 'need'. b.c. we read from:
+                // 'idx1 - (idx1 % cache_slice_t_size)' to the end of the cache line.
+                // so, if 'idx1 % cache_slice_t_size > 0' we will read
+                // 'idx1 % cache_slice_t_size * next_chunk_idx' more values than we 'need' to.
+                start.push_back(cache_slice_start);
 
                 count.clear();
                 count.push_back(chunk.second);
-                assert(cache_slice_t_size == 1);
-                count.push_back(cache_slice_t_size); // Must be 1 for now!...probably...
+
+                count.push_back(adjusted_size);
                 ncvar.getVar(start,count,&(*cached)[next_cache_idx]);
-                next_cache_idx += chunk.second;
+                next_cache_idx += chunk.second * adjusted_size;
             }
 
             value_cache.insert(key, cached);
         }
-        for( size_t j = 0; j < cache_slice_t_size; j++){
-            raw_values[i+j] = cached->at((j*cache_slice_t_size) + cat_pos);
+        // Find all values in the current cache slice and push them onto raw_values
+        while(value_idx >= cache_slice_start && 
+              value_idx < cache_slice_start + cache_slice_t_size &&
+              value_idx <= idx2){
+            raw_values.push_back(cached->at((cat_idx * cache_slice_t_size) + (value_idx % cache_slice_t_size)));
+            value_idx++;
         }
     }
 
-    
+    assert(raw_values.size() == read_len);
     rvalue = 0.0;
 
     double a , b = 0.0;

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -28,19 +28,11 @@ class NetCDFPerFeatureDataProviderTest : public ::testing::Test {
 
     void setupForcing();
 
-    std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> nc_provider;
-
-    typedef struct tm time_type;
-
-    std::shared_ptr<time_type> start_date_time;
-
-    std::shared_ptr<time_type> end_date_time;
-
+    std::string forcing_file_name;
+    std::unique_ptr<forcing_params> forcing_p;
 };
 
 void NetCDFPerFeatureDataProviderTest::SetUp() {
-    //setupForcing();
-
     setupForcing();
 }
 
@@ -58,21 +50,134 @@ void NetCDFPerFeatureDataProviderTest::setupForcing()
         "../data/forcing/cats-27_52_67-2015_12_01-2015_12_30.nc",
         "../../data/forcing/cats-27_52_67-2015_12_01-2015_12_30.nc"
         };
-    std::string forcing_file_name = utils::FileChecker::find_first_readable(forcing_file_names);
+    forcing_file_name = utils::FileChecker::find_first_readable(forcing_file_names);
 
     // Using this to compute epoch times... this is what's done in Formulation_Constructors.hpp, FWIW...
-    forcing_params forcing_p(forcing_file_name, "NetCDF", "2015-12-01 00:00:00", "2015-12-30 23:00:00");
+    forcing_p = std::make_unique<forcing_params>(forcing_file_name, "NetCDF", "2015-12-01 00:00:00", "2015-12-30 23:00:00");
+}
 
-    nc_provider = std::make_shared<data_access::NetCDFPerFeatureDataProvider>(forcing_file_name, forcing_p.simulation_start_t, forcing_p.simulation_end_t, utils::getStdErr() );
-    start_date_time = std::make_shared<time_type>();
-    end_date_time = std::make_shared<time_type>();
+///Test AORC Forcing Object
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadUsingIds)
+{
+    std::vector<std::string> ids = {"cat-27", "cat-52", "cat-67"};
+
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for(const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 3> expected = {285.8, 285.9, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+
+    ASSERT_EQ(ids, nc_provider.get_ids());
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadUsingIdsIsNotReverse)
+{
+    std::vector<std::string> ids = {"cat-27", "cat-52", "cat-67"};
+    auto rev = ids;
+    std::reverse(rev.begin(), rev.end());
+
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for(const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 3> expected = {285.8, 285.9, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+    auto ids_out = nc_provider.get_ids();
+    ASSERT_NE(rev, ids_out);
+    ASSERT_EQ(ids, ids_out);
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadUsingIdsSingle)
+{
+    std::vector<std::string> ids = {"cat-52"};
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    nc_provider.hint_shared_provider_id(ids[0]);
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    double value = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+    EXPECT_NEAR(value, 285.9, tol);
+    ASSERT_EQ(ids, nc_provider.get_ids());
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadSpan)
+{
+    std::vector<std::string> ids = {"cat-52", "cat-67"};
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for (const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 2> expected = {285.9, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+    ASSERT_EQ(ids, nc_provider.get_ids());
+}
+
+TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataReadMultiSpan)
+{
+    std::vector<std::string> ids = {"cat-27", "cat-67"};
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+    for (const std::string& id: ids){
+        nc_provider.hint_shared_provider_id(id);
+    }
+
+    auto start_time = nc_provider.get_data_start_time();
+    auto duration = nc_provider.record_duration();
+
+    double tol = 0.00002;
+    std::array<double, 2> expected = {285.8, 285.7};
+    size_t i = 0;
+    // read exactly one time step correctly aligned
+    for (const double expect: expected){
+        double result = nc_provider.get_value(CatchmentAggrDataSelector(ids[i], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+        EXPECT_NEAR(result, expect, tol);
+        i++;
+    }
+    ASSERT_EQ(ids, nc_provider.get_ids());
 }
 
 ///Test AORC Forcing Object
 TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
 {
+    NetCDFPerFeatureDataProvider nc_provider(forcing_file_name, forcing_p->simulation_start_t, forcing_p->simulation_end_t, utils::getStdErr() );
+
     // check to see that the variable "T2D" exists
-    auto var_names = nc_provider->get_available_variable_names();
+    auto var_names = nc_provider.get_available_variable_names();
     auto pos = std::find(var_names.begin(), var_names.end(), CSDMS_STD_NAME_SURFACE_TEMP);
     if ( pos != var_names.end() )
     {
@@ -84,14 +189,14 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
         FAIL();
     }
 
-    auto start_time = nc_provider->get_data_start_time();
-    auto ids = nc_provider->get_ids();
-    auto duration = nc_provider->record_duration();
+    auto start_time = nc_provider.get_data_start_time();
+    auto ids = nc_provider.get_ids();
+    auto duration = nc_provider.record_duration();
 
     //std::cout << "Checking values in catchment "<<ids[0]<<" at time "<<start_time<<" with duration "<<duration<<"..."<<std::endl;
 
     // read exactly one time step correctly aligned
-    double val1 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
+    double val1 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration, "K"), data_access::MEAN);
 
     //double tol = 0.00000612;
     double tol = 0.00002;
@@ -99,18 +204,18 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
     EXPECT_NEAR(val1, 285.8, tol);
 
     // read 1/2 of a time step correctly aligned
-    double val2 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration / 2, "K"), data_access::MEAN);
+    double val2 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration / 2, "K"), data_access::MEAN);
 
     EXPECT_NEAR(val2, 285.8, tol);
 
     // read 4 time steps correctly aligned
-    double val3 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration * 4, "K"), data_access::MEAN);
+    double val3 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], CSDMS_STD_NAME_SURFACE_TEMP, start_time, duration * 4, "K"), data_access::MEAN);
 
     EXPECT_NEAR(val3, 284.95, tol);
 
     // read exactly one time step correctly aligned but with a incorrect variable
     EXPECT_THROW(
-        double val4 = nc_provider->get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);,
+        double val4 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);,
         std::runtime_error);
 
 }


### PR DESCRIPTION
This is the core of #944 after factoring out #982 and #983.  The 18 remaining commits were logically grouped into the 6 on this branch.  Note that this is based on the HEAD of #982 currently, will need rebased once that merges.

## Additions

- Catchment-id **hinting** (`hint_shared_provider_id`) so the provider reads only the catchments a simulation requests, not every feature in the file.
- A **time-dimension value cache** that reads a span of time slices per access instead of repeated single-step reads.
- `align_cache_with_chunks()` to size the cache from the variable's on-disk chunking when present.
- Unit tests for the chunked/hinted read paths (`...UsingIds`, `...Span`, `...MultiSpan`, etc.).

## Removals

- Reading **all** features in the file regardless of the simulation domain — only required catchments are now read.
- The default constructor (`= delete`) — there is no valid un-parameterized provider.

## Changes

- `get_value` reworked to read through, and serve from, the chunked time-dimension cache.
- Cache size expressed as a named const (`N_EXPECTED_FORCING_VARS`) rather than a magic number.

## Testing

1. All netcdf provider tests pass locally

## Known issue: cache sizing

Per @PhilMiller's profiling note on #944: the cache is currently sized to match the working set. A functional cache needs to be **larger** than the working set — a request spanning more than one time step will thrash an exactly-matched cache. Carried over from #944.

## Coordination

- `get_value` overlaps the NGWPC reader rework in #979 (its dimension-ordering / `imap` changes touch the same function). Will look at cherry picking that work here.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows project standards
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (CHANGELOG "Unreleased")
- [x] Reviewers requested

### Target Environment support

- [x] Linux
- [x] MacOS

