### PR TITLE
perf: return catchment id by const reference

### DIFF
--- a/include/core/catchment/HY_CatchmentRealization.hpp
+++ b/include/core/catchment/HY_CatchmentRealization.hpp
@@ -39,7 +39,7 @@ class HY_CatchmentRealization
 
     std::shared_ptr<HY_Catchment> realized_catchment;
 
-    virtual std::string get_catchment_id() const = 0;
+    virtual const std::string& get_catchment_id() const = 0;
 
     virtual void set_catchment_id(std::string cat_id) = 0;
 

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -88,7 +88,7 @@ namespace realization {
             void finalize();
 
     protected:
-            std::string get_catchment_id() const override {
+            const std::string& get_catchment_id() const override {
                 return this->cat_id;
             }
 


### PR DESCRIPTION
get_catchment_id() returned std::string by value, allocating a copy on every call. It is invoked per-catchment, per-timestep on the formulation output path (and in CatchmentAggrDataSelector construction), so the copies add up on large/CONUS runs.
