### PR TITLE
NetCDF forcing cleanups

### DIFF
--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -14,9 +14,8 @@ target_include_directories(forcing PUBLIC
 
 target_link_libraries(forcing PUBLIC
         NGen::config_header
-        NGen::core
+        NGen::core_mediator
         Boost::boost                # Headers-only Boost
-        NGen::config_header
         Threads::Threads
 )
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -243,7 +243,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
 
     if (id_dim.isNull() )
     {
-        throw std::runtime_error("Provided NetCDF file has a NuLL dimension for variable  \"ids\"");
+        throw std::runtime_error("Provided NetCDF file has a NULL dimension for variable  \"ids\"");
     }
 
     auto num_ids = id_dim.getSize();
@@ -260,7 +260,7 @@ NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_pat
     // read the id strings
     ids.getVar(string_buffers.data());
 
-    // initalize the map of catchment-name to offset location and free the strings allocated by the C library
+    // initialize the map of catchment-name to offset location and free the strings allocated by the C library
     size_t loc = 0;
     for_each( string_buffers.begin(), string_buffers.end(), [&](char* str)
     {
@@ -465,15 +465,15 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     // account for the resampling methods
     switch(m)
     {
-        case SUM:   // we allready have the sum so do nothing
+        case SUM:   // we already have the sum so do nothing
             ;
         break;
 
         case MEAN: 
         { 
             // This is getting a length weighted mean
-            // the data values where allready scaled for where there was only partial use of a data value
-            // so we just need to do a final scale to account for the differnce between time_stride and duration_s
+            // the data values where already scaled for where there was only partial use of a data value
+            // so we just need to do a final scale to account for the difference between time_stride and duration_s
 
             double scale_factor = (selector.get_duration_secs() > time_stride ) ? (time_stride / selector.get_duration_secs()) : (1.0 / (a + b));
             rvalue *= scale_factor;
@@ -554,7 +554,7 @@ void NetCDFPerFeatureDataProvider::test_data_is_readable() {
             }
         } catch (const netCDF::exceptions::NcException& e) {
             std::string err_str = e.what();
-            // libnetcxx puts a lot of noice in the error message
+            // libnetcdf puts a lot of noise in the error message
             // so filter it out for clarity...
             size_t file_pos = err_str.find("file:");
             if (file_pos != std::string::npos) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -522,12 +522,7 @@ ngen_add_test(
     OBJECTS
         forcing/NetCDFPerFeatureDataProvider_Test.cpp
     LIBRARIES
-        NGen::core
-        NGen::core_nexus
-        NGen::core_mediator
         NGen::forcing
-        NGen::geojson
-        NGen::realizations_catchment
     REQUIRES
         NGEN_WITH_NETCDF
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -209,6 +209,10 @@ if(TARGET test_forcings_engine)
     # Use global add instead of target add so that both `test_forcings_engine` and `test_all`
     # receive this compile definition.
     add_compile_definitions(NGEN_LUMPED_CONFIG_PATH="${CMAKE_CURRENT_BINARY_DIR}/config_aorc.yml")
+
+    if(NGEN_WITH_MPI)
+        target_link_libraries(test_forcings_engine PRIVATE MPI::MPI_CXX)
+    endif()
 endif()
 
 ########################## BMI Protocol Unit Tests


### PR DESCRIPTION
Address some minor nits I noticed in the NetCDF forcing implementation

## Changes

- Fix typos
- Narrow the CMake dependencies to what's actually needed

## Testing

1. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
