### PR TITLE
NetCDF Output: dynamic nexus ID length

### DIFF
--- a/include/utilities/output/PerFormulationNexusOutputMgr.hpp
+++ b/include/utilities/output/PerFormulationNexusOutputMgr.hpp
@@ -48,9 +48,9 @@ namespace utils
      * Because it works with NetCDF files, this file does not write received data entries until ``commit_writes`` is
      * called.
      *
-     * While the constructor supports receiving a collection of formulation ids, the class itself can only deal with a
-     * single formulation.  As such, the current implementation expects the collection of formulation ids passed to the
-     * constructor to either be empty - in which case, a default formulation id is used - or of size 1.
+     * While the constructor supports receiving a collection of formulation IDs, the class itself can only deal with a
+     * single formulation.  As such, the current implementation expects the collection of formulation IDs passed to the
+     * constructor to either be empty - in which case, a default formulation ID is used - or of size 1.
      */
     class PerFormulationNexusOutputMgr : public NexusOutputsMgr
     {
@@ -60,19 +60,19 @@ namespace utils
         /**
          * Construct instance set for managing/writing nexus data files, creating the file(s) appropriately.
          *
-         * Note that the class is designed to be aware of its object id in the context of multiple instances operating
+         * Note that the class is designed to be aware of its object ID in the context of multiple instances operating
          * on the same managed output file (e.g., when there are multiple MPI ranks, in which case @ref obj_id and MPI
          * rank are synonymous) and supports multiple instances across one or many processes writing to the same file.
          * However, only obj_id `0` will initially create the nexus output file. Further, the instance relies on
          * users/callers to maintain any synchronization (i.e., call MPI_Barrier so other obj_ids don't get ahead of
          * obj_id `0` while it creates the file).
          *
-         * While the constructor supports receiving a collection of formulation ids, the class itself can only deal with
-         * a single formulation.  As such, the current implementation expects the collection of formulation ids passed
-         * to the constructor to either be empty - in which case, a default formulation id is used - or of size 1.
+         * While the constructor supports receiving a collection of formulation IDs, the class itself can only deal with
+         * a single formulation.  As such, the current implementation expects the collection of formulation IDs passed
+         * to the constructor to either be empty - in which case, a default formulation ID is used - or of size 1.
          *
-         * @param nexus_ids Nexus ids for which this instance manages data (in particular, local nexuses when using MPI).
-         * @param formulation_ids Either ``null`` or pointer to vector with at most one formulation id (see above).
+         * @param nexus_ids Nexus IDs for which this instance manages data (in particular, local nexuses when using MPI).
+         * @param formulation_ids Either ``null`` or pointer to vector with at most one formulation ID (see above).
          * @param output_root The output root for written files (as a string).
          * @param total_timesteps The total number of timesteps that will be written to the managed file.
          * @param obj_id The obj_id of this instance when multiple instances may operate on the same file; same as rank
@@ -96,7 +96,7 @@ namespace utils
         /**
          * Construct instance set for managing/writing nexus data files when there is only one obj_id/instance.
          *
-         * @param nexus_ids Nexus ids for which this instance manages data (in particular, local nexuses when using MPI).
+         * @param nexus_ids Nexus IDs for which this instance manages data (in particular, local nexuses when using MPI).
          * @param formulation_ids
          * @param output_root The output root for written files (as a string).
          * @param total_timesteps The total number of timesteps that will be written to the managed file.
@@ -111,7 +111,7 @@ namespace utils
         /**
          * Close this manager instance and the managed NetCDF file.
          *
-         * Close the managed NetCDF file and (if successful) clear the corresponding file id by resetting
+         * Close the managed NetCDF file and (if successful) clear the corresponding file ID by resetting
          * @ref netcdf_file_id to `-1`.
          *
          * Once an instance is closed, it cannot receive new data. Subsequent calls to @ref receive_data_entry functions
@@ -127,7 +127,7 @@ namespace utils
         /**
          * Write any received data entries that were not written immediately upon receipt to the managed data files.
          *
-         * Function expects/requires data for all local nexus ids to have been received. Since it expects this, it also
+         * Function expects/requires data for all local nexus IDs to have been received. Since it expects this, it also
          * increments the ::attribute:`current_time_index` value before exiting.
          *
          * Additionally, it clears the current ::attribute:`data_cache` and ::attribute:`current_formulation_id` values.
@@ -140,7 +140,7 @@ namespace utils
         /**
          * A test of whether this instance is closed.
          *
-         * This type determines whether it is closed by whether it has a valid NetCDF file id.
+         * This type determines whether it is closed by whether it has a valid NetCDF file ID.
          *
          * @return Whether this instance is closed.
          */
@@ -154,12 +154,12 @@ namespace utils
         std::shared_ptr<std::vector<std::string>> get_filenames();
 
         /**
-         * Receive a data entry for this nexus, specifying details including the formulation id.
+         * Receive a data entry for this nexus, specifying details including the formulation ID.
          *
          * If this instance is closed (@ref is_closed) an exception will be raised.
          *
-         * @param formulation_id The id of the formulation involved in producing this data.
-         * @param nexus_id The id for the nexus to which this data applies.
+         * @param formulation_id The ID of the formulation involved in producing this data.
+         * @param nexus_id The ID for the nexus to which this data applies.
          * @param data_time_marker A marker for the current simulation time for the data.
          * @param flow_data_at_t The nexus flow contribution at this time index (the main data to write).
          * @see close
@@ -207,18 +207,18 @@ namespace utils
         size_t determine_nexus_id_string_width() const;
 
         /**
-         * Pack a full nexus id string into a caller-provided fixed-width, null-padded char buffer.
+         * Pack a full nexus ID string into a caller-provided fixed-width, null-padded char buffer.
          *
-         * The id is stored verbatim (prefix included) in the first ``nexus_id.size()`` bytes of @p buffer, and any
-         * remaining bytes up to @p width are set to the null character.  An id whose length exactly equals @p width
-         * fills the entire buffer with no null terminator.  To avoid silently truncating an unexpectedly long id, an
-         * id longer than @p width is a hard error (consistent with the manager's existing throw-on-malformed-id
+         * The ID is stored verbatim (prefix included) in the first ``nexus_id.size()`` bytes of @p buffer, and any
+         * remaining bytes up to @p width are set to the null character.  An ID whose length exactly equals @p width
+         * fills the entire buffer with no null terminator.  To avoid silently truncating an unexpectedly long ID, an
+         * ID longer than @p width is a hard error (consistent with the manager's existing throw-on-malformed-ID
          * behavior).
          *
-         * @param nexus_id The full nexus id string (prefix included) to pack.
+         * @param nexus_id The full nexus ID string (prefix included) to pack.
          * @param buffer Pointer to a caller-provided buffer of at least @p width chars to pack into.
          * @param width The fixed char width of the buffer/record to pack into.
-         * @throw std::runtime_error if the id length exceeds @p width.
+         * @throw std::runtime_error if the ID length exceeds @p width.
          */
         static void pack_nexus_id(const std::string& nexus_id, char* buffer, size_t width);
 
@@ -227,10 +227,10 @@ namespace utils
         inline static const std::string nc_var_name_flow = "runoff_rate";
 
         /**
-         * Name of the NetCDF dimension giving the fixed character length of each stored nexus feature id string.
+         * Name of the NetCDF dimension giving the fixed character length of each stored nexus feature ID string.
          *
          * The ``feature_id`` variable is a 2-D character array dimensioned by the nexus dimension and this
-         * string-length dimension (whose size is @ref nexus_id_string_width), so the full id string is preserved
+         * string-length dimension (whose size is @ref nexus_id_string_width), so the full ID string is preserved
          * verbatim rather than reduced to a numeric value.
          */
         inline static const std::string nc_dim_name_id_str_len = "feature_id_str_len";
@@ -240,7 +240,7 @@ namespace utils
         /** Array of chunk sizes for  dimensions - nexus_id and time - of flow NetCDF variable, to set chunking. */
         size_t flow_var_chunk_size_per_dim[2];
 
-        /** Map of nexus id to corresponding index for that nexus in several data structures for this instance. */
+        /** Map of nexus ID to corresponding index for that nexus in several data structures for this instance. */
         std::unordered_map<std::string, size_t> nexus_data_indices;
 
         /**
@@ -258,10 +258,10 @@ namespace utils
          */
         std::vector<unsigned long>::size_type local_offset;
 
-        /** Nexus ids for which this instance/process will write data to the file (i.e., local when using MPI, all otherwise). */
+        /** Nexus IDs for which this instance/process will write data to the file (i.e., local when using MPI, all otherwise). */
         const std::vector<std::string> nexus_ids;
 
-        /** The current/last formulation id value received by `receive_data_entry`. */
+        /** The current/last formulation ID value received by `receive_data_entry`. */
         std::string current_formulation_id;
 
         std::string formulation_id;
@@ -281,7 +281,7 @@ namespace utils
         /** The total number of timesteps that will be written to the managed file. */
         size_t total_timesteps;
 
-        /** File id member variable for opening and writing to NetCDF file via the C API. */
+        /** File ID member variable for opening and writing to NetCDF file via the C API. */
         int netcdf_file_id = -1;
 
         /**
@@ -292,26 +292,26 @@ namespace utils
          * partially-constructed instance correctly reports as already-closed.
          *
          * Tracked separately from @ref netcdf_file_id because, in the gather-to-rank-0 path, non-root ranks never
-         * open a NetCDF file and so cannot use file id state to represent their open/closed status; without this
+         * open a NetCDF file and so cannot use file ID state to represent their open/closed status; without this
          * flag they would falsely report as already-closed and bail out of @ref receive_data_entry and
          * @ref commit_writes before participating in the per-timestep MPI gather.
          */
         bool is_file_open = false;
 
         /**
-         * The instance id for this instance, which should be the MPI rank if using MPI.
+         * The instance ID for this instance, which should be the MPI rank if using MPI.
          *
-         * For non-MPI use cases, there must always be an id 0, and it is assumed each new id is incremented by 1.
+         * For non-MPI use cases, there must always be an ID 0, and it is assumed each new ID is incremented by 1.
          */
         int obj_id;
 
-        /** Variable id for the ``nexus_id`` NetCDF variable. */
+        /** Variable ID for the ``nexus_id`` NetCDF variable. */
         int nc_var_id_nexus_id;
 
-        /** Variable id for the ``time`` NetCDF variable. */
+        /** Variable ID for the ``time`` NetCDF variable. */
         int nc_var_id_time;
 
-        /** Variable id for the ``flow`` NetCDF variable. */
+        /** Variable ID for the ``flow`` NetCDF variable. */
         int nc_var_id_flow;
 
         /** The total number of nexuses in this simulation, potentially across multiple instances and ranks. */
@@ -342,7 +342,7 @@ namespace utils
          *
          * @param dim_name The dimension name
          * @param size The dimension size
-         * @param dim_id_ptr A point to a location to hold the NetCDF dimension id for the added dimension
+         * @param dim_id_ptr A point to a location to hold the NetCDF dimension ID for the added dimension
          */
         void add_dimension(const std::string& dim_name, const size_t size, int* dim_id_ptr) const;
 
@@ -410,7 +410,7 @@ namespace utils
         #endif
 
         /**
-         * Close the (presumed open) NetCDF file and (if successful) clear the corresponding file id by resetting
+         * Close the (presumed open) NetCDF file and (if successful) clear the corresponding file ID by resetting
          * @ref netcdf_file_id to `-1`.
          */
         void close_netcdf_file();
@@ -424,7 +424,7 @@ namespace utils
          * Primarily intended to be run in constructor, in (somewhat less common) cases when there are multiple
          * instances all running in the same process (i.e., without MPI).  In such cases, parallel NetCDF capabilities
          * are not needed, so only one "create" function call is needed, but other instances still need a way to get
-         * the NetCDF id.
+         * the NetCDF ID.
          *
          */
         void open_netcdf_file();
@@ -432,28 +432,28 @@ namespace utils
         /**
          * For cases when only opening a NetCDF file/dataset, retrieve necessary variable metadata for execution.
          *
-         * Function will lookup and store the variable ids for the nexus_id, time, and flow/runoff variables.
+         * Function will lookup and store the variable IDs for the nexus_id, time, and flow/runoff variables.
          */
         void lookup_netcdf_metadata();
 
         /**
          * Setup the NetCDF metadata (dimensions and variables) for the managed NetCDF file/dataset.
          *
-         * Function will create and store the variable ids for the nexus_id, time, and flow/runoff variables.  To
-         * support those variables, it will also create the nexus_id and time dimensions, though not store those ids.
+         * Function will create and store the variable IDs for the nexus_id, time, and flow/runoff variables.  To
+         * support those variables, it will also create the nexus_id and time dimensions, though not store those IDs.
          */
         void setup_netcdf_metadata();
 
         /**
-         * On the first time step, write this instance's managed nexus ids to the NetCDF data.
+         * On the first time step, write this instance's managed nexus IDs to the NetCDF data.
          */
         void write_nexus_ids_once() const;
 
         #if NGEN_WITH_MPI && NGEN_WITH_PARALLEL_NETCDF
         /**
-         * Set the NetCDF variable with the given variable id to have ``NC_COLLECTIVE`` parallel access.
+         * Set the NetCDF variable with the given variable ID to have ``NC_COLLECTIVE`` parallel access.
          *
-         * @param nc_var_id The numeric NetCDF variable id
+         * @param nc_var_id The numeric NetCDF variable ID
          */
         void set_nc_var_parallel_collective(const int nc_var_id) const;
         #endif
@@ -469,7 +469,7 @@ namespace utils
         bool gather_to_root = false;
 
         /**
-         * Per-rank counts of nexus ids, indexed by rank.  Used as the ``recvcounts`` argument to ``MPI_Gatherv`` calls.
+         * Per-rank counts of nexus IDs, indexed by rank.  Used as the ``recvcounts`` argument to ``MPI_Gatherv`` calls.
          * Populated and held only on rank 0; empty on non-root ranks.  Only meaningful when @ref gather_to_root is
          * ``true``.
          */

--- a/include/utilities/output/PerFormulationNexusOutputMgr.hpp
+++ b/include/utilities/output/PerFormulationNexusOutputMgr.hpp
@@ -185,29 +185,42 @@ namespace utils
         static std::string parse_netcdf_return_code(const int nc_status);
 
         /**
-         * Fixed character width used to store each nexus feature ID string in the managed NetCDF file.
+         * Character width used to store each nexus feature ID string in the managed NetCDF file.
          *
          * The nexus identity is written as a fixed-width, null-padded character representation rather than a numeric
          * value, so that the full ID string (prefix included, e.g. ``nex-1`` vs ``tnx-1``) is preserved and distinct
-         * IDs never collapse together.  This same width sizes both the packing helper (@ref pack_nexus_id) and the
-         * NetCDF string-length dimension.
+         * IDs never collapse together.  Rather than a hard-coded maximum, this width is determined dynamically at
+         * construction as the longest nexus ID across the entire simulation (reduced across MPI ranks when running in
+         * parallel), and it sizes both the packing helper (@ref pack_nexus_id) and the NetCDF string-length dimension.
          */
-        static constexpr size_t nexus_id_string_width = 32;
+        size_t nexus_id_string_width;
+
+        /**
+         * Determine @ref nexus_id_string_width as the maximum nexus ID length across the whole simulation.
+         *
+         * Computes the longest local nexus ID and, when running under MPI, reduces it to the global maximum across
+         * all ranks so every rank agrees on a single width.  A minimum of 1 is enforced so the resulting NetCDF
+         * string-length dimension is never zero-sized.
+         *
+         * @return The width (in chars) to use for stored nexus feature ID strings.
+         */
+        size_t determine_nexus_id_string_width() const;
 
         /**
          * Pack a full nexus id string into a caller-provided fixed-width, null-padded char buffer.
          *
          * The id is stored verbatim (prefix included) in the first ``nexus_id.size()`` bytes of @p buffer, and any
-         * remaining bytes up to @ref nexus_id_string_width are set to the null character.  An id whose length exactly
-         * equals @ref nexus_id_string_width fills the entire buffer with no null terminator.  To avoid silently
-         * truncating an unexpectedly long id, an id longer than @ref nexus_id_string_width is a hard error (consistent
-         * with the manager's existing throw-on-malformed-id behavior).
+         * remaining bytes up to @p width are set to the null character.  An id whose length exactly equals @p width
+         * fills the entire buffer with no null terminator.  To avoid silently truncating an unexpectedly long id, an
+         * id longer than @p width is a hard error (consistent with the manager's existing throw-on-malformed-id
+         * behavior).
          *
          * @param nexus_id The full nexus id string (prefix included) to pack.
-         * @param buffer Pointer to a caller-provided buffer of at least @ref nexus_id_string_width chars to pack into.
-         * @throw std::runtime_error if the id length exceeds @ref nexus_id_string_width.
+         * @param buffer Pointer to a caller-provided buffer of at least @p width chars to pack into.
+         * @param width The fixed char width of the buffer/record to pack into.
+         * @throw std::runtime_error if the id length exceeds @p width.
          */
-        static void pack_nexus_id(const std::string& nexus_id, char* buffer);
+        static void pack_nexus_id(const std::string& nexus_id, char* buffer, size_t width);
 
         inline static const std::string nc_dim_name_nexus_id = "feature_id";
         inline static const std::string nc_dim_name_time = "time";

--- a/include/utilities/output/PerFormulationNexusOutputMgr.hpp
+++ b/include/utilities/output/PerFormulationNexusOutputMgr.hpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include <map>
 #include <unordered_map>
 #include <math.h>
+#include <boost/core/span.hpp>
 
 // Forward declaration to provide access to protected items in testing
 class PerFormulationNexusOutputMgr_Test;
@@ -210,17 +211,16 @@ namespace utils
          * Pack a full nexus ID string into a caller-provided fixed-width, null-padded char buffer.
          *
          * The ID is stored verbatim (prefix included) in the first ``nexus_id.size()`` bytes of @p buffer, and any
-         * remaining bytes up to @p width are set to the null character.  An ID whose length exactly equals @p width
-         * fills the entire buffer with no null terminator.  To avoid silently truncating an unexpectedly long ID, an
-         * ID longer than @p width is a hard error (consistent with the manager's existing throw-on-malformed-ID
-         * behavior).
+         * remaining bytes up to ``buffer.size()`` are set to the null character.  An ID whose length exactly equals
+         * ``buffer.size()`` fills the entire buffer with no null terminator.  To avoid silently truncating an
+         * unexpectedly long ID, an ID longer than @p buffer is a hard error (consistent with the manager's existing
+         * throw-on-malformed-ID behavior).
          *
          * @param nexus_id The full nexus ID string (prefix included) to pack.
-         * @param buffer Pointer to a caller-provided buffer of at least @p width chars to pack into.
-         * @param width The fixed char width of the buffer/record to pack into.
-         * @throw std::runtime_error if the ID length exceeds @p width.
+         * @param buffer The fixed-width char record (of the NetCDF string-length width) to pack into.
+         * @throw std::runtime_error if the ID length exceeds ``buffer.size()``.
          */
-        static void pack_nexus_id(const std::string& nexus_id, char* buffer, size_t width);
+        static void pack_nexus_id(const std::string& nexus_id, boost::span<char> buffer);
 
         inline static const std::string nc_dim_name_nexus_id = "feature_id";
         inline static const std::string nc_dim_name_time = "time";

--- a/src/utilities/output/CMakeLists.txt
+++ b/src/utilities/output/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(ngen_output PUBLIC
 if(NGEN_WITH_NETCDF)
     target_compile_definitions(ngen_output PUBLIC NGEN_WITH_NETCDF)
     target_sources(ngen_output PRIVATE "${CMAKE_CURRENT_LIST_DIR}/PerFormulationNexusOutputMgr.cpp")
-    target_link_libraries(ngen_output PUBLIC NetCDF)
+    target_link_libraries(ngen_output PUBLIC NetCDF Boost::boost)
     if (NGEN_WITH_MPI)
        target_link_libraries(ngen_output PUBLIC MPI::MPI_CXX)
        if (NOT NGEN_WITH_PARALLEL_NETCDF)

--- a/src/utilities/output/PerFormulationNexusOutputMgr.cpp
+++ b/src/utilities/output/PerFormulationNexusOutputMgr.cpp
@@ -428,14 +428,13 @@ size_t utils::PerFormulationNexusOutputMgr::determine_nexus_id_string_width() co
     return local_max;
 }
 
-void utils::PerFormulationNexusOutputMgr::pack_nexus_id(const std::string& nexus_id, char* buffer,
-                                                        const size_t width) {
-    if (nexus_id.size() > width) {
+void utils::PerFormulationNexusOutputMgr::pack_nexus_id(const std::string& nexus_id, boost::span<char> buffer) {
+    if (nexus_id.size() > buffer.size()) {
         throw std::runtime_error("Nexus ID '" + nexus_id + "' length " + std::to_string(nexus_id.size())
-            + " exceeds the maximum NetCDF feature ID width of " + std::to_string(width) + ".");
+            + " exceeds the maximum NetCDF feature ID width of " + std::to_string(buffer.size()) + ".");
     }
-    std::memcpy(buffer, nexus_id.data(), nexus_id.size());
-    std::memset(buffer + nexus_id.size(), '\0', width - nexus_id.size());
+    std::memcpy(buffer.data(), nexus_id.data(), nexus_id.size());
+    std::memset(buffer.data() + nexus_id.size(), '\0', buffer.size() - nexus_id.size());
 }
 
 void utils::PerFormulationNexusOutputMgr::add_dimension(const std::string& dim_name, const size_t size,
@@ -609,7 +608,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
     // null-padded char records (one record of nexus_id_string_width chars per nexus).
     std::vector<char> packed_nex_ids(nexus_ids.size() * nexus_id_string_width);
     for (size_t i = 0; i < nexus_ids.size(); ++i) {
-        pack_nexus_id(nexus_ids[i], packed_nex_ids.data() + i * nexus_id_string_width, nexus_id_string_width);
+        pack_nexus_id(nexus_ids[i], boost::span<char>(packed_nex_ids).subspan(i * nexus_id_string_width, nexus_id_string_width));
     }
 
 #if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
@@ -622,7 +621,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
         }
         std::vector<char> all_packed_nex_ids(static_cast<size_t>(total_nexus_count) * nexus_id_string_width);
         for (size_t i = 0; i < all_nex_ids.size(); ++i) {
-            pack_nexus_id(all_nex_ids[i], all_packed_nex_ids.data() + i * nexus_id_string_width, nexus_id_string_width);
+            pack_nexus_id(all_nex_ids[i], boost::span<char>(all_packed_nex_ids).subspan(i * nexus_id_string_width, nexus_id_string_width));
         }
         std::vector<size_t> start{0, 0};
         std::vector<size_t> count{static_cast<size_t>(total_nexus_count), nexus_id_string_width};

--- a/src/utilities/output/PerFormulationNexusOutputMgr.cpp
+++ b/src/utilities/output/PerFormulationNexusOutputMgr.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "PerFormulationNexusOutputMgr.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 
@@ -82,6 +83,8 @@ utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
     }
 
     nexus_outfile = output_root + "/formulation_" + this->formulation_id + "_nexuses.nc";
+
+    nexus_id_string_width = determine_nexus_id_string_width();
 
     // To support unit testing when not running via MPI, but when MPI and parallel netcdf are compiled in, we
     // have to detect things.
@@ -406,13 +409,33 @@ std::string utils::PerFormulationNexusOutputMgr::parse_netcdf_return_code(const 
     }
 }
 
