### PR TITLE
Fix bug in nexus output for serial

### DIFF
--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -63,8 +63,9 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         }
         else if(hy_features::identifiers::isNexus(feat_type))
         {
+            origins = network.get_origination_ids(feat_id);
             _nexuses.emplace(feat_id, std::make_unique<HY_PointHydroNexus>(
-                                          HY_PointHydroNexus(feat_id, destinations) ));
+                                          HY_PointHydroNexus(feat_id, destinations, origins) ));
         }
         else
         {


### PR DESCRIPTION
A bug was preventing the contributing catchments from being set properly for nexuses in serial executions.  This had two side effects:  noise in the logging, and all `0` values for nexus CSV output.  This addresses that by properly associating the upstream. 