### PR TITLE
perf: optimize read-only geopackage access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,49 @@ cmake_dependent_option(NGEN_WITH_COVERAGE "Build with test coverage" OFF "NGEN_W
 cmake_dependent_option(NGEN_WITH_PARALLEL_NETCDF "Build with NetCDF using HDF5-parallel support" OFF "NGEN_WITH_NETCDF" OFF)
 cmake_dependent_option(NGEN_WITH_ROUTING_TROUTE_BMI "Build with t-route integration called through a BMI implementation" OFF "NGEN_WITH_ROUTING" OFF)
 
+# Size, in bytes, of the SQLite memory-mapped I/O window used for read-only
+# geopackage access. Larger values let more of the file be served by mmap --
+# SQLite reads those pages directly from the shared OS page cache, skipping both
+# the per-page copy into a private buffer and the read() syscall; 0 disables
+# memory-mapped I/O. Default: 256 MiB.
+#
+# Max size vs. resident data: this is a CAP on how many bytes (from the start of
+# the file) are eligible for memory mapping -- NOT an allocation. The mapping is
+# lazy and the OS demand-pages, so resident memory only grows for the pages a
+# query actually touches; reading a couple tables from a 3.8 GiB CONUS gpkg with
+# a multi-GiB window still resides in ~10 MiB. Resident pages are also shared
+# read-only across reader processes via the OS page cache. So over-provisioning
+# the window costs virtual address space, not RAM -- err high.
+#
+# Bytes past the window are served by conventional read() syscalls. A rank's
+# features are scattered throughout the gpkg, NOT clustered at the front, so to
+# actually benefit the window must span (most of) the file. Size this by FILE
+# SIZE, not by how many features a rank reads:
+#   - Set it to ~the gpkg file size. The CONUS v2 hydrofabric is ~3.8 GiB, so
+#     use e.g. -DNGEN_SQLITE_MMAP_SIZE=4294967296 (~4 GiB); the 256 MiB default
+#     maps only its first ~7%.
+#   - SQLite clamps the request to the linked library's build-time
+#     SQLITE_MAX_MMAP_SIZE (often 1-2 GiB). ngen reads back the effective value
+#     and warns once if it was reduced; raising it requires rebuilding SQLite.
+#
+# The per-rank working set (distributed CONUS targets ~2048 features/core, ~8
+# MiB) is small; that is why sharing one whole-file mapping across a node's ranks
+# pays off, and it is the natural basis for the per-connection page cache
+# (NGEN_SQLITE_CACHE_SIZE), a separate knob from this whole-file mmap window.
+set(NGEN_SQLITE_MMAP_SIZE "268435456" CACHE STRING "SQLite mmap_size (bytes) for read-only gpkg; maps a window from file start, so set ~= gpkg file size (CONUS ~4 GiB), clamped to the library's SQLITE_MAX_MMAP_SIZE. 0 disables")
+
+# SQLite per-connection page cache for read-only geopackage access, as a raw
+# PRAGMA cache_size value: NEGATIVE = KiB of memory, POSITIVE = number of pages.
+# See https://www.sqlite.org/pragma.html#pragma_cache_size
+# This cache buffers pages served by conventional read() rather than mmap --
+# i.e. file offsets beyond the mmap window (see NGEN_SQLITE_MMAP_SIZE), which is
+# exactly where a large gpkg's tail lives when the library clamps mmap_size.
+# Size it to a rank's working set: distributed CONUS runs target ~2048
+# features/core (~8 MiB), so the default -16384 (16 MiB) holds a rank's reads
+# with headroom. The cache is per connection and lives only while a gpkg is
+# being read (init time), so it is not held for the whole run.
+set(NGEN_SQLITE_CACHE_SIZE "-16384" CACHE STRING "SQLite cache_size for read-only gpkg access (PRAGMA cache_size: negative=KiB, positive=pages)")
+
 option(BMI_FORTRAN_ISO_C_LIB_DIR "Directory hint for middleware Fortran shared lib handling iso_c_binding" "${NGEN_ROOT_DIR}/extern/iso_c_fortran_bmi/cmake_build")
 option(BMI_FORTRAN_ISO_C_LIB_NAME "Name for middleware Fortran shared lib handling iso_c_binding" "iso_c_bmi")
 
@@ -447,6 +490,8 @@ ngen_multiline_message(
 "    NGEN_WITH_PARALLEL_NETCDF: ${NGEN_WITH_PARALLEL_NETCDF}"
 "    NGEN_WITH_HDF5: ${NGEN_WITH_HDF5}"
 "    NGEN_WITH_SQLITE: ${NGEN_WITH_SQLITE}"
+"    NGEN_SQLITE_MMAP_SIZE: ${NGEN_SQLITE_MMAP_SIZE}"
+"    NGEN_SQLITE_CACHE_SIZE: ${NGEN_SQLITE_CACHE_SIZE}"
 "    NGEN_WITH_UDUNITS: ${NGEN_WITH_UDUNITS}"
 "    NGEN_WITH_BMI_FORTRAN: ${NGEN_WITH_BMI_FORTRAN}"
 "    NGEN_WITH_BMI_C: ${NGEN_WITH_BMI_C}"

--- a/include/NGenConfig.h.in
+++ b/include/NGenConfig.h.in
@@ -21,6 +21,20 @@
 #cmakedefine01 NGEN_WITH_TESTS
 #cmakedefine01 NGEN_QUIET
 
+// SQLite memory-mapped I/O window size (bytes) for read-only geopackage access;
+// set via the NGEN_SQLITE_MMAP_SIZE CMake cache variable. This caps how many
+// bytes (from the start of the file) are eligible for memory mapping -- it is a
+// maximum, NOT an allocation: resident memory only grows for pages actually
+// read (demand paging), and SQLite further clamps the value to the build's
+// SQLITE_MAX_MMAP_SIZE. Set it to ~the gpkg file size (CONUS ~4 GiB); 0 disables.
+#define NGEN_SQLITE_MMAP_SIZE @NGEN_SQLITE_MMAP_SIZE@
+
+// SQLite per-connection page cache for read-only geopackage access, as a raw
+// PRAGMA cache_size value (negative = KiB of memory, positive = pages). Buffers
+// pages served by conventional read() rather than mmap; size it to a rank's
+// working set. Set via the NGEN_SQLITE_CACHE_SIZE CMake cache variable.
+#define NGEN_SQLITE_CACHE_SIZE @NGEN_SQLITE_CACHE_SIZE@
+
 #include <string>
 
 namespace ngen {
@@ -43,6 +57,12 @@ namespace exec_info
     static constexpr bool with_routing             = NGEN_WITH_ROUTING;
     static constexpr bool with_routing_troute_bmi  = NGEN_WITH_ROUTING_TROUTE_BMI;
     static constexpr bool with_quiet               = NGEN_QUIET;
+
+    // SQLite memory-mapped I/O window size, in bytes (0 disables mmap I/O).
+    static constexpr long long sqlite_mmap_size    = NGEN_SQLITE_MMAP_SIZE;
+
+    // SQLite per-connection page cache (raw PRAGMA cache_size; <0 = KiB, >0 = pages).
+    static constexpr long long sqlite_cache_size   = NGEN_SQLITE_CACHE_SIZE;
 
     //! Compile-time build summary
     static constexpr const char* build_summary = R"(@NGEN_CONF_SUMMARY@)";

--- a/src/geopackage/CMakeLists.txt
+++ b/src/geopackage/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(geopackage proj.cpp
 add_library(NGen::geopackage ALIAS geopackage)
 target_include_directories(geopackage PUBLIC ${PROJECT_SOURCE_DIR}/include/geopackage)
 target_include_directories(geopackage PUBLIC ${PROJECT_SOURCE_DIR}/include/utilities)
-target_link_libraries(geopackage PUBLIC NGen::geojson Boost::boost SQLite::SQLite3)
+target_link_libraries(geopackage PUBLIC NGen::geojson Boost::boost SQLite::SQLite3 NGen::config_header)

--- a/src/geopackage/ngen_sqlite.cpp
+++ b/src/geopackage/ngen_sqlite.cpp
@@ -2,6 +2,10 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <string>
+#include <iostream>
+
+#include <NGenConfig.h>
 
 namespace ngen {
 namespace sqlite {
@@ -180,14 +184,112 @@ auto database::iterator::get<std::vector<uint8_t>>(int col) const
 
 // ngen::sqlite::database =====================================================
 
+namespace {
+    //! Percent-encode a filesystem path for use in a SQLite "file:" URI.
+    //! Unreserved characters (RFC 3986) and '/' are left as-is; everything else
+    //! (notably spaces, '?', '#', '%') is percent-encoded so the path survives
+    //! SQLite's URI parsing. SQLite decodes %XX back to the original byte.
+    std::string uri_encode_path(const std::string& path)
+    {
+        static const char hex[] = "0123456789ABCDEF";
+        std::string out;
+        out.reserve(path.size() + 8); // headroom for a few 3-byte escapes
+
+        // Iterate as unsigned char so bytes >= 0x80 (e.g. UTF-8 path components)
+        // are treated as 0..255 and encoded correctly, not as negative values.
+        for (unsigned char c : path) {
+            // Leave RFC 3986 "unreserved" characters as-is, plus '/', which we
+            // keep literal so it stays a path separator rather than becoming
+            // %2F. Everything else (spaces, and URI-significant characters like
+            // '?', '#', '%') must be escaped so SQLite's URI parser sees the
+            // original path when it decodes.
+            const bool unreserved =
+                (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                (c >= '0' && c <= '9') ||
+                c == '-' || c == '.' || c == '_' || c == '~' || c == '/';
+            if (unreserved) {
+                out.push_back(static_cast<char>(c));
+            } else {
+                // Emit the byte as "%HH": '%' then its two uppercase hex
+                // digits, high (c / 16) then low (c % 16).
+                out.push_back('%');
+                out.push_back(hex[c / 16]);
+                out.push_back(hex[c % 16]);
+            }
+        }
+        return out;
+    }
+
+    //! Apply best-effort read-tuning pragmas to a freshly opened, read-only
+    //! connection and warn once if the library clamped mmap_size. See
+    //! NGEN_SQLITE_MMAP_SIZE / NGEN_SQLITE_CACHE_SIZE.
+    void apply_read_tuning(sqlite3* conn)
+    {
+        // Best-effort read tuning; non-fatal if the build doesn't support a pragma.
+        //  - mmap_size: memory-map reads so SQLite reads pages directly from the OS
+        //    page cache without copying each into a per-connection buffer, and
+        //    without a read() syscall per page. This is a cap on the bytes (the
+        //    first N, from the start of the file) eligible for mmap, not an
+        //    allocation; build-time configurable via NGEN_SQLITE_MMAP_SIZE
+        //    (0 disables it).
+        //  - temp_store=MEMORY: keep transient structures (e.g. the ephemeral table
+        //    SQLite builds for "WHERE id IN (...)" subset queries) off disk.
+        //  - cache_size: per-connection page cache for pages served by read()
+        //    rather than mmap (offsets beyond the window); build-time configurable
+        //    via NGEN_SQLITE_CACHE_SIZE.
+        const long long requested_mmap = ngen::exec_info::sqlite_mmap_size;
+        const std::string mmap_pragma  = "PRAGMA mmap_size="  + std::to_string(requested_mmap) + ";";
+        const std::string cache_pragma = "PRAGMA cache_size=" + std::to_string(ngen::exec_info::sqlite_cache_size) + ";";
+        sqlite3_exec(conn, mmap_pragma.c_str(),  nullptr, nullptr, nullptr);
+        sqlite3_exec(conn, "PRAGMA temp_store=MEMORY;", nullptr, nullptr, nullptr);
+        sqlite3_exec(conn, cache_pragma.c_str(), nullptr, nullptr, nullptr);
+
+        // Align with the library: SQLite clamps mmap_size to its build-time
+        // SQLITE_MAX_MMAP_SIZE, which can silently leave the tail of a large gpkg on
+        // conventional read(). Read back the effective value and warn once if it was
+        // reduced below the request.
+        if (requested_mmap > 0) {
+            long long effective_mmap = -1;
+            sqlite3_stmt* stmt = nullptr;
+            if (sqlite3_prepare_v2(conn, "PRAGMA mmap_size;", -1, &stmt, nullptr) == SQLITE_OK) {
+                if (sqlite3_step(stmt) == SQLITE_ROW) {
+                    effective_mmap = sqlite3_column_int64(stmt, 0);
+                }
+                sqlite3_finalize(stmt);
+            }
+#if !NGEN_QUIET
+            static bool warned_mmap_clamped = false;
+            if (!warned_mmap_clamped && effective_mmap >= 0 && effective_mmap < requested_mmap) {
+                warned_mmap_clamped = true;
+                std::cerr << "WARNING: requested SQLite mmap_size " << requested_mmap
+                          << " bytes was clamped to " << effective_mmap
+                          << " by the linked library's SQLITE_MAX_MMAP_SIZE; geopackages larger than "
+                          << effective_mmap << " bytes will not be fully memory-mapped."
+                          << " Rebuild SQLite with a larger SQLITE_MAX_MMAP_SIZE to map the whole file."
+                          << std::endl;
+            }
+#endif
+        }
+    }
+}
+
 database::database(const std::string& path)
 {
+    // Open read-only AND immutable. The hydrofabric file does not change during
+    // a run, so 'immutable' lets SQLite skip all file locking and change
+    // detection on every open -- a win for any read-only access, and especially
+    // for the engine's many-readers, one-file MPI pattern, where advisory
+    // locking on a shared/parallel filesystem is the real bottleneck (not
+    // bandwidth).
+    const std::string uri = "file:" + uri_encode_path(path) + "?immutable=1";
     sqlite3*  conn = nullptr;
-    const int code = sqlite3_open_v2(path.c_str(), &conn, SQLITE_OPEN_READONLY, nullptr);
+    const int code = sqlite3_open_v2(uri.c_str(), &conn, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nullptr);
     if (code != SQLITE_OK) {
         throw sqlite_error{"sqlite3_open_v2", code};
     }
     conn_ = sqlite_t{conn};
+
+    apply_read_tuning(conn_.get());
 }
 
 auto database::connection() const noexcept -> sqlite3*

--- a/src/geopackage/read.cpp
+++ b/src/geopackage/read.cpp
@@ -15,6 +15,50 @@ void check_table_name(const std::string& table)
     }
 }
 
+namespace {
+//! Warn (advisory) when `id_column` in `layer` has no supporting index. Without
+//! one, the "WHERE <id_column> IN (?, ?, ...)" subset queries in read() degrade
+//! to full table scans, which is very slow on large hydrofabrics.
+void warn_if_id_column_unindexed(
+    ngen::sqlite::database& db,
+    const std::string& layer,
+    const std::string& id_column
+) {
+    try {
+        auto idx_list = db.query("PRAGMA index_list('" + layer + "')");
+        bool found_index = false;
+        idx_list.next();
+        while (!idx_list.done()) {
+            // PRAGMA index_list columns: seq(0), name(1), unique(2), ...
+            const std::string idx_name = idx_list.get<std::string>(1);
+            auto idx_info = db.query("PRAGMA index_info('" + idx_name + "')");
+            idx_info.next();
+            while (!idx_info.done()) {
+                // PRAGMA index_info columns: seqno(0), cid(1), name(2)
+                if (idx_info.get<std::string>(2) == id_column) {
+                    found_index = true;
+                    break;
+                }
+                idx_info.next();
+            }
+            if (found_index) break;
+            idx_list.next();
+        }
+        if (!found_index) {
+            #ifndef NGEN_QUIET
+            std::cerr << "WARNING: No index found on column '" << id_column << "' in layer '"
+                      << layer << "'. Subset queries may be slow." << std::endl;
+            #endif
+        }
+    } catch (const std::exception& e) {
+        #ifndef NGEN_QUIET
+        std::cerr << "WARNING: unable to check for an index on column '" << id_column
+                  << "': " << e.what() << std::endl;
+        #endif
+    }
+}
+} // namespace
+
 std::shared_ptr<geojson::FeatureCollection> ngen::geopackage::read(
     const std::string& gpkg_path,
     const std::string& layer = "",
@@ -24,6 +68,8 @@ std::shared_ptr<geojson::FeatureCollection> ngen::geopackage::read(
     // Check for malicious/invalid layer input
     check_table_name(layer);
 
+    // Opened read-only and immutable with read-tuning pragmas applied; see
+    // ngen::sqlite::database.
     ngen::sqlite::database db{gpkg_path};
 
     // Check if layer exists
@@ -61,6 +107,8 @@ std::shared_ptr<geojson::FeatureCollection> ngen::geopackage::read(
             #endif
         }
     }
+
+    warn_if_id_column_unindexed(db, layer, id_column);
 
     // Layer exists, getting statement for it
     //

--- a/test/geopackage/GeoPackage_Test.cpp
+++ b/test/geopackage/GeoPackage_Test.cpp
@@ -1,6 +1,10 @@
 #include <boost/geometry/io/wkt/write.hpp>
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <sstream>
+#include <streambuf>
+
 #include "geopackage.hpp"
 #include "FileChecker.h"
 
@@ -73,6 +77,82 @@ TEST_F(GeoPackage_Test, geopackage_idsubset_test)
     EXPECT_EQ(point.get<1>(), 0.5);
 
     ASSERT_TRUE(gpkg->get_feature(1) == nullptr);
+}
+
+// The reader warns (on stderr) when the id column has no supporting index,
+// since subset queries degrade to full table scans without one. Verify the
+// warning fires for an unindexed layer and is suppressed once an index exists,
+// and that reads remain correct with the read-only pragmas applied.
+TEST_F(GeoPackage_Test, geopackage_index_warning_test)
+{
+    const std::string needle = "No index found on column 'id'";
+
+    // --- Unindexed layer: warning expected ---
+    std::ostringstream captured;
+    std::streambuf* old_cerr = std::cerr.rdbuf(captured.rdbuf());
+    const auto gpkg = ngen::geopackage::read(this->path, "test", {});
+    std::cerr.rdbuf(old_cerr);
+
+    // Read correctness is unaffected by the pragmas.
+    EXPECT_NE(gpkg->find("First"), -1);
+    EXPECT_NE(gpkg->find("Second"), -1);
+    EXPECT_EQ(2, gpkg->get_size());
+
+    // The warning is emitted for this unindexed layer, except in a NGEN_QUIET
+    // build which suppresses such output. Assert the right thing in either case
+    // so the test never degrades to a no-op.
+    const bool warned = captured.str().find(needle) != std::string::npos;
+#ifndef NGEN_QUIET
+    EXPECT_TRUE(warned) << "expected a missing-index warning; got: " << captured.str();
+#else
+    EXPECT_FALSE(warned) << "NGEN_QUIET build should suppress the warning; got: " << captured.str();
+#endif
+
+    // --- Indexed copy: warning suppressed ---
+    namespace fs = std::filesystem;
+    const fs::path indexed = fs::temp_directory_path() / "ngen_indexed_example.gpkg";
+    fs::copy_file(this->path, indexed, fs::copy_options::overwrite_existing);
+
+    sqlite3* conn = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(indexed.c_str(), &conn, SQLITE_OPEN_READWRITE, nullptr), SQLITE_OK);
+    char* errmsg = nullptr;
+    const int rc = sqlite3_exec(conn, "CREATE INDEX idx_test_id ON \"test\"(id);", nullptr, nullptr, &errmsg);
+    if (rc != SQLITE_OK) {
+        std::string m = errmsg ? errmsg : "(unknown)";
+        sqlite3_free(errmsg);
+        sqlite3_close(conn);
+        fs::remove(indexed);
+        FAIL() << "failed to create test index: " << m;
+    }
+    sqlite3_close(conn);
+
+    std::ostringstream captured2;
+    old_cerr = std::cerr.rdbuf(captured2.rdbuf());
+    const auto gpkg2 = ngen::geopackage::read(indexed.string(), "test", {});
+    std::cerr.rdbuf(old_cerr);
+    fs::remove(indexed);
+
+    EXPECT_EQ(2, gpkg2->get_size());
+    EXPECT_EQ(captured2.str().find(needle), std::string::npos)
+        << "did not expect a missing-index warning once an index exists; got: " << captured2.str();
+}
+
+// The database is opened via a "file:...?immutable=1" URI, so paths containing
+// characters that are special in URIs (spaces being the common case) must be
+// percent-encoded. A path with spaces must still open and read correctly.
+TEST_F(GeoPackage_Test, geopackage_uri_encoded_path_test)
+{
+    namespace fs = std::filesystem;
+    const fs::path spaced = fs::temp_directory_path() / "ngen spaced example.gpkg";
+    fs::copy_file(this->path, spaced, fs::copy_options::overwrite_existing);
+
+    std::shared_ptr<geojson::FeatureCollection> gpkg;
+    ASSERT_NO_THROW(gpkg = ngen::geopackage::read(spaced.string(), "test", {}));
+    fs::remove(spaced);
+
+    EXPECT_EQ(2, gpkg->get_size());
+    EXPECT_NE(gpkg->find("First"), -1);
+    EXPECT_NE(gpkg->find("Second"), -1);
 }
 
 // this test is essentially the same as the above, however, the coordinates

--- a/test/geopackage/SQLite_Test.cpp
+++ b/test/geopackage/SQLite_Test.cpp
@@ -4,6 +4,7 @@
 
 #include "ngen_sqlite.hpp"
 #include "FileChecker.h"
+#include <NGenConfig.h>
 
 class SQLite_Test : public ::testing::Test
 {
@@ -33,6 +34,39 @@ TEST_F(SQLite_Test, sqlite_access_test)
     // user wants metadata
     EXPECT_TRUE(db.contains("gpkg_contents"));
     EXPECT_FALSE(db.contains("some_fake_table"));
+}
+
+// The wrapper applies read-tuning pragmas at open. Verify they reflect the
+// build-time configuration: cache_size is set verbatim, and mmap_size is
+// enabled but clamped at or below the requested value (the library's
+// SQLITE_MAX_MMAP_SIZE may reduce it). Read via the raw API for int64 safety.
+TEST_F(SQLite_Test, sqlite_read_tuning_pragmas_test)
+{
+    ngen::sqlite::database db {this->path};
+
+    auto read_pragma_int64 = [&](const char* pragma) -> long long {
+        sqlite3_stmt* stmt = nullptr;
+        EXPECT_EQ(sqlite3_prepare_v2(db.connection(), pragma, -1, &stmt, nullptr), SQLITE_OK);
+        long long value = -1;
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            value = sqlite3_column_int64(stmt, 0);
+        }
+        sqlite3_finalize(stmt);
+        return value;
+    };
+
+    EXPECT_EQ(read_pragma_int64("PRAGMA cache_size;"), ngen::exec_info::sqlite_cache_size);
+
+    // temp_store reads back as 0 (default), 1 (file), or 2 (memory); we set MEMORY.
+    EXPECT_EQ(read_pragma_int64("PRAGMA temp_store;"), 2);
+
+    const long long effective_mmap = read_pragma_int64("PRAGMA mmap_size;");
+    if (ngen::exec_info::sqlite_mmap_size > 0) {
+        EXPECT_GT(effective_mmap, 0);
+        EXPECT_LE(effective_mmap, ngen::exec_info::sqlite_mmap_size);
+    } else {
+        EXPECT_EQ(effective_mmap, 0);
+    }
 }
 
 TEST_F(SQLite_Test, sqlite_query_test)


### PR DESCRIPTION
Reading the hydrofabric geopackage is I/O-bound, and the engine opens the same file read-only from many ranks at once. Speed that path up:

- Open with the "file:...?immutable=1" URI so SQLite skips file locking and change detection -- the key win for many concurrent readers on a shared filesystem (Lustre/GPFS), and harmless for any read-only use.
- Apply read-tuning pragmas (mmap_size, cache_size, temp_store=MEMORY); mmap_size and cache_size are build-time configurable and defaulted for a distributed CONUS rank's working set (~2048 features/core).
- Warn when the id column is unindexed, since the "WHERE id IN (...)" subset queries otherwise degrade to full table scans.

Rationale for the pragma defaults and the mmap clamp/read() fallback lives in the CMake cache-var comments and inline. Tests cover the index warning, a URI-encoded path, the applied pragmas, and read correctness.

Some of the comments in the CMakeLists.txt are a bit excessive, and could be moved into more standalone documentation (just not sure what/where that should live right now).

## Reviewer Note:
The `uri_encode_path` function *could* be replaced by some boost::url utilities, but that would require a compiled boost dependency (not header only).  I didn't think it worth it for this simple function alone at this time.

## Testing
- Using an indexed gpkg showed significant improvements on CONUS runs, hence the check and warn for relevant indicies.

## TODO
- Test and quantify the benefit of using the `immutable` uri parameter
- Test this specific set of pragmas

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