-void utils::PerFormulationNexusOutputMgr::pack_nexus_id(const std::string& nexus_id, char* buffer) {
-    if (nexus_id.size() > nexus_id_string_width) {
+size_t utils::PerFormulationNexusOutputMgr::determine_nexus_id_string_width() const {
+    // Never let the string-length dimension be zero-sized (e.g., an instance with no local nexus IDs).
+    size_t local_max = 1;
+    for (const std::string& id : nexus_ids) {
+        local_max = std::max(local_max, id.size());
+    }
+
+#if NGEN_WITH_MPI
+    if (isMpiInitialized()) {
+        int local = static_cast<int>(local_max);
+        int global = 0;
+        MPI_Allreduce(&local, &global, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+        local_max = static_cast<size_t>(global);
+    }
+#endif
+
+    return local_max;
+}
+
+void utils::PerFormulationNexusOutputMgr::pack_nexus_id(const std::string& nexus_id, char* buffer,
+                                                        const size_t width) {
+    if (nexus_id.size() > width) {
         throw std::runtime_error("Nexus id '" + nexus_id + "' length " + std::to_string(nexus_id.size())
-            + " exceeds the maximum NetCDF feature id width of " + std::to_string(nexus_id_string_width) + ".");
+            + " exceeds the maximum NetCDF feature id width of " + std::to_string(width) + ".");
     }
     std::memcpy(buffer, nexus_id.data(), nexus_id.size());
-    std::memset(buffer + nexus_id.size(), '\0', nexus_id_string_width - nexus_id.size());
+    std::memset(buffer + nexus_id.size(), '\0', width - nexus_id.size());
 }
 
 void utils::PerFormulationNexusOutputMgr::add_dimension(const std::string& dim_name, const size_t size,
@@ -586,7 +609,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
     // null-padded char records (one record of nexus_id_string_width chars per nexus).
     std::vector<char> packed_nex_ids(nexus_ids.size() * nexus_id_string_width);
     for (size_t i = 0; i < nexus_ids.size(); ++i) {
-        pack_nexus_id(nexus_ids[i], packed_nex_ids.data() + i * nexus_id_string_width);
+        pack_nexus_id(nexus_ids[i], packed_nex_ids.data() + i * nexus_id_string_width, nexus_id_string_width);
     }
 
 #if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
@@ -599,7 +622,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
         }
         std::vector<char> all_packed_nex_ids(static_cast<size_t>(total_nexus_count) * nexus_id_string_width);
         for (size_t i = 0; i < all_nex_ids.size(); ++i) {
-            pack_nexus_id(all_nex_ids[i], all_packed_nex_ids.data() + i * nexus_id_string_width);
+            pack_nexus_id(all_nex_ids[i], all_packed_nex_ids.data() + i * nexus_id_string_width, nexus_id_string_width);
         }
         std::vector<size_t> start{0, 0};
         std::vector<size_t> count{static_cast<size_t>(total_nexus_count), nexus_id_string_width};

--- a/src/utilities/output/PerFormulationNexusOutputMgr.cpp
+++ b/src/utilities/output/PerFormulationNexusOutputMgr.cpp
@@ -68,7 +68,7 @@ utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
         this->formulation_id = get_default_formulation_id();
     }
     else if (formulation_ids->size() > 1) {
-        throw std::runtime_error("PerFormulationNexusOutputMgr currently cannot have more than one formulation id.");
+        throw std::runtime_error("PerFormulationNexusOutputMgr currently cannot have more than one formulation ID.");
     }
     else {
         this->formulation_id = (*formulation_ids)[0];
@@ -207,7 +207,7 @@ void utils::PerFormulationNexusOutputMgr::close() {
 }
 
 void utils::PerFormulationNexusOutputMgr::commit_writes() {
-    // If no current formulation id set, that should mean there is nothing to write
+    // If no current formulation ID set, that should mean there is nothing to write
     // If closed, then assume we can no longer write, so do nothing and just return
     if (current_formulation_id.empty() || is_closed()) {
         return;
@@ -215,7 +215,7 @@ void utils::PerFormulationNexusOutputMgr::commit_writes() {
 
     int nc_status;
 
-    // On the first write, also write the nexus id variable values
+    // On the first write, also write the nexus ID variable values
     write_nexus_ids_once();
 
     // Default: this instance writes its own local slice straight from current_nexus_data.
@@ -363,7 +363,7 @@ std::string utils::PerFormulationNexusOutputMgr::parse_netcdf_return_code(const 
     case NC_EBADNAME:
         return "not a valid NetCDF name";
     case NC_EBADGRPID:
-        return "bad group id or nc_id that does not contain group id";
+        return "bad group ID or nc_id that does not contain group ID";
     case NC_EDIMSIZE:
         return "invalid dimension size";
     case NC_EEXIST:
@@ -431,8 +431,8 @@ size_t utils::PerFormulationNexusOutputMgr::determine_nexus_id_string_width() co
 void utils::PerFormulationNexusOutputMgr::pack_nexus_id(const std::string& nexus_id, char* buffer,
                                                         const size_t width) {
     if (nexus_id.size() > width) {
-        throw std::runtime_error("Nexus id '" + nexus_id + "' length " + std::to_string(nexus_id.size())
-            + " exceeds the maximum NetCDF feature id width of " + std::to_string(width) + ".");
+        throw std::runtime_error("Nexus ID '" + nexus_id + "' length " + std::to_string(nexus_id.size())
+            + " exceeds the maximum NetCDF feature ID width of " + std::to_string(width) + ".");
     }
     std::memcpy(buffer, nexus_id.data(), nexus_id.size());
     std::memset(buffer + nexus_id.size(), '\0', width - nexus_id.size());
@@ -501,7 +501,7 @@ void utils::PerFormulationNexusOutputMgr::create_netcdf_file() {
     std::cout << "Creating nexus NetCDF file '" << nexus_outfile << "' for regular access." << std::endl;
     int nc_status = nc_create(nexus_outfile.c_str(), NC_NETCDF4 | NC_NOCLOBBER, &netcdf_file_id);
     if (nc_status != NC_NOERR) {
-        throw std::runtime_error("PerFormulationNexusOutputMgr id " + std::to_string(obj_id) + " could not "
+        throw std::runtime_error("PerFormulationNexusOutputMgr ID " + std::to_string(obj_id) + " could not "
             + "create file '" + nexus_outfile + "' for regular access: " + parse_netcdf_return_code(nc_status));
     }
 }
@@ -515,7 +515,7 @@ void utils::PerFormulationNexusOutputMgr::create_netcdf_file_parallel(MPI_Comm m
     std::cout << "Creating nexus NetCDF file '" << nexus_outfile << "' for parallel access." << std::endl;
     int nc_status = nc_create_par(nexus_outfile.c_str(), NC_NETCDF4 | NC_NOCLOBBER, mpi_comm, MPI_INFO_NULL, &netcdf_file_id);
     if (nc_status != NC_NOERR) {
-        throw std::runtime_error("PerFormulationNexusOutputMgr id " + std::to_string(obj_id) + " could not "
+        throw std::runtime_error("PerFormulationNexusOutputMgr ID " + std::to_string(obj_id) + " could not "
             + "create file '" + nexus_outfile + "' for parallel access: " + parse_netcdf_return_code(nc_status));
     }
 }
@@ -566,7 +566,7 @@ void utils::PerFormulationNexusOutputMgr::setup_netcdf_metadata() {
 
     add_dimension(nc_dim_name_nexus_id, total_nexus_count, &nc_nex_id_dim_id);
     add_dimension(nc_dim_name_time, total_timesteps, &nc_time_dim_id);
-    // Fixed-width string-length dimension backing the 2-D char feature_id variable, so the full id string
+    // Fixed-width string-length dimension backing the 2-D char feature_id variable, so the full ID string
     // (prefix included) is preserved verbatim rather than collapsed to a numeric value.
     add_dimension(nc_dim_name_id_str_len, nexus_id_string_width, &nc_id_str_len_dim_id);
 
@@ -605,7 +605,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
     if (current_time_index != 0)
         return;
 
-    // Pack each local nexus id verbatim (full string, prefix included) into a contiguous block of fixed-width,
+    // Pack each local nexus ID verbatim (full string, prefix included) into a contiguous block of fixed-width,
     // null-padded char records (one record of nexus_id_string_width chars per nexus).
     std::vector<char> packed_nex_ids(nexus_ids.size() * nexus_id_string_width);
     for (size_t i = 0; i < nexus_ids.size(); ++i) {
@@ -614,7 +614,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
 
 #if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
     if (gather_to_root) {
-        // Gather every rank's full nexus id strings to rank 0 (in rank-contiguous order), then rank 0 packs
+        // Gather every rank's full nexus ID strings to rank 0 (in rank-contiguous order), then rank 0 packs
         // them into the fixed-width, null-padded char block and writes it once.
         std::vector<std::string> all_nex_ids = parallel::gather_strings(nexus_ids, MPI_COMM_WORLD);
         if (obj_id != 0) {
@@ -629,7 +629,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
         int nc_status = nc_put_vara_text(netcdf_file_id, nc_var_id_nexus_id, start.data(), count.data(),
                                          all_packed_nex_ids.data());
         if (nc_status != NC_NOERR) {
-            throw std::runtime_error("Error writing nexus ids to netcdf for nexus output manager: "
+            throw std::runtime_error("Error writing nexus IDs to netcdf for nexus output manager: "
                 + parse_netcdf_return_code(nc_status));
         }
         return;
@@ -642,7 +642,7 @@ void utils::PerFormulationNexusOutputMgr::write_nexus_ids_once() const {
     int nc_status = nc_put_vara_text(netcdf_file_id, nc_var_id_nexus_id, start.data(), count.data(),
                                      packed_nex_ids.data());
     if (nc_status != NC_NOERR) {
-        throw std::runtime_error("Error writing nexus ids to netcdf for nexus output manager: "
+        throw std::runtime_error("Error writing nexus IDs to netcdf for nexus output manager: "
             + parse_netcdf_return_code(nc_status));
     }
 }
@@ -655,7 +655,7 @@ void utils::PerFormulationNexusOutputMgr::set_nc_var_parallel_collective(const i
         std::cout << "Setting NetCDF var '" << std::to_string(nc_var_id) << "' to NC_COLLECTIVE." << std::endl;
         return;
     }
-    throw std::runtime_error("Failed to set variable id '" + std::to_string(nc_var_id) + "' to NC_COLLECTIVE "
+    throw std::runtime_error("Failed to set variable ID '" + std::to_string(nc_var_id) + "' to NC_COLLECTIVE "
         + "access: " + parse_netcdf_return_code(nc_status));
 }
 #endif

--- a/test/utils/PerFormulationNexusOutputMgr_Test.cpp
+++ b/test/utils/PerFormulationNexusOutputMgr_Test.cpp
@@ -64,8 +64,8 @@ protected:
         return max_len;
     }
 
-    static void friend_pack_nexus_id(const std::string& nexus_id, char* buffer, size_t width) {
-        utils::PerFormulationNexusOutputMgr::pack_nexus_id(nexus_id, buffer, width);
+    static void friend_pack_nexus_id(const std::string& nexus_id, boost::span<char> buffer) {
+        utils::PerFormulationNexusOutputMgr::pack_nexus_id(nexus_id, buffer);
     }
 
     /**
@@ -1583,12 +1583,12 @@ TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_1_a)
 /** Test that pack_nexus_id packs a normal ID verbatim and null-pads the rest of the fixed-width buffer. */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_a)
 {
-    const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
+    const size_t width = 32; // pack helper derives the width from the buffer span; exercise it at a representative width
     // Pre-fill with a non-null sentinel so the null padding is actually verified (not just left-over zeros).
     std::vector<char> buffer(width, 'X');
     const std::string id = "tnx-1";
 
-    friend_pack_nexus_id(id, buffer.data(), width);
+    friend_pack_nexus_id(id, buffer);
 
     // The ID bytes are copied verbatim, prefix included.
     for (size_t i = 0; i < id.size(); ++i) {
@@ -1603,11 +1603,11 @@ TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_a)
 /** Test that pack_nexus_id handles an ID exactly the fixed width, filling every byte with no null terminator. */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_b)
 {
-    const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
+    const size_t width = 32; // pack helper derives the width from the buffer span; exercise it at a representative width
     const std::string id(width, 'a'); // exactly the fixed width
     std::vector<char> buffer(width, '\0');
 
-    friend_pack_nexus_id(id, buffer.data(), width);
+    friend_pack_nexus_id(id, buffer);
 
     for (size_t i = 0; i < width; ++i) {
         ASSERT_EQ(buffer[i], 'a') << "Expected full-width fill at byte " << i;
@@ -1617,11 +1617,11 @@ TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_b)
 /** Test that pack_nexus_id throws when the ID is longer than the fixed width (no silent truncation). */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_c)
 {
-    const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
+    const size_t width = 32; // pack helper derives the width from the buffer span; exercise it at a representative width
     const std::string id(width + 1, 'a'); // one char too long to fit
     std::vector<char> buffer(width, '\0');
 
-    ASSERT_THROW(friend_pack_nexus_id(id, buffer.data(), width), std::runtime_error);
+    ASSERT_THROW(friend_pack_nexus_id(id, buffer), std::runtime_error);
 }
 
 #endif // #if NGEN_MPI_UNIT_TESTS ... #else

--- a/test/utils/PerFormulationNexusOutputMgr_Test.cpp
+++ b/test/utils/PerFormulationNexusOutputMgr_Test.cpp
@@ -69,12 +69,12 @@ protected:
     }
 
     /**
-     * Read the 2-D fixed-width char ``feature_id`` variable back and reconstruct the full string id for each
+     * Read the 2-D fixed-width char ``feature_id`` variable back and reconstruct the full string ID for each
      * nexus, taking the characters up to the first null (CF-style fixed-width char labels).
      *
      * @param var The ``feature_id`` NetCDF variable (dimensioned by nexus count then fixed string width).
-     * @param count The number of nexus id records to read.
-     * @return Vector of reconstructed full string ids, prefix included.
+     * @param count The number of nexus ID records to read.
+     * @return Vector of reconstructed full string IDs, prefix included.
      */
     static std::vector<std::string> read_feature_id_strings(const netCDF::NcVar& var, size_t count) {
         const size_t width = var.getDim(1).getSize();
@@ -142,11 +142,11 @@ protected:
 
     // TODO: Might also need EX 4 with 40396 nexuses but spread about real partitions (and tested exclusively via the MPI stuff)
 
-    // Example 5: nexus feature id collision scenario. It is possible for the same numeric suffix to appear
-    // under more than one id prefix (here the regular "nex-" prefix alongside a "tnx-" prefix, nex-1
-    // alongside tnx-1); the collision is only of the numeric component, since the full ids remain distinct.
-    // The full string feature ids must therefore be written out so the two physically distinct nexuses stay
-    // distinct rather than collapsing to a single numeric id. Distinct flow values per id let the read-back
+    // Example 5: nexus feature ID collision scenario. It is possible for the same numeric suffix to appear
+    // under more than one ID prefix (here the regular "nex-" prefix alongside a "tnx-" prefix, nex-1
+    // alongside tnx-1); the collision is only of the numeric component, since the full IDs remain distinct.
+    // The full string feature IDs must therefore be written out so the two physically distinct nexuses stay
+    // distinct rather than collapsing to a single numeric ID. Distinct flow values per ID let the read-back
     // verify each row.
     std::shared_ptr<std::vector<std::string>> ex_5_form_names = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"form-0"});
     std::vector<std::string> ex_5_form_0_all_nexus_id = {"nex-1", "tnx-1", "nex-2", "tnx-2"};
@@ -154,11 +154,11 @@ protected:
     std::vector<std::string> ex_5_timestamps = {"2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z"};
     std::vector<std::time_t> ex_5_timestamps_seconds = {1735707600, 1735711200};
 
-    // Example 6: the nexus feature id (numeric) collision exercised across MPI ranks. The colliding
-    // pair (nex-1 / tnx-1) is split one id per rank, so the single output file can only be correct if the
-    // MPI gather-to-root path assembles both ranks' fixed-width string ids (not just the in-process write).
-    // Rank 0 owns the regular "nex-" ids and rank 1 owns the terminal "tnx-" ids; the global file order is
-    // rank-contiguous (rank 0's block then rank 1's block). Distinct per-id flow values let the read-back
+    // Example 6: the nexus feature ID (numeric) collision exercised across MPI ranks. The colliding
+    // pair (nex-1 / tnx-1) is split one ID per rank, so the single output file can only be correct if the
+    // MPI gather-to-root path assembles both ranks' fixed-width string IDs (not just the in-process write).
+    // Rank 0 owns the regular "nex-" IDs and rank 1 owns the terminal "tnx-" IDs; the global file order is
+    // rank-contiguous (rank 0's block then rank 1's block). Distinct per-ID flow values let the read-back
     // verify each row and catch any cross-rank row mix-up.
     std::shared_ptr<std::vector<std::string>> ex_6_form_names = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"form-0"});
     std::vector<std::string> ex_6_form_0_group_a_nexus_ids = {"nex-1", "nex-2"};                      // rank 0
@@ -248,7 +248,7 @@ void PerFormulationNexusOutputMgr_Test::SetUp()
         ex_2_timestamps_seconds[t] = ex_2_initial_time_seconds + t * 3600;
     }
 
-    // Generate the ids and data used for example 3 (2 time steps)
+    // Generate the IDs and data used for example 3 (2 time steps)
     ex_3_form_0_all_nexus_id.resize(ex_3_nexus_count);
     ex_3_form_0_group_b_nexus_ids.resize(ex_3_nexus_count / 2);
     ex_3_form_0_group_a_nexus_ids.resize(ex_3_nexus_count - ex_3_form_0_group_b_nexus_ids.size());
@@ -264,12 +264,12 @@ void PerFormulationNexusOutputMgr_Test::SetUp()
         double data_ts_0 = (n+1)/1000.0;
         double data_ts_1 = (data_ts_0) * 2.0;
 
-        // Add id and data to appropriate "all" data structures
+        // Add ID and data to appropriate "all" data structures
         ex_3_form_0_all_nexus_id[n] = nid;
         ex_3_all_data[0][n] = data_ts_0;
         ex_3_all_data[1][n] = data_ts_1;
 
-        // Add id and data to appropriate group data structures
+        // Add ID and data to appropriate group data structures
         if (is_group_a) {
             ex_3_form_0_group_a_nexus_ids[a_idx] = nid;
             ex_3_group_a_data[0][a_idx] = data_ts_0;
@@ -317,7 +317,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, construct_2_a)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // Pick the right nexus id and data group for this rank
+    // Pick the right nexus ID and data group for this rank
     std::vector<std::string> *nexus_ids;
     if (rank == 0) {
         nexus_ids = &ex_2_form_0_group_a_nexus_ids;
@@ -363,7 +363,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_a)
         ASSERT_TRUE(std::all_of(ex_2_all_data[t].cbegin(), ex_2_all_data[t].cend(), [](double d) { return d > 0.0;}));
     }
 
-    // Pick the right nexus id and data group for this rank
+    // Pick the right nexus ID and data group for this rank
     std::vector<std::string> *nexus_ids;
     std::vector<std::vector<double>> *group_data;
     if (rank == 0) {
@@ -421,7 +421,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_a)
     flow.getVar(values);
     for (size_t t = 0; t < ex_2_timestamps.size(); ++t) {
         for (size_t n = 0; n < ex_2_form_0_all_nexus_id.size(); ++n) {
-            ASSERT_EQ(values[n][t], ex_2_all_data[t][n]) << "On timestep " << t << " for nexus id " << nexus_ids->at(n)
+            ASSERT_EQ(values[n][t], ex_2_all_data[t][n]) << "On timestep " << t << " for nexus ID " << nexus_ids->at(n)
                 << " value was " << values[n][t] << " but expected was " << ex_2_all_data[t][n] << "; \n"
                 << "Full timestep data for this timestep is: \n" << values << "\n ***** \n";
         }
@@ -430,7 +430,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_a)
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-/** Test example 2 writes feature ids correctly using multiple simultaneous writes via MPI. */
+/** Test example 2 writes feature IDs correctly using multiple simultaneous writes via MPI. */
 TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
 {
     MPI_Barrier(MPI_COMM_WORLD);
@@ -439,7 +439,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
     ASSERT_LE(rank, 1);
     ASSERT_EQ(size, 2);
 
-    // Pick the right nexus id and data group for this rank
+    // Pick the right nexus ID and data group for this rank
     std::vector<std::string> *nexus_ids;
     std::vector<std::vector<double>> *group_data;
     if (rank == 0) {
@@ -481,7 +481,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
     // When done writing, another barrier before any checks/asserts
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // Now, compare feature id variable data from both
+    // Now, compare feature ID variable data from both
 
     // Should only be one filename
     const netCDF::NcFile ncf(mgr.get_filenames()->at(0), netCDF::NcFile::read);
@@ -499,24 +499,24 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
 }
 
 /**
- * Test the MPI gather-to-root write path for a nexus feature id collision.
+ * Test the MPI gather-to-root write path for a nexus feature ID collision.
  *
- * The colliding pair nex-1 / tnx-1 is split across ranks (rank 0 owns the regular "nex-" ids, rank 1 owns
- * the terminal "tnx-" ids), so a correct single output file requires the fixed-width MPI_CHAR id gather to
- * assemble both ranks' ids — the in-process single-instance write alone could never reproduce this. Asserts
- * every rank's id is present as a distinct full string in the correct global (rank-contiguous) order, that
+ * The colliding pair nex-1 / tnx-1 is split across ranks (rank 0 owns the regular "nex-" IDs, rank 1 owns
+ * the terminal "tnx-" IDs), so a correct single output file requires the fixed-width MPI_CHAR ID gather to
+ * assemble both ranks' IDs — the in-process single-instance write alone could never reproduce this. Asserts
+ * every rank's ID is present as a distinct full string in the correct global (rank-contiguous) order, that
  * the colliding pair occupies distinct rows, and that each row's flow data matches what was sent for that
- * specific id, so a cross-rank row mix-up would be caught.
+ * specific ID, so a cross-rank row mix-up would be caught.
  */
 TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_6_a)
 {
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // Expect exactly two ranks (the colliding pair is split one id per rank)
+    // Expect exactly two ranks (the colliding pair is split one ID per rank)
     ASSERT_LE(rank, 1);
     ASSERT_EQ(size, 2);
 
-    // Pick the right nexus id and data group for this rank
+    // Pick the right nexus ID and data group for this rank
     std::vector<std::string> *nexus_ids;
     std::vector<std::vector<double>> *group_data;
     if (rank == 0) {
@@ -559,10 +559,10 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_6_a)
     // When done writing everything, another barrier before any checks/asserts
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // Read back the single assembled file and verify ids and flow together
+    // Read back the single assembled file and verify IDs and flow together
     const netCDF::NcFile ncf(mgr.get_filenames()->at(0), netCDF::NcFile::read);
 
-    // feature_id: every rank's id present as a distinct, exact full string in the correct global order
+    // feature_id: every rank's ID present as a distinct, exact full string in the correct global order
     const netCDF::NcVar nc_var_nex_ids = ncf.getVar(friend_get_nc_nex_id_dim_name(&mgr));
     ASSERT_FALSE(nc_var_nex_ids.isNull());
     ASSERT_EQ(nc_var_nex_ids.getDim(0).getSize(), ex_6_form_0_all_nexus_id.size());
@@ -577,9 +577,9 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_6_a)
     auto tnx1_it = std::find(nex_id_strs.begin(), nex_id_strs.end(), "tnx-1");
     ASSERT_NE(nex1_it, nex_id_strs.end());
     ASSERT_NE(tnx1_it, nex_id_strs.end());
-    ASSERT_NE(nex1_it, tnx1_it) << "nex-1 and tnx-1 must occupy distinct rows, not a single collapsed id";
+    ASSERT_NE(nex1_it, tnx1_it) << "nex-1 and tnx-1 must occupy distinct rows, not a single collapsed ID";
 
-    // Each row's flow data must match what was sent for that specific id, so the distinct ids are not merely
+    // Each row's flow data must match what was sent for that specific ID, so the distinct IDs are not merely
     // labels on data swapped/merged between ranks during the gather.
     const netCDF::NcVar flow = ncf.getVar(friend_get_nc_flow_var_name(&mgr));
     ASSERT_FALSE(flow.isNull());
@@ -591,7 +591,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_6_a)
     for (size_t t = 0; t < ex_6_timestamps.size(); ++t) {
         for (size_t n = 0; n < ex_6_form_0_all_nexus_id.size(); ++n) {
             ASSERT_EQ(values[n][t], ex_6_all_data[t][n])
-                << "Flow mismatch for nexus id " << nex_id_strs[n] << " at time step " << t;
+                << "Flow mismatch for nexus ID " << nex_id_strs[n] << " at time step " << t;
         }
     }
 
@@ -686,7 +686,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_8_a)
     for (size_t t = 0; t < ex_8_timestamps.size(); ++t) {
         for (size_t n = 0; n < ex_8_form_0_all_nexus_id.size(); ++n) {
             ASSERT_EQ(values[n][t], ex_8_all_data[t][n])
-                << "Flow mismatch for nexus id " << nex_id_strs[n] << " at time step " << t;
+                << "Flow mismatch for nexus ID " << nex_id_strs[n] << " at time step " << t;
         }
     }
 
@@ -860,7 +860,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, nexus_out_file_0_a)
     ASSERT_EQ(nexus_outfile, expected);
 }
 
-/** Test that current formulation id is as expected after receiving data entry. */
+/** Test that current formulation ID is as expected after receiving data entry. */
 TEST_F(PerFormulationNexusOutputMgr_Test, receive_data_entry_0_a) {
 
     int nex_id_index = 0;
@@ -1049,7 +1049,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, DISABLED_commit_writes_0_c) {
     ASSERT_THROW(mgr.commit_writes(), std::runtime_error);
 }
 
-/** Test that example 0 has the nexus id var values written to the NetCDF file. */
+/** Test that example 0 has the nexus ID var values written to the NetCDF file. */
 TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_0_d)
 {
     std::string form_name = ex_0_form_names->at(0);
@@ -1192,7 +1192,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_1_b) {
     }
 }
 
-/** Test that example 1 has the nexus id var values written to the NetCDF file with multiple instances. */
+/** Test that example 1 has the nexus ID var values written to the NetCDF file with multiple instances. */
 TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_1_c)
 {
     std::string form_name = ex_1_form_names->at(0);
@@ -1243,12 +1243,12 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_1_c)
 }
 
 /**
- * Regression test for a nexus feature id (numeric) collision (single instance, end-to-end).
+ * Regression test for a nexus feature ID (numeric) collision (single instance, end-to-end).
  *
- * The nexus id set contains the colliding pair nex-1 and tnx-1, which share the numeric suffix 1. Under the
+ * The nexus ID set contains the colliding pair nex-1 and tnx-1, which share the numeric suffix 1. Under the
  * old integer feature_id schema both collapsed to feature_id == 1, conflating two physically distinct
- * nexuses; with the full-string id schema they must read back as two distinct rows ("nex-1" and "tnx-1"),
- * each carrying its own flow data. tnx-2/nex-2 are included so the collision is not the only id present.
+ * nexuses; with the full-string ID schema they must read back as two distinct rows ("nex-1" and "tnx-1"),
+ * each carrying its own flow data. tnx-2/nex-2 are included so the collision is not the only ID present.
  */
 TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_5_a)
 {
@@ -1275,7 +1275,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_5_a)
     // Should only be one filename
     const netCDF::NcFile ncf(filenames->at(0), netCDF::NcFile::read);
 
