### PR TITLE
Fix bug where catchment output goes to stdout if CSV output disabled

### DIFF
--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -36,6 +36,9 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
 
           if (!formulations->is_disable_catchment_output()) {
             formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+          } else {
+            // Route to the null sink so disabled catchment output is discarded, not dumped to stdout
+            formulation->set_output_stream("");
           }
 
           // TODO: add command line or config option to have this be omitted

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -43,6 +43,11 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
           {
             formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
           }
+          else
+          {
+            // Route to the null sink so disabled catchment output is discarded, not dumped to stdout
+            formulation->set_output_stream("");
+          }
 
           // TODO: add command line or config option to have this be omitted
           //FIXME why isn't default param working here??? get_output_header_line() fails.


### PR DESCRIPTION
Through a combination of #943 and #973, a bug was introduced such that, if catchment CSV output was disabled, catchment output data would instead be written directly to standard out.  

This resolves that bug by avoiding using/keeping the default stdout stream as the output stream for catchment formulations.  If regular CSV output is disabled, handle this case and explicitly set to the null stream.