-    // The feature_id char variable must contain every id as a distinct, exact full string (prefix included).
+    // The feature_id char variable must contain every ID as a distinct, exact full string (prefix included).
     const netCDF::NcVar nexus_ids = ncf.getVar(friend_get_nc_nex_id_dim_name(&mgr));
     ASSERT_FALSE(nexus_ids.isNull());
     ASSERT_EQ(nexus_ids.getDim(0).getSize(), ex_5_form_0_all_nexus_id.size());
@@ -1290,10 +1290,10 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_5_a)
     auto tnx1_it = std::find(nex_id_strs.begin(), nex_id_strs.end(), "tnx-1");
     ASSERT_NE(nex1_it, nex_id_strs.end());
     ASSERT_NE(tnx1_it, nex_id_strs.end());
-    ASSERT_NE(nex1_it, tnx1_it) << "nex-1 and tnx-1 must occupy distinct rows, not a single collapsed id";
+    ASSERT_NE(nex1_it, tnx1_it) << "nex-1 and tnx-1 must occupy distinct rows, not a single collapsed ID";
 
-    // Each row's flow data must match what was sent for that specific id across both time steps, so the
-    // distinct ids are not merely labels on swapped/merged data.
+    // Each row's flow data must match what was sent for that specific ID across both time steps, so the
+    // distinct IDs are not merely labels on swapped/merged data.
     const netCDF::NcVar flow = ncf.getVar(friend_get_nc_flow_var_name(&mgr));
     ASSERT_FALSE(flow.isNull());
     // Note that nexus feature_id dim comes before time dim, so have to order this way
@@ -1302,7 +1302,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_5_a)
     for (size_t t = 0; t < ex_5_timestamps.size(); ++t) {
         for (size_t n = 0; n < ex_5_form_0_all_nexus_id.size(); ++n) {
             ASSERT_EQ(values[n][t], ex_5_all_data[t][n])
-                << "Flow mismatch for nexus id " << nex_id_strs[n] << " at time step " << t;
+                << "Flow mismatch for nexus ID " << nex_id_strs[n] << " at time step " << t;
         }
     }
 }
@@ -1389,7 +1389,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_c) {
     flow.getVar(values);
     for (size_t t = 0; t < ex_2_timestamps.size(); ++t) {
         for (size_t n = 0; n < ex_2_form_0_all_nexus_id.size(); ++n) {
-            ASSERT_EQ(values[n][t], ex_2_all_data[t][n]) << "On timestep " << t << " for nexus id " << nexus_ids->at(n)
+            ASSERT_EQ(values[n][t], ex_2_all_data[t][n]) << "On timestep " << t << " for nexus ID " << nexus_ids->at(n)
                 << " value was " << values[n][t] << " but expected was " << ex_2_all_data[t][n] << "; \n"
                 << "Full timestep data for this timestep is: \n" << values << "\n ***** \n";
         }
@@ -1511,7 +1511,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, is_closed_0_c) {
     ASSERT_TRUE(mgr.is_closed());
 }
 
-/** Test that example 0 works with write_nexus_ids_once and has nexus id var values written to NetCDF file. */
+/** Test that example 0 works with write_nexus_ids_once and has nexus ID var values written to NetCDF file. */
 TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_0_a)
 {
     std::string form_name = ex_0_form_names->at(0);
@@ -1542,7 +1542,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_0_a)
 }
 
 /**
- * Test that example 1 works with write_nexus_ids_once and has nexus id var values written to NetCDF file with multiple
+ * Test that example 1 works with write_nexus_ids_once and has nexus ID var values written to NetCDF file with multiple
  * instances.
  */
 TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_1_a)
@@ -1580,7 +1580,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_1_a)
     ASSERT_EQ(nex_id_strs, ex_1_form_0_all_nexus_id);
 }
 
-/** Test that pack_nexus_id packs a normal id verbatim and null-pads the rest of the fixed-width buffer. */
+/** Test that pack_nexus_id packs a normal ID verbatim and null-pads the rest of the fixed-width buffer. */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_a)
 {
     const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
@@ -1590,17 +1590,17 @@ TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_a)
 
     friend_pack_nexus_id(id, buffer.data(), width);
 
-    // The id bytes are copied verbatim, prefix included.
+    // The ID bytes are copied verbatim, prefix included.
     for (size_t i = 0; i < id.size(); ++i) {
         ASSERT_EQ(buffer[i], id[i]) << "Mismatch at byte " << i;
     }
-    // Everything after the id is null padding.
+    // Everything after the ID is null padding.
     for (size_t i = id.size(); i < width; ++i) {
         ASSERT_EQ(buffer[i], '\0') << "Expected null padding at byte " << i;
     }
 }
 
-/** Test that pack_nexus_id handles an id exactly the fixed width, filling every byte with no null terminator. */
+/** Test that pack_nexus_id handles an ID exactly the fixed width, filling every byte with no null terminator. */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_b)
 {
     const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
@@ -1614,7 +1614,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_b)
     }
 }
 
-/** Test that pack_nexus_id throws when the id is longer than the fixed width (no silent truncation). */
+/** Test that pack_nexus_id throws when the ID is longer than the fixed width (no silent truncation). */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_c)
 {
     const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width

--- a/test/utils/PerFormulationNexusOutputMgr_Test.cpp
+++ b/test/utils/PerFormulationNexusOutputMgr_Test.cpp
@@ -51,12 +51,21 @@ protected:
         return obj->write_nexus_ids_once();
     }
 
-    static size_t friend_nexus_id_string_width() {
-        return utils::PerFormulationNexusOutputMgr::nexus_id_string_width;
+    static size_t friend_nexus_id_string_width(const utils::PerFormulationNexusOutputMgr* obj) {
+        return obj->nexus_id_string_width;
     }
 
-    static void friend_pack_nexus_id(const std::string& nexus_id, char* buffer) {
-        utils::PerFormulationNexusOutputMgr::pack_nexus_id(nexus_id, buffer);
+    /** Longest string length among the given IDs; the expected feature_id string-length dimension. */
+    static size_t longest_id_length(const std::vector<std::string>& ids) {
+        size_t max_len = 0;
+        for (const std::string& id : ids) {
+            max_len = std::max(max_len, id.size());
+        }
+        return max_len;
+    }
+
+    static void friend_pack_nexus_id(const std::string& nexus_id, char* buffer, size_t width) {
+        utils::PerFormulationNexusOutputMgr::pack_nexus_id(nexus_id, buffer, width);
     }
 
     /**
@@ -68,7 +77,7 @@ protected:
      * @return Vector of reconstructed full string ids, prefix included.
      */
     static std::vector<std::string> read_feature_id_strings(const netCDF::NcVar& var, size_t count) {
-        const size_t width = friend_nexus_id_string_width();
+        const size_t width = var.getDim(1).getSize();
         std::vector<char> chars(count * width);
         var.getVar(chars.data());
         std::vector<std::string> ids(count);
@@ -161,6 +170,31 @@ protected:
     std::vector<std::string> ex_6_timestamps = {"2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z"};
     std::vector<std::time_t> ex_6_timestamps_seconds = {1735707600, 1735711200};
     size_t ex_6_num_time_steps = 2;
+
+    // Example 7: a single-instance nexus set whose IDs differ in length to exercise the dynamically-sized
+    // feature_id string-length dimension. The stored width must equal the longest ID, and every shorter ID
+    // must round-trip exactly (null-padded), not truncated.
+    std::shared_ptr<std::vector<std::string>> ex_7_form_names = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"form-0"});
+    std::vector<std::string> ex_7_form_0_all_nexus_id = {
+        "nx-2", "nex-1", "cat-1000012", "a-very-long-nexus-identifier-000000042"
+    };
+    std::vector<std::vector<double>> ex_7_all_data = {{1.0, 2.0, 3.0, 4.0}, {11.0, 12.0, 13.0, 14.0}};
+    std::vector<std::string> ex_7_timestamps = {"2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z"};
+    std::vector<std::time_t> ex_7_timestamps_seconds = {1735707600, 1735711200};
+
+    // Example 8: differing per-rank ID lengths across the MPI write. Rank 0 owns only short IDs while rank 1
+    // owns a much longer ID, so the feature_id string-length dimension is correct only if the maximum ID
+    // length is reduced across ranks rather than taken from the (rank 0) writing rank's local IDs.
+    std::shared_ptr<std::vector<std::string>> ex_8_form_names = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"form-0"});
+    std::vector<std::string> ex_8_form_0_group_a_nexus_ids = {"nex-1", "nex-2"};                                 // rank 0 (local max 5)
+    std::vector<std::string> ex_8_form_0_group_b_nexus_ids = {"terminal-nexus-1234567890123", "tnx-2"};          // rank 1 (local max 28)
+    std::vector<std::string> ex_8_form_0_all_nexus_id = {"nex-1", "nex-2", "terminal-nexus-1234567890123", "tnx-2"};
+    std::vector<std::vector<double>> ex_8_group_a_data = {{1.0, 2.0}, {11.0, 12.0}};
+    std::vector<std::vector<double>> ex_8_group_b_data = {{101.0, 102.0}, {111.0, 112.0}};
+    std::vector<std::vector<double>> ex_8_all_data = {{1.0, 2.0, 101.0, 102.0}, {11.0, 12.0, 111.0, 112.0}};
+    std::vector<std::string> ex_8_timestamps = {"2025-01-01T00:00:00Z", "2025-01-01T01:00:00Z"};
+    std::vector<std::time_t> ex_8_timestamps_seconds = {1735707600, 1735711200};
+    size_t ex_8_num_time_steps = 2;
 
     std::vector<std::string> files_to_cleanup;
 
@@ -456,7 +490,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_2_b)
     ASSERT_FALSE(nc_var_nex_ids.isNull());
     ASSERT_EQ(nc_var_nex_ids.getDim(0).getSize(), ex_2_form_0_all_nexus_id.size());
     // feature_id is now a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nc_var_nex_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nc_var_nex_ids.getDim(1).getSize(), longest_id_length(ex_2_form_0_all_nexus_id));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nc_var_nex_ids, ex_2_form_0_all_nexus_id.size());
     ASSERT_EQ(nex_id_strs, ex_2_form_0_all_nexus_id);
@@ -533,7 +567,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_6_a)
     ASSERT_FALSE(nc_var_nex_ids.isNull());
     ASSERT_EQ(nc_var_nex_ids.getDim(0).getSize(), ex_6_form_0_all_nexus_id.size());
     // feature_id is a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nc_var_nex_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nc_var_nex_ids.getDim(1).getSize(), longest_id_length(ex_6_form_0_all_nexus_id));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nc_var_nex_ids, ex_6_form_0_all_nexus_id.size());
     ASSERT_EQ(nex_id_strs, ex_6_form_0_all_nexus_id);
@@ -557,6 +591,101 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_6_a)
     for (size_t t = 0; t < ex_6_timestamps.size(); ++t) {
         for (size_t n = 0; n < ex_6_form_0_all_nexus_id.size(); ++n) {
             ASSERT_EQ(values[n][t], ex_6_all_data[t][n])
+                << "Flow mismatch for nexus id " << nex_id_strs[n] << " at time step " << t;
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+/**
+ * Test cross-rank sizing of the feature_id string-length dimension when ranks own IDs of differing lengths.
+ *
+ * Rank 0 owns only short IDs and rank 1 owns a much longer ID, so the single assembled output file is correct
+ * only if the maximum ID length is reduced across ranks (MPI_Allreduce) rather than taken from the writing
+ * rank's local IDs. Asserts the stored width equals the global longest ID length, that both ranks' managers
+ * report that same global width (so the reduction reached every rank, including the shorter-ID rank 0 that
+ * sizes the dimension), that rank 0's short IDs round-trip exactly at the larger global width, and that all
+ * IDs and their flow data land in the correct rows.
+ */
+TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_8_a)
+{
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_LE(rank, 1);
+    ASSERT_EQ(size, 2);
+
+    std::vector<std::string> *nexus_ids;
+    std::vector<std::vector<double>> *group_data;
+    if (rank == 0) {
+        nexus_ids = &ex_8_form_0_group_a_nexus_ids;
+        group_data = &ex_8_group_a_data;
+    }
+    else {
+        nexus_ids = &ex_8_form_0_group_b_nexus_ids;
+        group_data = &ex_8_group_b_data;
+    }
+
+    // The global longest ID (owned by rank 1) must exceed rank 0's local longest, so a rank-local width would
+    // be wrong for the assembled file.
+    const size_t global_width = longest_id_length(ex_8_form_0_all_nexus_id);
+    ASSERT_GT(global_width, longest_id_length(ex_8_form_0_group_a_nexus_ids));
+
+    const std::vector<int> nexus_per_rank = {
+        static_cast<int>(ex_8_form_0_group_a_nexus_ids.size()), static_cast<int>(ex_8_form_0_group_b_nexus_ids.size())
+    };
+    std::vector<int> local_offsets = {0, nexus_per_rank[0]};
+    utils::PerFormulationNexusOutputMgr mgr(*nexus_ids, ex_8_form_names, output_root, ex_8_num_time_steps, rank, local_offsets[rank], 2, ex_8_form_0_all_nexus_id.size());
+
+    if (rank == 0) {
+        std::shared_ptr<std::vector<std::string>> filenames = mgr.get_filenames();
+        for (const std::string& f : *filenames) {
+            files_to_cleanup.push_back(f);
+        }
+    }
+
+    // Every rank must have reduced to the same global width, not its own local maximum.
+    ASSERT_EQ(friend_nexus_id_string_width(&mgr), global_width);
+
+    for (size_t t = 0; t < ex_8_timestamps.size(); ++t) {
+        for (size_t n = 0; n < nexus_ids->size(); ++n) {
+            mgr.receive_data_entry(ex_8_form_names->at(0),
+                                   nexus_ids->at(n),
+                                   utils::time_marker(t, ex_8_timestamps_seconds[t], ex_8_timestamps[t]),
+                                   group_data->at(t)[n]);
+        }
+        mgr.commit_writes();
+    }
+
+    mgr.close();
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    const netCDF::NcFile ncf(mgr.get_filenames()->at(0), netCDF::NcFile::read);
+
+    const netCDF::NcVar nc_var_nex_ids = ncf.getVar(friend_get_nc_nex_id_dim_name(&mgr));
+    ASSERT_FALSE(nc_var_nex_ids.isNull());
+    ASSERT_EQ(nc_var_nex_ids.getDim(0).getSize(), ex_8_form_0_all_nexus_id.size());
+    // String-length dimension sized to the global longest ID, verified independently of the manager's width.
+    ASSERT_EQ(nc_var_nex_ids.getDim(1).getSize(), global_width);
+
+    std::vector<std::string> nex_id_strs = read_feature_id_strings(nc_var_nex_ids, ex_8_form_0_all_nexus_id.size());
+    ASSERT_EQ(nex_id_strs, ex_8_form_0_all_nexus_id);
+
+    // Rank 0's short IDs must survive verbatim at the (larger) global width, i.e. correctly null-padded.
+    ASSERT_NE(std::find(nex_id_strs.begin(), nex_id_strs.end(), "nex-1"), nex_id_strs.end());
+    ASSERT_NE(std::find(nex_id_strs.begin(), nex_id_strs.end(), "terminal-nexus-1234567890123"), nex_id_strs.end());
+
+    const netCDF::NcVar flow = ncf.getVar(friend_get_nc_flow_var_name(&mgr));
+    ASSERT_FALSE(flow.isNull());
+    ASSERT_EQ(flow.getDim(0).getSize(), ex_8_form_0_all_nexus_id.size());
+    ASSERT_EQ(flow.getDim(1).getSize(), ex_8_num_time_steps);
+    // Note that nexus feature_id dim comes before time dim, so have to order this way
+    double values[4][2];
+    flow.getVar(values);
+    for (size_t t = 0; t < ex_8_timestamps.size(); ++t) {
+        for (size_t n = 0; n < ex_8_form_0_all_nexus_id.size(); ++n) {
+            ASSERT_EQ(values[n][t], ex_8_all_data[t][n])
                 << "Flow mismatch for nexus id " << nex_id_strs[n] << " at time step " << t;
         }
     }
@@ -947,7 +1076,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_0_d)
     // These should all have size 4 for the current example, equal to the size of ex_0_form_0_nexus_ids
     ASSERT_EQ(nexus_ids.getDim(0).getSize(), 4);
     // feature_id is now a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nexus_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nexus_ids.getDim(1).getSize(), longest_id_length(ex_0_form_0_nexus_ids));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nexus_ids, ex_0_form_0_nexus_ids.size());
 
@@ -1106,7 +1235,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_1_c)
     // These should all have size 8 for the current example, equal to the size of ex_1_form_0_all_nexus_id
     ASSERT_EQ(nexus_ids.getDim(0).getSize(), 8);
     // feature_id is now a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nexus_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nexus_ids.getDim(1).getSize(), longest_id_length(ex_1_form_0_all_nexus_id));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nexus_ids, ex_1_form_0_all_nexus_id.size());
 
@@ -1151,7 +1280,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_5_a)
     ASSERT_FALSE(nexus_ids.isNull());
     ASSERT_EQ(nexus_ids.getDim(0).getSize(), ex_5_form_0_all_nexus_id.size());
     // feature_id is a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nexus_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nexus_ids.getDim(1).getSize(), longest_id_length(ex_5_form_0_all_nexus_id));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nexus_ids, ex_5_form_0_all_nexus_id.size());
     ASSERT_EQ(nex_id_strs, ex_5_form_0_all_nexus_id);
@@ -1176,6 +1305,49 @@ TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_5_a)
                 << "Flow mismatch for nexus id " << nex_id_strs[n] << " at time step " << t;
         }
     }
+}
+
+/**
+ * Test that a single-instance nexus set with differing ID lengths (including one longer than the former
+ * fixed width of 32) is written with a feature_id string-length dimension sized to the longest ID, and that
+ * every shorter ID round-trips exactly with correct null padding rather than being truncated or over-padded.
+ */
+TEST_F(PerFormulationNexusOutputMgr_Test, commit_writes_7_a)
+{
+    std::string form_name = ex_7_form_names->at(0);
+
+    // Guard the premise: the set really mixes lengths and its longest ID exceeds the former fixed width.
+    const size_t expected_width = longest_id_length(ex_7_form_0_all_nexus_id);
+    ASSERT_GT(expected_width, 32u);
+    ASSERT_GT(expected_width, ex_7_form_0_all_nexus_id.front().size());
+
+    utils::PerFormulationNexusOutputMgr mgr(ex_7_form_0_all_nexus_id, ex_7_form_names, output_root, ex_7_timestamps.size());
+
+    std::shared_ptr<std::vector<std::string>> filenames = mgr.get_filenames();
+    for (const std::string& f : *filenames) {
+        files_to_cleanup.push_back(f);
+    }
+
+    for (size_t t = 0; t < ex_7_timestamps.size(); ++t) {
+        for (size_t n = 0; n < ex_7_form_0_all_nexus_id.size(); ++n) {
+            mgr.receive_data_entry(form_name,
+                                   ex_7_form_0_all_nexus_id[n],
+                                   utils::time_marker(t, ex_7_timestamps_seconds[t], ex_7_timestamps[t]),
+                                   ex_7_all_data[t][n]);
+        }
+        mgr.commit_writes();
+    }
+
+    const netCDF::NcFile ncf(filenames->at(0), netCDF::NcFile::read);
+    const netCDF::NcVar nexus_ids = ncf.getVar(friend_get_nc_nex_id_dim_name(&mgr));
+    ASSERT_FALSE(nexus_ids.isNull());
+    ASSERT_EQ(nexus_ids.getDim(0).getSize(), ex_7_form_0_all_nexus_id.size());
+    // String-length dimension sized to the longest ID, verified independently of the manager's own width.
+    ASSERT_EQ(nexus_ids.getDim(1).getSize(), expected_width);
+    ASSERT_EQ(friend_nexus_id_string_width(&mgr), expected_width);
+
+    std::vector<std::string> nex_id_strs = read_feature_id_strings(nexus_ids, ex_7_form_0_all_nexus_id.size());
+    ASSERT_EQ(nex_id_strs, ex_7_form_0_all_nexus_id);
 }
 
 /** Make sure writes work for example 2 for multiple time steps, but using just a single instance. */
@@ -1362,7 +1534,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_0_a)
     // These should all have size 4 for the current example, equal to the size of ex_0_form_0_nexus_ids
     ASSERT_EQ(nexus_ids.getDim(0).getSize(), 4);
     // feature_id is now a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nexus_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nexus_ids.getDim(1).getSize(), longest_id_length(ex_0_form_0_nexus_ids));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nexus_ids, ex_0_form_0_nexus_ids.size());
 
@@ -1401,7 +1573,7 @@ TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_1_a)
     // These should all have size 8 for the current example, equal to the size of ex_1_form_0_all_nexus_id
     ASSERT_EQ(nexus_ids.getDim(0).getSize(), 8);
     // feature_id is now a 2-D fixed-width char variable: nexus dimension then string-length dimension.
-    ASSERT_EQ(nexus_ids.getDim(1).getSize(), friend_nexus_id_string_width());
+    ASSERT_EQ(nexus_ids.getDim(1).getSize(), longest_id_length(ex_1_form_0_all_nexus_id));
 
     std::vector<std::string> nex_id_strs = read_feature_id_strings(nexus_ids, ex_1_form_0_all_nexus_id.size());
 
@@ -1411,12 +1583,12 @@ TEST_F(PerFormulationNexusOutputMgr_Test, write_nexus_ids_once_1_a)
 /** Test that pack_nexus_id packs a normal id verbatim and null-pads the rest of the fixed-width buffer. */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_a)
 {
-    const size_t width = friend_nexus_id_string_width();
+    const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
     // Pre-fill with a non-null sentinel so the null padding is actually verified (not just left-over zeros).
     std::vector<char> buffer(width, 'X');
     const std::string id = "tnx-1";
 
-    friend_pack_nexus_id(id, buffer.data());
+    friend_pack_nexus_id(id, buffer.data(), width);
 
     // The id bytes are copied verbatim, prefix included.
     for (size_t i = 0; i < id.size(); ++i) {
@@ -1431,11 +1603,11 @@ TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_a)
 /** Test that pack_nexus_id handles an id exactly the fixed width, filling every byte with no null terminator. */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_b)
 {
-    const size_t width = friend_nexus_id_string_width();
+    const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
     const std::string id(width, 'a'); // exactly the fixed width
     std::vector<char> buffer(width, '\0');
 
-    friend_pack_nexus_id(id, buffer.data());
+    friend_pack_nexus_id(id, buffer.data(), width);
 
     for (size_t i = 0; i < width; ++i) {
         ASSERT_EQ(buffer[i], 'a') << "Expected full-width fill at byte " << i;
@@ -1445,11 +1617,11 @@ TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_b)
 /** Test that pack_nexus_id throws when the id is longer than the fixed width (no silent truncation). */
 TEST_F(PerFormulationNexusOutputMgr_Test, pack_nexus_id_c)
 {
-    const size_t width = friend_nexus_id_string_width();
+    const size_t width = 32; // pack helper is width-parameterized; exercise it at a representative width
     const std::string id(width + 1, 'a'); // one char too long to fit
     std::vector<char> buffer(width, '\0');
 
-    ASSERT_THROW(friend_pack_nexus_id(id, buffer.data()), std::runtime_error);
+    ASSERT_THROW(friend_pack_nexus_id(id, buffer.data(), width), std::runtime_error);
 }
 
 #endif // #if NGEN_MPI_UNIT_TESTS ... #else


### PR DESCRIPTION
Prospective changes to address my comments on #988 

## Changes

- Size the array of nexus identifiers in netCDF output files by the longest identifier in use in the simulation
- Pass the buffers as `span` instead of as a raw character pointer
- Change comments and strings to refer to ID rather than id

## Testing

1. Unit test as elaborated

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: