### PR TITLE
Refactor existing catchment output handling and add features required to optimize large runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 
-- Lorem ipsum dolor sit amet
+- An `output` configuration block for realization configs: `root`, per-domain (`catchment`/`nexus`) `enable`/`format`/`grouping`/`rank_subdir`, and a global value `precision`. See [Realization Configuration](doc/REALIZATION_CONFIGURATION.md#output).
+- Catchment output routed through a pluggable output manager (CSV backend), with an optional `grouping: per_formulation` that aggregates a formulation's catchments into one file with a leading `catchment_id` column (columns uniform per file by construction).
+- Per-domain `rank_subdir` option placing each MPI rank's CSV output under a `rank_<N>/` subdirectory (applied automatically for `per_formulation` under MPI).
 
 ### Deprecated
 
-- Nothing.
+- Top-level realization config keys `output_root`, `disable_catchment_output`, and `per_formulation_nexus_files`, superseded by the `output` block (still honored when no `output` block is present).
 
 ### Removed
 

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -55,7 +55,9 @@ Additionally, C++ compilers needs to be compatible (ideally officially *tested* 
 
 #### GCC
 
-Based on [this page](https://gcc.gnu.org/projects/cxx-status.html#cxx17), the C++ 17 support requirement probably equates to some GCC version `7` release or later.
+Based on [this page](https://gcc.gnu.org/projects/cxx-status.html#cxx17), C++ 17 *language* support alone equates to some GCC version `7` release or later. However, the project also relies on a complete C++ 17 `<filesystem>` implementation (e.g. `std::hash<std::filesystem::path>`), which GCC `8`'s libstdc++ does not fully provide, so the effective minimum is GCC `9` or later.
+
+On RHEL/Rocky/AlmaLinux `8`, whose system compiler is GCC `8`, install and enable a newer [`gcc-toolset`](https://developers.redhat.com/products/developertoolset/overview) rather than the base `gcc` (the project's container image, `docker/ngen.dockerfile`, uses `gcc-toolset-12`).
 
 #### Clang
 

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -21,15 +21,38 @@ The Configuration is a key-value object and must contain these three first level
 
 ## Optional Top-Level Keys
 
+### `output`
+The configuration may optionally contain an `output` object that controls where and how catchment and nexus output are written. All fields are optional:
+
+* `root` — root output directory for both catchment and nexus output; created if it does not already exist (default: the working directory, `./`).
+* `precision` — number of significant digits used when a text (CSV) backend renders values (default: `9`).
+* `catchment` and `nexus` — per-domain settings, each an object with:
+  * `enable` — whether this domain's output is written (default: `true`; set `catchment.enable` to `false` to skip catchment files).
+  * `format` — serialization format, `"csv"` (default) or `"netcdf"`. NetCDF is currently supported for nexus output only.
+  * `grouping` — how a domain's records are distributed across files (the file-*granularity* axis):
+    * `"per_feature"` (default) — one file per catchment / per nexus.
+    * `"per_formulation"` — the catchments of a formulation aggregate into one file with a leading `catchment_id` column (one file per formulation). Fewer, larger files, with columns uniform within each file by construction. (Nexus CSV aggregation is not yet implemented.)
+  * `rank_subdir` — whether an MPI rank's files are placed under a `rank_<N>/` subdirectory (the filesystem-*layout* axis, orthogonal to `grouping`; default `false`). Only affects distributed (multi-rank) runs — a no-op in serial — and reduces filesystem contention when many ranks share a directory. For `per_formulation` under MPI it is applied automatically regardless of this setting, since each rank must write its own file to avoid collisions.
+
+```
+"output": {
+    "root": "/path/to/output/",
+    "catchment": { "enable": true, "format": "csv", "grouping": "per_formulation", "rank_subdir": true },
+    "nexus":     { "enable": true, "format": "csv", "grouping": "per_feature",     "rank_subdir": true }
+}
+```
+
+> [!NOTE]
+> The `output` object supersedes the top-level `output_root`, `disable_catchment_output`, and `per_formulation_nexus_files` keys documented below. Those remain supported for backward compatibility and are honored only when no `output` object is present (with a deprecation warning); new configurations should use `output`.
+
 ### `output_root`
-The configuration may optionally contain an `output_root` key with a user-defined root output directory as the key, for nexus and catchment outputs.
+_Deprecated: prefer `output.root`._ The configuration may optionally contain an `output_root` key with a user-defined root output directory as the key, for nexus and catchment outputs.
 
 ### `disable_catchment_output`
-
-The configuration may optionally contain a `disable_catchment_output` key, with a boolean value.  When set to `true`, catchment output data files will not be written (default: `false`).
+_Deprecated: prefer `output.catchment.enable` set to `false`._ The configuration may optionally contain a `disable_catchment_output` key, with a boolean value.  When set to `true`, catchment output data files will not be written (default: `false`).
 
 ### `per_formulation_nexus_files`
-The configuration may optionally contain a `per_formulation_nexus_files` key with a boolean value to indicate per-formulation, NetCDF files should be used for writing nexus data, rather than the default of per-nexus CSV files.  Note that if `per_formulation_nexus_files` is set to `true`, the `catchments` cannot be used to define formulations for individual catchments, and the global formulation config must be used for all catchments.
+_Deprecated: prefer `output.nexus.format` set to `"netcdf"`._ The configuration may optionally contain a `per_formulation_nexus_files` key with a boolean value to indicate per-formulation, NetCDF files should be used for writing nexus data, rather than the default of per-nexus CSV files.  Note that if `per_formulation_nexus_files` is set to `true`, the `catchments` cannot be used to define formulations for individual catchments, and the global formulation config must be used for all catchments.
 
 > [!IMPORTANT]
 > NetCDF support must be turned on for the ngen build to use this option for per-formulation NetCDF file.  This is done by including the `-DNGEN_WITH_NETCDF=ON` arg to CMake on the command line when generating a build directory.
@@ -51,25 +74,16 @@ Note that these are not exhaustive examples.
    "global": {},
    "time": {},
    "catchments": {},
-   "output_root": "/path/to/output/"
+   "output": { "root": "/path/to/output/" }
 } 
 ```
-or
+or, using the deprecated top-level keys (still supported when no `output` object is present):
 ```
 {
    "global": {},
    "time": {},
    "output_root": "/path/to/output/",
    "per_formulation_nexus_files": true|false
-} 
-```
-or
-```
-{
-   "global": {},
-   "time": {},
-   "output_root": "/path/to/output/",
-   "write_catchment_output": true|false
 } 
 ```
 

--- a/docker/ngen.dockerfile
+++ b/docker/ngen.dockerfile
@@ -33,7 +33,10 @@ RUN cmake -S . \
           -DNGEN_WITH_PYTHON:BOOL=OFF \
           -DNGEN_WITH_TESTS:BOOL=ON \
           -DNGEN_QUIET:BOOL=ON \
-          -DNGEN_WITH_EXTERN_SLOTH:BOOL=ON
+          -DNGEN_WITH_EXTERN_SLOTH:BOOL=ON \
+          `# Rocky 8 ships GCC 8, whose std::filesystem lives in a separate library; link it` \
+          `# explicitly. --start-group avoids ordering issues with the static libstdc++fs.` \
+          -DCMAKE_EXE_LINKER_FLAGS="-Wl,--start-group -lstdc++fs"
 
 RUN cmake --build /ngen_build \
           --target testbmicppmodel ngen \

--- a/docker/ngen.dockerfile
+++ b/docker/ngen.dockerfile
@@ -4,8 +4,16 @@ FROM rockylinux:${ROCKYLINUX_TAG}
 RUN dnf update -y \
     && dnf install -y dnf-plugins-core epel-release \
     && dnf repolist \
-    && dnf install -y --allowerasing tar git gcc-c++ gcc make cmake udunits2-devel coreutils \
+    && dnf install -y --allowerasing tar git gcc-toolset-12 make cmake udunits2-devel coreutils \
     && dnf clean all
+
+# Rocky 8's system compiler is GCC 8, whose libstdc++ lacks complete C++17 <filesystem>
+# support (notably std::hash<std::filesystem::path>). Build with the gcc-toolset-12 SCL
+# toolchain instead, and point the runtime loader at its libstdc++.
+ENV PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/gcc-toolset-12/root/usr/lib64:/opt/rh/gcc-toolset-12/root/usr/lib" \
+    CC="/opt/rh/gcc-toolset-12/root/usr/bin/gcc" \
+    CXX="/opt/rh/gcc-toolset-12/root/usr/bin/g++"
 
 ARG BOOST_VERSION="1.86.0"
 RUN export BOOST_ARCHIVE="boost_$(echo ${BOOST_VERSION} | tr '\.' '_').tar.gz" \
@@ -33,10 +41,7 @@ RUN cmake -S . \
           -DNGEN_WITH_PYTHON:BOOL=OFF \
           -DNGEN_WITH_TESTS:BOOL=ON \
           -DNGEN_QUIET:BOOL=ON \
-          -DNGEN_WITH_EXTERN_SLOTH:BOOL=ON \
-          `# Rocky 8 ships GCC 8, whose std::filesystem lives in a separate library; link it` \
-          `# explicitly. --start-group avoids ordering issues with the static libstdc++fs.` \
-          -DCMAKE_EXE_LINKER_FLAGS="-Wl,--start-group -lstdc++fs"
+          -DNGEN_WITH_EXTERN_SLOTH:BOOL=ON
 
 RUN cmake --build /ngen_build \
           --target testbmicppmodel ngen \

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -4,6 +4,10 @@
 #include "Catchment_Formulation.hpp"
 #include "Layer.hpp"
 #include "State_Exception.hpp"
+#include "CatchmentOutputsMgr.hpp"
+
+#include <memory>
+#include <string>
 
 namespace ngen
 {
@@ -34,16 +38,22 @@ namespace ngen
          * @param features collection of HY_Features associated with the domain
          * @param idx index of the layer
          * @param formulation Formulation associated with the domain
+         * @param output_mgr Shared, driver-owned catchment output manager (may be null when output is
+         *        disabled). The layer registers as its own feature (formulation id "layer_<id>",
+         *        feature id = the layer name) in that manager, so its output honors the configured
+         *        format/grouping and lands in its own file alongside the surface catchments.
          */
         DomainLayer(
                 const LayerDescription& desc,
                 const Simulation_Time& s_t,
                 feature_type& features,
                 long idx,
-                std::shared_ptr<realization::Catchment_Formulation> formulation):
-                    Layer(desc, s_t, features, idx), formulation(formulation)
+                std::shared_ptr<realization::Catchment_Formulation> formulation,
+                std::shared_ptr<utils::CatchmentOutputsMgr> output_mgr):
+                    Layer(desc, s_t, features, idx, std::move(output_mgr)), formulation(formulation),
+                    output_formulation_id("layer_" + std::to_string(desc.id)),
+                    output_catchment_id(desc.name)
         {
-            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
         }
 
         /***
@@ -73,9 +83,12 @@ namespace ngen
                             +" (layer id: "+std::to_string(description.id)+")";
                 throw models::external::State_Exception(msg);
             } 
-            std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
-            formulation->get_output_line_for_timestep(output_time_index)+"\n";
-            formulation->write_output(output);
+            if (catchment_output_mgr) {
+                catchment_output_mgr->receive_data_entry(
+                    output_formulation_id, output_catchment_id,
+                    utils::time_marker(output_time_index, simulation_time.get_current_epoch_time(), current_timestamp),
+                    formulation->get_output_values_for_timestep(output_time_index));
+            }
             ++output_time_index;
             if ( output_time_index < simulation_time.get_total_output_times() )
             {
@@ -86,6 +99,9 @@ namespace ngen
 
         private:
         std::shared_ptr<realization::Catchment_Formulation> formulation;
+        //! This layer's identity in the shared manager, split into its (formulation, catchment) key.
+        std::string output_formulation_id;
+        std::string output_catchment_id;
     };
 }
 

--- a/include/core/HY_Features.hpp
+++ b/include/core/HY_Features.hpp
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <set>
+#include <memory>
 
 #include <HY_Catchment.hpp>
 #include <HY_HydroNexus.hpp>
@@ -35,9 +36,10 @@ namespace hy_features {
      *     auto r = features.catchment_at(id);
      *     auto r_c = dynamic_pointer_cast<realization::Catchment_Formulation>(r);
      *     double response = r_c->get_response(time_index, 3600.0);
-     *     std::string output = std::to_string(time_index)+", examlpe_time_stamp,"+
-     *                          r_c->get_output_line_for_timestep(time_index)+"\n";
-     *     r_c->write_output(output);
+     *     // outputs for the timestep as a vector<double> of values,
+     *     // in the order the output fields are defined.
+     *     auto fields = r_c->get_output_fields();
+     *     auto values = r_c->get_output_values_for_timestep(time_index);
      * }
      * @endcode
      */

--- a/include/core/HY_Features_MPI.hpp
+++ b/include/core/HY_Features_MPI.hpp
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 #include <set>
+#include <memory>
 
 #include <HY_Catchment.hpp>
 #include <HY_PointHydroNexusRemote.hpp>

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -8,12 +8,15 @@
 #include "State_Exception.hpp"
 #include "geojson/FeatureBuilder.hpp"
 #include <boost/core/span.hpp>
+#include <memory>
 
 namespace hy_features
 {
     class HY_Features;
     class HY_Features_MPI;
 }
+
+namespace utils { class CatchmentOutputsMgr; }
 
 namespace ngen
 {
@@ -32,41 +35,46 @@ namespace ngen
                 const LayerDescription& desc, 
                 const std::vector<std::string>& p_u, 
                 const Simulation_Time& s_t, 
-                feature_type& f, 
-                geojson::GeoJSON cd, 
-                long idx) :
+                feature_type& f,
+                geojson::GeoJSON cd,
+                long idx,
+                std::shared_ptr<utils::CatchmentOutputsMgr> cat_output_mgr) :
             description(desc),
             processing_units(p_u),
             simulation_time(s_t),
             features(f),
             catchment_data(cd),
-            output_time_index(idx)
+            output_time_index(idx),
+            catchment_output_mgr(cat_output_mgr)
         {
 
         }
 
         /**
          * @brief Construct a minimum layer object
-         * 
-         * @param desc 
-         * @param s_t 
-         * @param f 
-         * @param idx 
+         *
+         * @param desc
+         * @param s_t
+         * @param f
+         * @param idx
+         * @param cat_output_mgr Catchment output sink for this layer (may be null when output is disabled)
          */
         Layer(
-                const LayerDescription& desc, 
-                const Simulation_Time& s_t, 
+                const LayerDescription& desc,
+                const Simulation_Time& s_t,
                 feature_type& f,
-                long idx) :
+                long idx,
+                std::shared_ptr<utils::CatchmentOutputsMgr> cat_output_mgr) :
             description(desc),
             simulation_time(s_t),
             features(f),
-            output_time_index(idx)
+            output_time_index(idx),
+            catchment_output_mgr(cat_output_mgr)
         {
 
         }
 
-        virtual ~Layer() {}
+        virtual ~Layer();   // out-of-line; see Layer.cpp
 
         /***
          * @brief Return the next timestep that will be processed by this layer in epoch time units
@@ -119,7 +127,9 @@ namespace ngen
         feature_type& features;
         //TODO is this really required at the top level? or can this be moved to SurfaceLayer?
         const geojson::GeoJSON catchment_data;
-        long output_time_index;       
+        long output_time_index;
+        //! Catchment output sink for this layer's per-timestep push; null when output is disabled.
+        std::shared_ptr<utils::CatchmentOutputsMgr> catchment_output_mgr = nullptr;
 
     };
 }

--- a/include/core/SurfaceLayer.hpp
+++ b/include/core/SurfaceLayer.hpp
@@ -17,8 +17,9 @@ namespace ngen
                 feature_type& f, 
                 geojson::GeoJSON cd, 
                 long idx,
-                const std::shared_ptr<utils::NexusOutputsMgr> &nexus_outputs_mgr) :
-                    Layer(desc,p_u,s_t,f,cd,idx), 
+                const std::shared_ptr<utils::NexusOutputsMgr> &nexus_outputs_mgr,
+                std::shared_ptr<utils::CatchmentOutputsMgr> catchment_output_mgr) :
+                    Layer(desc,p_u,s_t,f,cd,idx,catchment_output_mgr),
                     nexus_outputs_mgr(nexus_outputs_mgr)
         {
 

--- a/include/core/catchment/HY_CatchmentArea.hpp
+++ b/include/core/catchment/HY_CatchmentArea.hpp
@@ -17,14 +17,6 @@ class HY_CatchmentArea : public HY_CatchmentRealization, public GM_Object
     HY_CatchmentArea();
     HY_CatchmentArea(utils::StreamHandler output_stream);
     //HY_CatchmentArea(forcing_params forcing_config, utils::StreamHandler output_stream); //TODO not sure I like this pattern
-    void set_output_stream(std::string file_path){
-        if (file_path.empty() || file_path == "/dev/null" || file_path == "null" || file_path == "NULL") {
-            output = std::move(utils::StreamHandler::getNullStream());
-        } else {
-            output = std::move(utils::FileStreamHandler(file_path.c_str()));
-        }
-    }
-    void write_output(std::string out){ output<<out; }
     virtual ~HY_CatchmentArea();
 
     protected:

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 #include <memory>
+#include <boost/core/span.hpp>
 #include "Catchment_Formulation.hpp"
 #include "GenericDataProvider.hpp"
 
@@ -139,27 +140,6 @@ namespace realization {
         }
 
         /**
-         * Get the values making up the header line from get_output_header_line(), but organized as a vector of strings.
-         *
-         * @return The values making up the header line from get_output_header_line() organized as a vector.
-         */
-        const std::vector<std::string> &get_output_header_fields() const {
-            return output_header_fields;
-        }
-
-        /**
-         * Get a header line appropriate for a file made up of entries from this type's implementation of
-         * ``get_output_line_for_timestep``.
-         *
-         * Note that like the output generating function, this line does not include anything for time step.
-         *
-         * @return An appropriate header line for this type.
-         */
-        std::string get_output_header_line(std::string delimiter) const override {
-            return boost::algorithm::join(get_output_header_fields(), delimiter);
-        }
-
-        /**
          * Get the names of variables in formulation output.
          *
          * Get the names of the variables to include in the output from this formulation, which should be some ordered
@@ -232,6 +212,15 @@ namespace realization {
 
         void set_output_header_fields(const std::vector<std::string> &output_headers) {
             output_header_fields = output_headers;
+        }
+
+        /**
+         * The configured/derived output header (display) field names, positionally parallel to
+         * @ref get_output_variable_names -- header i is the output name for variable i. A concrete
+         * subclass uses these as each column's output_name when building @ref get_output_fields.
+         */
+        boost::span<const std::string> get_output_header_field_names() const {
+            return output_header_fields;
         }
 
         /**

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -61,28 +61,46 @@ namespace realization {
         boost::span<const std::string> get_available_variable_names() const override;
 
         /**
-         * Get a delimited string with all the output variable values for the given time step.
+         * Get the output variable values for the given time step, one per output column and positionally aligned
+         * with @ref get_output_fields.
          *
-         * This method is useful for preparing calculated data in a representation useful for output files, such as
-         * CSV files.
+         * The values are the model's calculated outputs for the time step; the time step index itself is not
+         * included.
          *
-         * The resulting string contains only the calculated output values for the time step, and not the time step
-         * index itself.
-         *
-         * An empty string is returned if the time step value is not in the range of valid time steps for which there
-         * are calculated values for all variables.
-         *
-         * The default delimiter is a comma.
-         *
-         * Implementations will throw `invalid_argument` exceptions if data for the provided time step parameter is not
-         * accessible.  Note that, for this type, only the last processed time step is accessible, because formulations
-         * do not save results from previous time steps.  This also has the consequence of there being no valid set of
-         * arguments before a least one call to @ref get_response has been made.
+         * Only the last processed time step is accessible, because formulations do not save results from previous
+         * time steps; there is thus no valid time step before at least one call to @ref update has been made.
+         * Throws `std::invalid_argument` if @p timestep is not the current (last processed) time step.
          *
          * @param timestep The time step for which data is desired.
-         * @return A delimited string with all the output variable values for the given time step.
+         * @return The output values for the given time step, one per output column.
          */
-        std::string get_output_line_for_timestep(int timestep, std::string delimiter) override;
+        std::vector<double> get_output_values_for_timestep(int timestep) override;
+
+        /**
+         * Get this formulation's output fields (header name + units) in output order. Units come
+         * straight from the backing BMI model (@c GetVarUnits) per output variable; std::nullopt when
+         * the model reports none (GetVarUnits fails / BMI_FAILURE) rather than failing the run.
+         */
+        std::vector<utils::OutputField> get_output_fields() const override {
+            // The output variables and their header (output) names are 1:1 and positionally aligned
+            // (enforced at construction) -- variable i is written under header i. Build one field per
+            // variable: units come from the model for that variable; the output name is its header
+            // (which defaults to the variable name, or is a configured alias).
+            const std::vector<std::string> &variables = get_output_variable_names();
+            boost::span<const std::string> headers = get_output_header_field_names();
+            std::vector<utils::OutputField> fields;
+            fields.reserve(variables.size());
+            for (std::size_t i = 0; i < variables.size(); ++i) {
+                std::optional<std::string> units;
+                try {
+                    units = get_bmi_model()->GetVarUnits(variables[i]);
+                } catch (...) {
+                    units = std::nullopt;
+                }
+                fields.emplace_back(variables[i], headers[i], std::move(units));
+            }
+            return fields;
+        }
 
         /**
          * Get the model response for a time step.
@@ -441,7 +459,7 @@ namespace realization {
          * The member serves as an implicit marker of how many time steps have been processed so far.  Knowing this is
          * required to maintain valid behavior in certain things, such as @ref get_response (we may want to process
          * multiple time steps forward to a particular index other than the next, but it would not be valid to receive
-         * a ``t_index`` earlier than the last processed time step) and @ref get_output_line_for_timestep (because
+         * a ``t_index`` earlier than the last processed time step) and @ref get_output_values_for_timestep (because
          * formulations do not save results from previous time steps, only the results from the last processed time step
          * can be used to generate output).
          */

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -353,7 +353,14 @@ namespace realization {
             return modules[get_index_for_primary_module()]->get_data_start_time();
         }
 
-        std::string get_output_line_for_timestep(int timestep, std::string delimiter) override;
+        std::vector<double> get_output_values_for_timestep(int timestep) override;
+
+        /**
+         * Get this formulation's output fields (header name + units) in output order. The units come
+         * from the submodule that produces each variable -- the same source its value comes from --
+         * by reusing the submodules' own output fields.
+         */
+        std::vector<utils::OutputField> get_output_fields() const override;
 
         double get_response(time_step_t t_index, time_step_t t_delta) override;
 

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -6,8 +6,7 @@
 #include "Formulation.hpp"
 #include <HY_CatchmentArea.hpp>
 #include "GenericDataProvider.hpp"
-
-#define DEFAULT_FORMULATION_OUTPUT_DELIMITER ","
+#include "utilities/output/CatchmentOutputsMgr.hpp"   // utils::OutputField
 
 namespace realization {
 
@@ -31,36 +30,26 @@ namespace realization {
                                                     const std::string &pattern, const std::string &replacement);
 
             /**
-             * Get a header line appropriate for a file made up of entries from this type's implementation of
-             * ``get_output_line_for_timestep``.
+             * Get this formulation's output fields -- name plus metadata (units, ...) -- in the same
+             * order as the values returned by @ref get_output_values_for_timestep.
              *
-             * Note that like the output generating function, this line does not include anything for time step.
+             * The name is the output header field (configured, or defaulting to the output variable
+             * name); the units come from the same source that produces each value. So each field is
+             * positionally aligned with, and describes, the corresponding value.
              *
-             * A default implementation is provided for inheritors of this type, which includes only "Total Discharge."
-             *
-             * @return An appropriate header line for this type.
+             * @return The ordered output fields.
              */
-            virtual std::string get_output_header_line(std::string delimiter=DEFAULT_FORMULATION_OUTPUT_DELIMITER) const;
+            virtual std::vector<utils::OutputField> get_output_fields() const = 0;
 
             /**
-             * Get a formatted line of output values for the given time step as a delimited string.
+             * Get the output values for the given time step, positionally aligned with @ref get_output_fields.
              *
-             * This method is useful for preparing calculated data in a representation useful for output files, such as
-             * CSV files.
+             * Values are returned as raw doubles, with no formatting or precision applied by the formulation.
              *
-             * The resulting string will contain calculated values for applicable output variables for the particular
-             * formulation, as determined for the given time step.  However, the string will not contain any
-             * representation of the time step itself.
-             *
-             * An empty string is returned if the time step value is not in the range of valid time steps for which there
-             * are calculated values for all variables.
-             *
-             * @param timestep The time step for which data is desired.
-             * @param delimiter The value delimiter for the string.
-             * @return A delimited string with all the output variable values for the given time step.
+             * @param timestep The time step for which values are desired.
+             * @return The output values for @p timestep, one per output column.
              */
-            virtual std::string get_output_line_for_timestep(int timestep,
-                                                             std::string delimiter = DEFAULT_FORMULATION_OUTPUT_DELIMITER) = 0;
+            virtual std::vector<double> get_output_values_for_timestep(int timestep) = 0;
 
             /**
              * Execute the backing model formulation for the given time step, where it is of the specified size, and

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <string>
+#include <iostream>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -25,6 +26,7 @@
 #include "realizations/config/routing.hpp"
 #include "realizations/config/config.hpp"
 #include "realizations/config/layer.hpp"
+#include "realizations/config/output.hpp"
 
 namespace realization {
 
@@ -40,10 +42,12 @@ namespace realization {
                 boost::property_tree::ptree loaded_tree;
                 boost::property_tree::json_parser::read_json(file_path, loaded_tree);
                 this->tree = loaded_tree;
+                initialize_output_config();
             }
 
             Formulation_Manager(boost::property_tree::ptree &loaded_tree) {
                 this->tree = loaded_tree;
+                initialize_output_config();
             }
 
             ~Formulation_Manager() = default;
@@ -54,18 +58,8 @@ namespace realization {
                 //and routing and other non feature specific tasks from this main function
                 //which has to iterate the entire hydrofabric.
 
-                // TODO: (later) consider whether this really belongs inside the global formulation
-                auto per_formulation_setting = tree.get_child_optional("per_formulation_nexus_files");
-                if (per_formulation_setting) {
-                    #if !NGEN_WITH_NETCDF
-                    throw std::runtime_error("ERROR: per_formulation_nexus_files is set to true, but NGEN was built without NetCDF support.");
-                    #else
-                    use_per_formulation_nexus_files = per_formulation_setting->get_value<bool>();
-                    #endif
-                }
-                else {
-                    use_per_formulation_nexus_files = false;
-                }
+                // Output configuration (output_config) is parsed at construction
+                // so get_output_config() is valid before read().
 
                 auto possible_global_config = tree.get_child_optional("global");
 
@@ -104,7 +98,6 @@ namespace realization {
                                 output_stream
                                 )
                             );
-                            domain_formulations.at(layer_desc.id)->set_output_stream(get_output_root() + layer_desc.name + "_layer_"+std::to_string(layer_desc.id) + ".csv");
                         }
                         //TODO for each layer, create deferred providers for use by other layers
                         //VERY SIMILAR TO NESTED MODULE INIT
@@ -137,7 +130,8 @@ namespace realization {
                 auto possible_catchment_configs = tree.get_child_optional("catchments");
 
                 // For now at least, this isn't allowed
-                if (possible_catchment_configs && use_per_formulation_nexus_files) {
+                if (possible_catchment_configs &&
+                    output_config.nexus.format == realization::config::OutputFormat::netcdf) {
                     std::string msg = "ERROR: Individual catchment formulation configs are not allowed when using "
                                       "per-formulation nexus files.";
                     std::cerr << msg;
@@ -223,8 +217,66 @@ namespace realization {
                 return this->formulations.empty();
             }
 
+            /**
+             * @brief Get the formatted output root: check the existence of the output_root directory defined
+             * in realization. If true, return the directory name. Otherwise, try to create the directory
+             * or throw an error on failure.
+             *
+             * @return std::string of the output root directory
+             */
+            std::string get_output_root() const {
+                const auto output_root = this->tree.get_optional<std::string>("output_root");
+                if (output_root != boost::none && *output_root != "") {
+                    // Check if the path ends with a trailing slash, otherwise add it.
+                    std::string str = output_root->back() == '/'
+                           ? *output_root
+                           : *output_root + "/";
+
+                    const char* dir = str.c_str();
+
+                    //use C++ system function to check if there is a dir match that defined in realization
+                    struct stat sb;
+                    if (stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
+                        return str;
+                    } else {
+                        errno = 0;
+                        int result = mkdir(dir, 0755);
+                        if (result == 0)
+                            return str;
+                        // Another process/MPI rank may have created the directory between this rank's stat and
+                        // mkdir calls, so consider EEXIST as success as long as the path is a directory.
+                        if (errno == EEXIST && stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode))
+                            return str;
+                        throw std::runtime_error("failed to create directory '" + str + "': " + std::strerror(errno));
+                    }
+                }
+
+                //for case where there is no output_root in the realization file
+                return "./";
+            }
+
+            /**
+             * Check if the formulation has catchment output writing disabled.
+             *
+             * @return bool
+             */
+            bool is_disable_catchment_output() const {
+                return tree.get_optional<bool>("disable_catchment_output").get_value_or(false);
+            }
+
+            /**
+             * Whether nexus output is written as per-formulation NetCDF files (the deprecated
+             * per_formulation_nexus_files mode, now expressed as nexus format == netcdf).
+             *
+             * @return bool
+             */
             bool is_using_per_formulation_nexus_files() const {
-                return use_per_formulation_nexus_files;
+                return output_config.nexus.format == realization::config::OutputFormat::netcdf;
+            }
+
+            //! The parsed output configuration block.
+            const realization::config::Output& get_output_config() const {
+                return output_config;
             }
 
             typename std::map<std::string, std::shared_ptr<Catchment_Formulation>>::const_iterator begin() const {
@@ -283,72 +335,25 @@ namespace realization {
             }
 
             /**
-             * @brief Get the formatted output root: check the existence of the output_root directory defined
-             * in realization. If true, return the directory name. Otherwise, try to create the directory
-             * or throw an error on failure.
-             *
-             * @code{.cpp}
-             * // Example config:
-             * // ...
-             * // "output_root": "/path/to/dir/"
-             * // ...
-             * const auto manager = Formulation_Manger(CONFIG);
-             * manager.get_output_root();
-             * //> "/path/to/dir/"
-             * @endcode
-             * 
-             * @return std::string of the output root directory
+             * Parse the output configuration from the realization tree (preferring
+             * the "output" block, falling back to the deprecated top-level keys),
+             * warn on deprecated usage, and validate build support. Called once at
+             * construction so output accessors are valid before read().
              */
-            std::string get_output_root() const {
-                const auto output_root = this->tree.get_optional<std::string>("output_root");
-                if (output_root != boost::none && *output_root != "") {
-                    // Check if the path ends with a trailing slash,
-                    // otherwise add it.
-                    std::string str = output_root->back() == '/'
-                           ? *output_root
-                           : *output_root + "/";
-
-                    const char* dir = str.c_str();
-
-                    //use C++ system function to check if there is a dir match that defined in realization
-                    struct stat sb;
-                    if (stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
-                        return str;
-                    } else {
-                        errno = 0;
-                        int result = mkdir(dir, 0755);      
-                        if (result == 0)
-                            return str;
-                        // Another process/MPI rank may have created the directory between this rank's stat and
-                        // mkdir calls, so consider EEXIST as success as long as the path is a directory.
-                        if (errno == EEXIST && stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode))
-                            return str;
-                        throw std::runtime_error("failed to create directory '" + str + "': " + std::strerror(errno));
-                    }
+            void initialize_output_config() {
+                output_config = realization::config::Output::from_realization(tree);
+                #if !NGEN_QUIET
+                if (output_config.from_legacy_keys) {
+                    std::cerr << "WARNING: top-level 'output_root', 'disable_catchment_output', and "
+                                 "'per_formulation_nexus_files' keys are deprecated; prefer an 'output' "
+                                 "config block (output.root / output.catchment / output.nexus)." << std::endl;
                 }
- 
-                //for case where there is no output_root in the realization file
-                return "./";
-
-            }
-
-             /**
-             * Check if the formulation has catchment output writing disabled.
-             *
-             * @code{.cpp}
-             * // Example config:
-             * // ...
-             * // "disable_catchment_output": true
-             * // ...
-             * const auto manager = Formulation_Manger(CONFIG);
-             * manager.is_disable_catchment_output();
-             * //> true
-             * @endcode
-             * 
-             * @return bool
-             */
-            bool is_disable_catchment_output() const {
-                return tree.get_optional<bool>("disable_catchment_output").get_value_or(false);
+                #endif
+                #if !NGEN_WITH_NETCDF
+                if (output_config.nexus.format == realization::config::OutputFormat::netcdf) {
+                    throw std::runtime_error("ERROR: nexus output format 'netcdf' requested, but NGEN was built without NetCDF support.");
+                }
+                #endif
             }
 
             /**
@@ -706,7 +711,7 @@ namespace realization {
 
             bool using_routing = false;
 
-            bool use_per_formulation_nexus_files;
+            realization::config::Output output_config;
 
             ngen::LayerDataStorage layer_storage;
 

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -36,6 +36,7 @@ namespace realization {
                 boost::property_tree::ptree loaded_tree;
                 boost::property_tree::json_parser::read_json(data, loaded_tree);
                 this->tree = loaded_tree;
+                initialize_output_config();
             }
 
             Formulation_Manager(const std::string &file_path) {
@@ -215,63 +216,6 @@ namespace realization {
              */
             bool is_empty() {
                 return this->formulations.empty();
-            }
-
-            /**
-             * @brief Get the formatted output root: check the existence of the output_root directory defined
-             * in realization. If true, return the directory name. Otherwise, try to create the directory
-             * or throw an error on failure.
-             *
-             * @return std::string of the output root directory
-             */
-            std::string get_output_root() const {
-                const auto output_root = this->tree.get_optional<std::string>("output_root");
-                if (output_root != boost::none && *output_root != "") {
-                    // Check if the path ends with a trailing slash, otherwise add it.
-                    std::string str = output_root->back() == '/'
-                           ? *output_root
-                           : *output_root + "/";
-
-                    const char* dir = str.c_str();
-
-                    //use C++ system function to check if there is a dir match that defined in realization
-                    struct stat sb;
-                    if (stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
-                        return str;
-                    } else {
-                        errno = 0;
-                        int result = mkdir(dir, 0755);
-                        if (result == 0)
-                            return str;
-                        // Another process/MPI rank may have created the directory between this rank's stat and
-                        // mkdir calls, so consider EEXIST as success as long as the path is a directory.
-                        if (errno == EEXIST && stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode))
-                            return str;
-                        throw std::runtime_error("failed to create directory '" + str + "': " + std::strerror(errno));
-                    }
-                }
-
-                //for case where there is no output_root in the realization file
-                return "./";
-            }
-
-            /**
-             * Check if the formulation has catchment output writing disabled.
-             *
-             * @return bool
-             */
-            bool is_disable_catchment_output() const {
-                return tree.get_optional<bool>("disable_catchment_output").get_value_or(false);
-            }
-
-            /**
-             * Whether nexus output is written as per-formulation NetCDF files (the deprecated
-             * per_formulation_nexus_files mode, now expressed as nexus format == netcdf).
-             *
-             * @return bool
-             */
-            bool is_using_per_formulation_nexus_files() const {
-                return output_config.nexus.format == realization::config::OutputFormat::netcdf;
             }
 
             //! The parsed output configuration block.

--- a/include/realizations/config/catchment_output.hpp
+++ b/include/realizations/config/catchment_output.hpp
@@ -1,0 +1,62 @@
+#ifndef NGEN_REALIZATION_CONFIG_CATCHMENT_OUTPUT_HPP
+#define NGEN_REALIZATION_CONFIG_CATCHMENT_OUTPUT_HPP
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "realizations/config/output.hpp"
+#include "utilities/output/CatchmentOutputsMgr.hpp"
+#include "utilities/output/CatchmentCsvOutputMgr.hpp"
+
+namespace realization
+{
+    namespace config
+    {
+        //! Default file name for an aggregated (per_formulation) catchment file. The rank, when
+        //! applicable, is carried in the resolved root (a rank_<N>/ subdirectory), not the file name.
+        static const std::string DEFAULT_AGGREGATED_FILENAME = "cat_output.csv";
+
+        /**
+         * Build the catchment output manager from the parsed output configuration. Grouping and
+         * precision come from @p output_config; the resolved root comes from @c output_config.root,
+         * which the caller is expected to have already adjusted for rank layout (see
+         * @ref rank_output_root) so any rank_<N>/ subdirectory is baked into the root.
+         *
+         * The manager is constructed with the full set of @p descriptors (every catchment and its
+         * columns), so the backend lays out its files up front and is ready to receive data on return.
+         *
+         * Side effect: constructing the manager creates the output directory tree it writes into
+         * (config parsing only normalizes the root -- it does not touch the filesystem). Each output
+         * manager owns creating what it writes, so no caller need pre-create the directory.
+         *
+         * Only the CSV format is implemented today; any other configured format is rejected here (the
+         * branch on @c output_config.catchment.format is where an added format would slot in). Layout
+         * follows the grouping: @c per_formulation aggregates each formulation's catchments into one
+         * file (leading catchment_id column) named @p aggregated_filename; @c per_feature writes one
+         * file per catchment.
+         *
+         * @throw std::runtime_error if a catchment output format other than CSV is configured.
+         */
+        inline std::shared_ptr<utils::CatchmentOutputsMgr> make_catchment_output_mgr(
+                const Output& output_config,
+                std::vector<utils::FeatureDescriptor> descriptors,
+                const std::string& aggregated_filename = DEFAULT_AGGREGATED_FILENAME)
+        {
+            if (output_config.catchment.format == OutputFormat::csv) {
+                const bool aggregate = output_config.catchment.grouping == OutputGrouping::per_formulation;
+                return std::make_shared<utils::CatchmentCsvOutputMgr>(
+                    output_config.root,
+                    aggregate ? std::optional<std::string>(aggregated_filename) : std::nullopt,
+                    output_config.precision, std::move(descriptors));
+            } else {
+                throw std::runtime_error("Catchment output: only the CSV format is currently supported.");
+            }
+        }
+    } // namespace config
+} // namespace realization
+
+#endif // NGEN_REALIZATION_CONFIG_CATCHMENT_OUTPUT_HPP

--- a/include/realizations/config/output.hpp
+++ b/include/realizations/config/output.hpp
@@ -1,0 +1,174 @@
+#ifndef NGEN_REALIZATION_CONFIG_OUTPUT_H
+#define NGEN_REALIZATION_CONFIG_OUTPUT_H
+
+#include <string>
+#include <stdexcept>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/optional.hpp>
+
+namespace realization {
+  namespace config {
+
+    //! Key for the dedicated output configuration block in a realization config.
+    static const std::string OUTPUT_CONFIG_KEY = "output";
+
+    //! Deprecated top-level keys this block replaces.
+    static const std::string LEGACY_OUTPUT_ROOT_KEY        = "output_root";
+    static const std::string LEGACY_DISABLE_CATCHMENT_KEY  = "disable_catchment_output";
+    static const std::string LEGACY_PER_FORMULATION_KEY    = "per_formulation_nexus_files";
+
+    //! Serialization format for an output domain.
+    enum class OutputFormat { csv, netcdf };
+
+    //! How a domain's records are distributed across files (the file-*granularity* axis):
+    //!   per_feature     - one file per feature (one CSV per catchment / per nexus)
+    //!   per_formulation - the features of a formulation aggregate into one file (a feature-id
+    //!                     column distinguishes their rows). Fewer, larger files; columns are
+    //!                     uniform within a file by construction.
+    //! Orthogonal to this is @ref OutputDomain::rank_subdir, the filesystem-*layout* axis.
+    enum class OutputGrouping { per_feature, per_formulation };
+
+    inline OutputFormat parse_output_format(const std::string& s)
+    {
+        if (s == "csv")    return OutputFormat::csv;
+        if (s == "netcdf") return OutputFormat::netcdf;
+        throw std::runtime_error("Invalid output format '" + s + "'; expected 'csv' or 'netcdf'.");
+    }
+
+    inline OutputGrouping parse_output_grouping(const std::string& s)
+    {
+        if (s == "per_feature")     return OutputGrouping::per_feature;
+        if (s == "per_formulation") return OutputGrouping::per_formulation;
+        throw std::runtime_error("Invalid output grouping '" + s + "'; expected 'per_feature' or 'per_formulation'.");
+    }
+
+    //! Settings for one output domain (catchment or nexus).
+    struct OutputDomain {
+        bool enable = true;
+        OutputFormat format = OutputFormat::csv;
+        OutputGrouping grouping = OutputGrouping::per_feature;
+        //! Place each MPI rank's files under a "rank_<N>/" subdirectory (the filesystem-layout axis,
+        //! orthogonal to @ref grouping). Only affects distributed (multi-rank) runs; a no-op in
+        //! serial. It is a free preference for per_feature; for per_formulation under MPI it is
+        //! required (else ranks would collide on one aggregated file) and applied regardless.
+        //! @see rank_output_root
+        bool rank_subdir = false;
+
+        OutputDomain() = default;
+
+        explicit OutputDomain(const boost::property_tree::ptree& tree) {
+            enable = tree.get<bool>("enable", true);
+            rank_subdir = tree.get<bool>("rank_subdir", false);
+            if (auto f = tree.get_optional<std::string>("format"))   format   = parse_output_format(*f);
+            if (auto g = tree.get_optional<std::string>("grouping")) grouping = parse_output_grouping(*g);
+        }
+    };
+
+    /**
+     * The output root for a rank's files in this domain: appends "rank_<N>/" to @p base_root when the
+     * domain requests per-rank subdirectories, or when it aggregates per formulation (which requires
+     * per-rank separation so ranks don't write the same file). Only distributed (@p mpi_num_procs > 1)
+     * runs are affected; in serial @p base_root is returned unchanged. The directory is created
+     * lazily by the backend when it opens files.
+     */
+    inline std::string rank_output_root(const std::string& base_root, const OutputDomain& domain,
+                                        int mpi_rank, int mpi_num_procs)
+    {
+        const bool needs_rank_subdir = domain.rank_subdir
+                                       || domain.grouping == OutputGrouping::per_formulation;
+        if (mpi_num_procs > 1 && needs_rank_subdir) {
+            return base_root + "rank_" + std::to_string(mpi_rank) + "/";
+        }
+        return base_root;
+    }
+
+    /**
+     * Parsed representation of a realization config's output settings.
+     *
+     * Modern form (preferred):
+     * @code{.json}
+     * "output": {
+     *     "root": "/path/to/output/",
+     *     "catchment": { "enable": true, "format": "csv", "grouping": "per_feature" },
+     *     "nexus":     { "enable": true, "format": "csv", "grouping": "per_feature" }
+     * }
+     * @endcode
+     *
+     * For backward compatibility, when no "output" block is present the
+     * deprecated top-level keys output_root / disable_catchment_output /
+     * per_formulation_nexus_files are honored instead (see from_realization).
+     */
+    struct Output {
+        //! Significant digits applied uniformly when a text backend (CSV) renders values.
+        static constexpr int DEFAULT_PRECISION = 9;
+
+        //! Output directory. Built through from_realization this is the normalized root: a
+        //! trailing-slash path ("./" when unset). The default constructor and the public
+        //! parse_block / parse_legacy leave it as the raw configured value. Creating the directory
+        //! on disk is a separate step -- see create_output_directory -- performed by the caller near
+        //! where output is written, so config parsing has no filesystem side effect.
+        std::string root;
+        OutputDomain catchment;
+        OutputDomain nexus;
+        //! Global value precision for text output backends.
+        int precision = DEFAULT_PRECISION;
+        //! True when built from the deprecated top-level keys (used to warn).
+        bool from_legacy_keys = false;
+
+        Output() = default;
+
+        //! Parse the modern "output" block sub-tree.
+        static Output parse_block(const boost::property_tree::ptree& output_tree)
+        {
+            Output out;
+            out.root = output_tree.get<std::string>("root", "");
+            out.precision = output_tree.get<int>("precision", DEFAULT_PRECISION);
+            if (auto c = output_tree.get_child_optional("catchment")) out.catchment = OutputDomain(*c);
+            if (auto n = output_tree.get_child_optional("nexus"))     out.nexus     = OutputDomain(*n);
+            return out;
+        }
+
+        //! Build from the deprecated top-level keys.
+        static Output parse_legacy(const boost::property_tree::ptree& realization_tree)
+        {
+            Output out;
+            const auto root        = realization_tree.get_optional<std::string>(LEGACY_OUTPUT_ROOT_KEY);
+            const auto disable_cat = realization_tree.get_optional<bool>(LEGACY_DISABLE_CATCHMENT_KEY);
+            const auto per_form    = realization_tree.get_child_optional(LEGACY_PER_FORMULATION_KEY);
+
+            if (root)        out.root = *root;
+            if (disable_cat) out.catchment.enable = !(*disable_cat);
+            if (per_form && per_form->get_value<bool>(false)) out.nexus.format = OutputFormat::netcdf;
+
+            out.from_legacy_keys = static_cast<bool>(root) || static_cast<bool>(disable_cat) || static_cast<bool>(per_form);
+            return out;
+        }
+
+        //! Prefer the modern "output" block; otherwise fall back to legacy keys, then normalize the
+        //! root (see normalize_root) so an Output built through this entry point exposes a
+        //! trailing-slash directory. parse_block / parse_legacy return the raw root. Creating the
+        //! directory is left to the caller (see create_output_directory) -- parsing has no side effect.
+        static Output from_realization(const boost::property_tree::ptree& realization_tree)
+        {
+            auto block = realization_tree.get_child_optional(OUTPUT_CONFIG_KEY);
+            Output out = block ? parse_block(*block) : parse_legacy(realization_tree);
+            out.root = normalize_root(out.root);
+            return out;
+        }
+
+    private:
+        //! Normalize a configured directory to a trailing-slash path, falling back to "./" when
+        //! unset. Pure: creating the directory is a separate side effect (see create_output_directory).
+        static std::string normalize_root(const std::string& configured_root)
+        {
+            if (configured_root.empty()) {
+                return "./";
+            }
+            return configured_root.back() == '/' ? configured_root : configured_root + "/";
+        }
+    };
+
+  }//end namespace config
+}//end namespace realization
+#endif //NGEN_REALIZATION_CONFIG_OUTPUT_H

--- a/include/utilities/output/CatchmentCsvOutputMgr.hpp
+++ b/include/utilities/output/CatchmentCsvOutputMgr.hpp
@@ -1,0 +1,108 @@
+/*
+Copyright (C) 2026 Lynker
+------------------------------------------------------------------------
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+------------------------------------------------------------------------
+*/
+
+#ifndef NGEN_CATCHMENTCSVOUTPUTMGR_HPP
+#define NGEN_CATCHMENTCSVOUTPUTMGR_HPP
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "CatchmentOutputsMgr.hpp"
+
+namespace utils
+{
+    /**
+     * CSV backend for catchment output. A single map of open output streams, keyed by resolved file
+     * path, backs both groupings:
+     *   - per-feature: one file per (formulation, catchment).
+     *   - aggregated: the catchments of a formulation share one file (the aggregated filename), with
+     *     a leading catchment_id column; the header is written once per file.
+     * In both cases the default formulation id keeps the flat "<output_root><name>" layout, and any
+     * other formulation id is placed in a "<output_root><formulation_id>/" subdirectory -- so
+     * independent formulation setups never collide, and each aggregated file holds a single
+     * formulation's (uniform) column set.
+     *
+     * Rows are written immediately on receipt (@ref commit_writes only flushes). Values are rendered
+     * to text at a uniform significant-digit precision fixed at construction.
+     */
+    class CatchmentCsvOutputMgr : public CatchmentOutputsMgr
+    {
+
+    public:
+
+        /**
+         * @param output_root The directory to write into: a resolved path with a trailing slash (as
+         *        produced by realization::config normalization, e.g. "./" or "out/rank_3/"), not a
+         *        filename prefix. Created here (along with any per-formulation subdirectories) if it
+         *        does not exist, so callers need not pre-create it.
+         * @param aggregated_filename File name used for each formulation's shared file when @p
+         *        aggregate is true (e.g. "cat_output.csv", or "cat_rank_<N>.csv" for a per-rank MPI file).
+         *        When present, the catchments of each formulation share one aggregated file
+         *        (the catchment id becomes a leading column); nullopt is one file per catchment.
+         * @param precision Significant digits applied uniformly when rendering all values to text.
+         * @param descriptors The full set of catchments (and their fields) this manager will write;
+         *        files are opened and headers written for all of them here, so the manager is ready to
+         *        receive data immediately after construction.
+         */
+        CatchmentCsvOutputMgr(std::string output_root, std::optional<std::string> aggregated_filename,
+                              int precision, std::vector<FeatureDescriptor> descriptors);
+
+        ~CatchmentCsvOutputMgr() override;
+
+        // Keep the default-formulation-id convenience overload visible alongside the override.
+        using CatchmentOutputsMgr::receive_data_entry;
+
+        void receive_data_entry(const std::string &formulation_id, const std::string &catchment_id,
+                                const time_marker &data_time_marker, const std::vector<double> &values) override;
+
+        void commit_writes() override;
+
+        void close() override;
+
+        bool is_closed() override;
+
+    private:
+        const std::string output_root_;
+        const std::optional<std::string> aggregated_filename_;
+        const int precision_;
+        bool closed_ = false;
+
+        // Open output streams keyed by resolved file path. In per-feature mode each (formulation,
+        // catchment) has its own path; in aggregated mode every catchment of a formulation resolves
+        // to the same path and shares one stream.
+        std::unordered_map<std::filesystem::path, std::shared_ptr<std::ofstream>> streams_;
+
+        //! Resolve the output file path for a (formulation, catchment). The file name is the
+        //! catchment ("<catchment>.csv") per-feature, or the shared aggregated filename when
+        //! aggregating; the default formulation id keeps the flat "<root><name>" layout, any other
+        //! id nests under "<root><formulation>/".
+        std::filesystem::path output_path(const std::string &formulation_id, const std::string &catchment_id);
+
+        //! Resolve the stream a (formulation, catchment)'s rows are written to, or nullptr if not registered.
+        std::ofstream* stream_for(const std::string &formulation_id, const std::string &catchment_id);
+
+        //! Open the file(s) and write the header for one descriptor; called for each at construction.
+        void add_feature(const FeatureDescriptor &descriptor);
+    };
+} // utils
+
+#endif //NGEN_CATCHMENTCSVOUTPUTMGR_HPP

--- a/include/utilities/output/CatchmentOutputsMgr.hpp
+++ b/include/utilities/output/CatchmentOutputsMgr.hpp
@@ -1,0 +1,179 @@
+/*
+Copyright (C) 2026 Lynker
+------------------------------------------------------------------------
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+------------------------------------------------------------------------
+*/
+
+// Catchment output manager, modeled on NexusOutputsMgr: a concrete backend is constructed with the
+// full set of catchments/fields it will handle (see FeatureDescriptor and the backend's
+// constructor), then data is pushed in via receive_data_entry and the backend serializes it however
+// it chooses. Constructing with the complete set means a backend has everything it needs to lay out
+// its sink up front, rather than discovering features incrementally. The two hierarchies
+// (nexus/catchment) are kept separate for now and can be unified behind a shared base later.
+
+#ifndef NGEN_CATCHMENTOUTPUTSMGR_HPP
+#define NGEN_CATCHMENTOUTPUTSMGR_HPP
+
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// For utils::time_marker, shared with the nexus managers. (A later refactor can
+// move time_marker to a neutral header when the two hierarchies are unified.)
+#include "NexusOutputsMgr.hpp"
+
+namespace utils
+{
+    /**
+     * Abstract class for managing and writing to catchment data files.
+     *
+     * The set of catchments a manager handles, and their output schema, is fixed at construction
+     * (see the concrete backend's constructor and @ref FeatureDescriptor); this class is the
+     * data sink for that fixed set.
+     */
+    class CatchmentOutputsMgr
+    {
+
+    public:
+        /**
+         * The formulation id used when a caller omits one (the common single-formulation case).
+         *
+         * Carrying a formulation id lets a simulation run independent formulation setups over the
+         * same catchment without their output colliding; backends may organize output by formulation
+         * (e.g. a per-formulation file or subdirectory).
+         */
+        static std::string default_formulation_id() { return "default"; }
+
+        /**
+         * Receive a data entry for a catchment at a given simulation time, specifying the formulation id.
+         *
+         * @param formulation_id The id of the formulation involved in producing this data.
+         * @param catchment_id The id for the catchment to which this data applies.
+         * @param data_time_marker A marker for the current simulation time for the data.
+         * @param values The catchment's output values for this time, positionally aligned with the
+         *        columns the manager was constructed with. Values cross this boundary as typed
+         *        doubles for the backend to serialize as it sees fit -- no string formatting or parsing.
+         */
+        virtual void receive_data_entry(const std::string &formulation_id,
+                                        const std::string &catchment_id,
+                                        const time_marker &data_time_marker,
+                                        const std::vector<double> &values) = 0;
+
+        /**
+         * Receive a data entry for a catchment using the default formulation id.
+         *
+         * @see default_formulation_id
+         */
+        virtual void receive_data_entry(const std::string &catchment_id,
+                                        const time_marker &data_time_marker,
+                                        const std::vector<double> &values) {
+            receive_data_entry(default_formulation_id(), catchment_id, data_time_marker, values);
+        }
+
+        /**
+         * Flush any data buffered since the last commit out to the underlying sink.
+         *
+         * A backend that writes eagerly (relying on its own stream buffering) may do little here
+         * beyond a flush; one that batches writes accumulated entries now. This is an optional mid-run
+         * durability checkpoint -- @ref close performs a final commit regardless.
+         */
+        virtual void commit_writes() = 0;
+
+        /**
+         * Close down this manager: commit everything received, finalize the output, and close files.
+         *
+         * The expected shape is close() == @ref commit_writes (flush all received data) followed by
+         * finalizing and closing the sink, so callers never need a separate commit_writes() before
+         * close(). commit_writes() remains available for mid-run flushes.
+         *
+         * close() is the point at which a commit/finalize failure is reported, so it may throw; call
+         * it explicitly if you need to observe such errors. A backend's destructor should still call
+         * close() as a best-effort backstop, but must never let an exception escape the destructor.
+         *
+         * Once closed, a manager cannot receive new data; subsequent @ref receive_data_entry calls
+         * should throw. close() is idempotent -- calling it on an already-closed instance returns.
+         */
+        virtual void close() = 0;
+
+        /**
+         * A test of whether this instance is closed.
+         *
+         * Mirrors the sibling NexusOutputsMgr interface, where backends use it as a guard against
+         * writing after close; kept here for parity across the two hierarchies.
+         *
+         * @return Whether this instance is closed.
+         * @see close
+         */
+        virtual bool is_closed() = 0;
+
+        virtual ~CatchmentOutputsMgr() = default;
+    };
+
+    /**
+     * One output column: the mapping from a source variable to its output, positionally aligned with
+     * the values a formulation supplies to @ref CatchmentOutputsMgr::receive_data_entry.
+     *
+     * @c source_name is the model's output variable -- where the value comes from; @c output_name is
+     * the name written to the sink (a CSV header, or a variable name in a self-describing format) and
+     * may alias the source. Codifying both lets a backend describe the source->output relationship
+     * (and carry richer per-column metadata in @c attributes, e.g. long_name / coordinates) rather
+     * than only emitting a label. @c units is the column's units, or std::nullopt when the source
+     * reports none -- distinct from a present-but-empty/dimensionless units string. A field states all
+     * three explicitly (there is no defaulted or implicit construction), so units is always a
+     * conscious choice at the point of construction.
+     */
+    struct OutputField
+    {
+        std::string source_name;              //!< the model's output variable -- the value's source
+        std::string output_name;              //!< the name written to the sink; may alias source_name
+        std::optional<std::string> units;     //!< nullopt when the source reports no units
+        std::map<std::string, std::string> attributes;
+
+        //! A column mapping a source variable to a (possibly renamed) output name.
+        OutputField(std::string source_name, std::string output_name,
+                    std::optional<std::string> units,
+                    std::map<std::string, std::string> attributes = {})
+            : source_name(std::move(source_name)), output_name(std::move(output_name)),
+              units(std::move(units)), attributes(std::move(attributes)) {}
+    };
+
+    /**
+     * One feature's output schema, supplied to a manager at construction.
+     *
+     * A backend uses the full set of these to lay out its sink before any data arrives (e.g. open
+     * files and write their headers). One per (formulation, feature).
+     */
+    struct FeatureDescriptor
+    {
+        std::string formulation_id;
+        std::string catchment_id;
+        std::vector<OutputField> fields;   //!< output fields, in the order values are supplied
+
+        FeatureDescriptor(std::string formulation_id,
+                              std::string catchment_id,
+                              std::vector<OutputField> fields)
+            : formulation_id(std::move(formulation_id)),
+              catchment_id(std::move(catchment_id)),
+              fields(std::move(fields)) {}
+
+        //! Register under the default formulation id (single-formulation case).
+        FeatureDescriptor(std::string catchment_id, std::vector<OutputField> fields)
+            : FeatureDescriptor(CatchmentOutputsMgr::default_formulation_id(),
+                                    std::move(catchment_id), std::move(fields)) {}
+    };
+} // utils
+
+#endif //NGEN_CATCHMENTOUTPUTSMGR_HPP

--- a/include/utilities/output/PerNexusCsvOutputMgr.hpp
+++ b/include/utilities/output/PerNexusCsvOutputMgr.hpp
@@ -36,7 +36,10 @@ namespace utils
          * Construct instance set for managing/writing nexus data files.
          *
          * @param nexus_ids Nexus ids for which this instance manages data (in particular, local nexuses when using MPI).
-         * @param output_root The output root for written files (as a string).
+         * @param output_root The effective output directory for written files. The caller folds in any
+         *        per-rank subdirectory (e.g. via @c realization::config::rank_output_root), so this is
+         *        the final directory; it is created here if it does not already exist. Mirrors how the
+         *        catchment CSV manager takes an already-resolved root.
          */
         PerNexusCsvOutputMgr(const std::vector<std::string>& nexus_ids, const std::string &output_root);
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -523,6 +523,13 @@ int main(int argc, char* argv[]) {
     nexus_collection.reset();
 
     std::shared_ptr<utils::NexusOutputsMgr> nexus_outputs_mgr;
+    const auto& nexus_output = manager->get_output_config().nexus;
+    // Routing consumes nexus output, so a routing run with nexus output disabled cannot work.
+    if (manager->get_using_routing() && !nexus_output.enable) {
+        throw std::runtime_error(
+            "Routing is enabled but nexus output is disabled (output.nexus.enable = false); "
+            "the routing run has no nexus output to consume.");
+    }
     #if NGEN_WITH_MPI
     std::vector<std::string> nexus_ids;
     std::copy_if(features.nexuses().begin(), features.nexuses().end(), std::back_inserter(nexus_ids),
@@ -535,7 +542,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::string> nexus_ids(features.nexuses().begin(), features.nexuses().end());
     #endif
 
-    if (manager->get_output_config().nexus.format == realization::config::OutputFormat::netcdf) {
+    if (nexus_output.enable && nexus_output.format == realization::config::OutputFormat::netcdf) {
         // TODO: (later) use nullptr for now, until full support for multiple formulations per catchment is available
         std::shared_ptr<std::vector<std::string>> formulation_ids = nullptr;
 
@@ -572,11 +579,15 @@ int main(int argc, char* argv[]) {
 
         #endif
     }
-    else {
-        // CSV nexus output: one file per nexus.
-        nexus_outputs_mgr = std::make_shared<utils::PerNexusCsvOutputMgr>(
-            nexus_ids, manager->get_output_config().root);
+    else if (nexus_output.enable && nexus_output.format == realization::config::OutputFormat::csv) {
+        // CSV nexus output: one file per nexus. Under MPI, when the domain sets rank_subdir, each
+        // rank's files go in a rank_<N>/ subdirectory to cut filesystem contention from many ranks
+        // sharing a directory. Resolved once into the root here (same helper as catchment output).
+        const std::string nexus_root = realization::config::rank_output_root(
+            manager->get_output_config().root, nexus_output, mpi_rank, mpi_num_procs);
+        nexus_outputs_mgr = std::make_shared<utils::PerNexusCsvOutputMgr>(nexus_ids, nexus_root);
     }
+    // else: nexus output disabled -- nexus_outputs_mgr stays null.
 
     std::cout<<"Running Models"<<std::endl;
 
@@ -669,7 +680,9 @@ int main(int argc, char* argv[]) {
 
     // Close output file(s). close() flushes and commits everything received, so no separate
     // end-of-run commit_writes() is needed (writes buffer normally during the run).
-    nexus_outputs_mgr->close();
+    if (nexus_outputs_mgr) {
+        nexus_outputs_mgr->close();
+    }
     if (catchment_outputs_mgr) {
         catchment_outputs_mgr->close();
     }

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -55,6 +55,8 @@
 #include <DomainLayer.hpp>
 #include "utilities/output/NexusOutputsMgr.hpp"
 #include "utilities/output/PerNexusCsvOutputMgr.hpp"
+#include "utilities/output/CatchmentOutputsMgr.hpp"
+#include "realizations/config/catchment_output.hpp"
 #if NGEN_WITH_NETCDF
 #include "utilities/output/PerFormulationNexusOutputMgr.hpp"
 #endif
@@ -461,6 +463,45 @@ int main(int argc, char* argv[]) {
 
     //validate dendritic connections
     features.validate_dendritic();
+
+    // Build the catchment output manager now that the features (and their formulations) exist: gather
+    // every catchment's output columns, then construct the manager with the full set up front. 
+    // Under MPI each rank's files go in a rank_<N>/ subdirectory when the domain requests it,
+    // or always for per_formulation (so ranks never share a file) -- resolved once into the root here.
+    std::shared_ptr<utils::CatchmentOutputsMgr> catchment_outputs_mgr;
+    std::shared_ptr<utils::CatchmentOutputsMgr> domain_outputs_mgr;
+    const auto& catchment_output = manager->get_output_config().catchment;
+    if (catchment_output.enable) {
+        std::vector<utils::FeatureDescriptor> descriptors;
+        for (const auto& id : features.catchments()) {
+            descriptors.emplace_back(id, manager->get_formulation(id)->get_output_fields());
+        }
+        realization::config::Output cat_config = manager->get_output_config();
+        cat_config.root = realization::config::rank_output_root(
+            cat_config.root, cat_config.catchment, mpi_rank, mpi_num_procs);
+        catchment_outputs_mgr = realization::config::make_catchment_output_mgr(
+            cat_config, std::move(descriptors));
+    }
+
+    //A domain formulation is domain-wide and runs
+    // identically on every rank, so writing it once here avoids N redundant per-rank copies; the root
+    // is not rank-scoped (single writer). Each domain layer is its own feature
+    // ("layer_<id>", layer name), landing under "<root>/layer_<id>/".
+    if (catchment_output.enable && mpi_rank == 0) {
+        std::vector<utils::FeatureDescriptor> descriptors;
+        auto& layer_meta = manager->get_layer_metadata();
+        for (int layer_key : layer_meta.get_keys()) {
+            if (manager->has_domain_formulation(layer_key)) {
+                const auto& layer_desc = layer_meta.get_layer(layer_key);
+                descriptors.emplace_back("layer_" + std::to_string(layer_desc.id), layer_desc.name,
+                                         manager->get_domain_formulation(layer_key)->get_output_fields());
+            }
+        }
+        if (!descriptors.empty()) {
+            domain_outputs_mgr = realization::config::make_catchment_output_mgr(
+                manager->get_output_config(), std::move(descriptors));
+        }
+    }
     // TODO don't really need catchment_collection once catchments are added to nexus collection
     // Still using  catchments for geometry at the moment, fix this later
     // catchment_collection.reset();
@@ -494,7 +535,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::string> nexus_ids(features.nexuses().begin(), features.nexuses().end());
     #endif
 
-    if (manager->is_using_per_formulation_nexus_files()) {
+    if (manager->get_output_config().nexus.format == realization::config::OutputFormat::netcdf) {
         // TODO: (later) use nullptr for now, until full support for multiple formulations per catchment is available
         std::shared_ptr<std::vector<std::string>> formulation_ids = nullptr;
 
@@ -515,7 +556,7 @@ int main(int argc, char* argv[]) {
         MPI_Bcast(&total_nexus_count, 1, MPI_INT, mpi_num_procs - 1, MPI_COMM_WORLD);
 
         #if NGEN_WITH_NETCDF
-        nexus_outputs_mgr = std::make_shared<utils::PerFormulationNexusOutputMgr>(nexus_ids, formulation_ids, manager->get_output_root(), timesteps, mpi_rank, local_nexus_write_offset, mpi_num_procs, total_nexus_count);
+        nexus_outputs_mgr = std::make_shared<utils::PerFormulationNexusOutputMgr>(nexus_ids, formulation_ids, manager->get_output_config().root, timesteps, mpi_rank, local_nexus_write_offset, mpi_num_procs, total_nexus_count);
         #else
         throw std::runtime_error("NetCDF support required to use per-formulation nexus files.");
         #endif
@@ -524,7 +565,7 @@ int main(int argc, char* argv[]) {
         MPI_Barrier(MPI_COMM_WORLD);
         #else
         #if NGEN_WITH_NETCDF
-        nexus_outputs_mgr = std::make_shared<utils::PerFormulationNexusOutputMgr>(nexus_ids, formulation_ids, manager->get_output_root(), timesteps);
+        nexus_outputs_mgr = std::make_shared<utils::PerFormulationNexusOutputMgr>(nexus_ids, formulation_ids, manager->get_output_config().root, timesteps);
         #else
         throw std::runtime_error("NetCDF support required to use per-formulation nexus files.");
         #endif
@@ -532,7 +573,9 @@ int main(int argc, char* argv[]) {
         #endif
     }
     else {
-        nexus_outputs_mgr = std::make_shared<utils::PerNexusCsvOutputMgr>(nexus_ids, manager->get_output_root());
+        // CSV nexus output: one file per nexus.
+        nexus_outputs_mgr = std::make_shared<utils::PerNexusCsvOutputMgr>(
+            nexus_ids, manager->get_output_config().root);
     }
 
     std::cout<<"Running Models"<<std::endl;
@@ -570,7 +613,8 @@ int main(int argc, char* argv[]) {
             // create a domain wide layer
             auto formulation = manager->get_domain_formulation(keys[i]);
             layers[i] =
-                std::make_shared<ngen::DomainLayer>(desc, layer_sim_time, features, 0, formulation);
+                std::make_shared<ngen::DomainLayer>(desc, layer_sim_time, features, 0, formulation,
+                                                    domain_outputs_mgr);
         } else {
             for (std::string id : features.catchments(keys[i])) {
                 cat_ids.push_back(id);
@@ -582,7 +626,8 @@ int main(int argc, char* argv[]) {
                     layer_sim_time,
                     features,
                     catchment_collection,
-                    0
+                    0,
+                    catchment_outputs_mgr
                 );
             } else {
                 layers[i] = std::make_shared<ngen::SurfaceLayer>(
@@ -592,7 +637,8 @@ int main(int argc, char* argv[]) {
                     features,
                     catchment_collection,
                     0,
-                    nexus_outputs_mgr
+                    nexus_outputs_mgr,
+                    catchment_outputs_mgr
                 );
             }
         }
@@ -621,8 +667,15 @@ int main(int argc, char* argv[]) {
 
     simulation->run_catchments();
 
-    // Close nexus output file(s)
+    // Close output file(s). close() flushes and commits everything received, so no separate
+    // end-of-run commit_writes() is needed (writes buffer normally during the run).
     nexus_outputs_mgr->close();
+    if (catchment_outputs_mgr) {
+        catchment_outputs_mgr->close();
+    }
+    if (domain_outputs_mgr) {
+        domain_outputs_mgr->close();
+    }
 
 #if NGEN_WITH_MPI
     MPI_Barrier(MPI_COMM_WORLD);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,6 +22,13 @@ target_include_directories(core PUBLIC
         ${PROJECT_SOURCE_DIR}/include/bmi
         )
 
+# Layer.cpp routes through the abstract CatchmentOutputsMgr interface (header-only), so core needs
+# the output headers on its include path -- but must NOT link ngen_output. Linking it would pull the
+# concrete managers (and their NetCDF/MPI dependencies) into every core consumer, including the
+# routing tests. PRIVATE keeps this to core's own translation units; Layer.hpp only forward-declares
+# the type, and consumers that use the concrete backends link NGen::output directly.
+target_include_directories(core PRIVATE ${PROJECT_SOURCE_DIR}/include/utilities/output)
+
 if (NGEN_WITH_PYTHON)
     target_link_libraries(core PUBLIC NGen::python)
 endif ()

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -34,16 +34,6 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
 
-          if (!formulations->is_disable_catchment_output()) {
-            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
-          } else {
-            // Route to the null sink so disabled catchment output is discarded, not dumped to stdout
-            formulation->set_output_stream("");
-          }
-
-          // TODO: add command line or config option to have this be omitted
-          //FIXME why isn't default param working here??? get_output_header_line() fails.
-          formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
           //Find upstream nexus ids
           origins = network.get_origination_ids(feat_id);
 

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -39,20 +39,7 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          if (!formulations->is_disable_catchment_output())
-          {
-            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
-          }
-          else
-          {
-            // Route to the null sink so disabled catchment output is discarded, not dumped to stdout
-            formulation->set_output_stream("");
-          }
 
-          // TODO: add command line or config option to have this be omitted
-          //FIXME why isn't default param working here??? get_output_header_line() fails.
-          formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
-          
           // get the catchment layer from the hydro fabric
           const auto& cat_json_node = linked_hydro_fabric->get_feature(feat_id);
           long lyr = cat_json_node->has_key("layer") ? cat_json_node->get_property("layer").as_natural_number() : 0;

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -1,11 +1,16 @@
 #include <Layer.hpp>
 #include <Catchment_Formulation.hpp>
+#include <CatchmentOutputsMgr.hpp>
 
 #if NGEN_WITH_MPI
 #include "HY_Features_MPI.hpp"
 #else
 #include "HY_Features.hpp"
 #endif
+
+// Out-of-line so the shared_ptr members are destroyed where their (possibly forward-declared) types
+// are complete.
+ngen::Layer::~Layer() = default;
 
 void ngen::Layer::update_models(boost::span<double> catchment_outflows,
                                 std::unordered_map<std::string, int> &catchment_indexes,
@@ -19,6 +24,11 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
     //std::cout<<"Output Time Index: "<<output_time_index<<std::endl;
     if(output_time_index%1000 == 0) std::cout<<"Running timestep " << output_time_index <<std::endl;
     std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
+    // Catchment output (if enabled) is pushed to this layer's output manager, which owns the
+    // sinks and decides formatting/aggregation. Build the time marker once for all catchments
+    // in this timestep (mirrors SurfaceLayer).
+    utils::time_marker current_time_marker(
+        output_time_index, simulation_time.get_current_epoch_time(), current_timestamp);
     for(const auto& id : processing_units) {
         int sub_time = output_time_index;
         //std::cout<<"Running cat "<<id<<std::endl;
@@ -50,9 +60,10 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
         // XXX: This is currently accumulating in meters of depth, which may not be desirable
         catchment_outflows[results_index] += response;
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
-        std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
-            r_c->get_output_line_for_timestep(output_time_index)+"\n";
-        r_c->write_output(output);
+        if (catchment_output_mgr) {
+            catchment_output_mgr->receive_data_entry(
+                id, current_time_marker, r_c->get_output_values_for_timestep(output_time_index));
+        }
         //TODO put this somewhere else.  For now, just trying to ensure we get m^3/s into nexus output
         double area;
         try {

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -71,9 +71,13 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
 
         // TODO: (later) eventually may want to use this form, if we support multiple formulations per catchment
         //nexus_outputs_mgr->receive_data_entry(form_id, id, current_time_index, current_timestamp, contribution_at_t);
-        nexus_outputs_mgr->receive_data_entry(id, current_time_marker, contribution_at_t);
+        if (nexus_outputs_mgr) {
+            nexus_outputs_mgr->receive_data_entry(id, current_time_marker, contribution_at_t);
+        }
 
         //std::cout<<"\tNexus "<<id<<" has "<<contribution_at_t<<" m^3/s"<<std::endl;
     } //done nexuses
-    nexus_outputs_mgr->commit_writes();
+    if (nexus_outputs_mgr) {
+        nexus_outputs_mgr->commit_writes();
+    }
 }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -16,27 +16,28 @@ namespace realization {
             return available_forcings;
         }
 
-        std::string Bmi_Module_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
+        std::vector<double> Bmi_Module_Formulation::get_output_values_for_timestep(int timestep) {
             // TODO: something must be added to store values if more than the current time step is wanted
             // TODO: if such a thing is added, it should probably be configurable to turn it off
             if (timestep != (next_time_step_index - 1)) {
                 throw std::invalid_argument("Only current time step valid when getting output for BMI C++ formulation");
             }
-
             static bool no_conversion_message_logged = false;
             if (!no_conversion_message_logged) {
                 no_conversion_message_logged = true;
                 logging::warning("Output variables do not have unit conversion. Capability not yet implemented in ngen.");
             }
 
-            std::string output_str;
-            for (const std::string& name : get_output_variable_names()) {
-                // Placeholder to request no conversion
+            auto const & names = get_output_variable_names();
+            std::vector<double> values;
+            values.reserve(names.size());
+            // Fetch values through the unit-checked/converting get_value path; output_units is empty,
+            // so values are returned unconverted, positionally aligned with the names.
+            for (const std::string& name : names) {
                 std::string output_units = "";
-                double value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN);
-                output_str += (output_str.empty() ? "" : ",") + std::to_string(value);
+                values.push_back(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN));
             }
-            return output_str;
+            return values;
         }
 
         void Bmi_Module_Formulation::update(time_step_t t_index, time_step_t t_delta) {
@@ -381,7 +382,9 @@ namespace realization {
                 set_output_variable_names(get_bmi_model()->GetOutputVarNames());
             }
 
-            // Output header fields, if present
+            // Output header fields, if present. These label the output columns and must be 1:1 with
+            // the output variables (header i names variable i); on a count mismatch, warn and fall
+            // back to the variable names so the two stay positionally aligned.
             auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
             if (out_headers_it != properties.end()) {
                 std::vector<geojson::JSONProperty> out_headers_json_list = out_headers_it->second.as_list();
@@ -389,7 +392,15 @@ namespace realization {
                 for (int i = 0; i < out_headers_json_list.size(); ++i) {
                     out_headers[i] = out_headers_json_list[i].as_string();
                 }
-                set_output_header_fields(out_headers);
+                if (get_output_variable_names().size() == out_headers.size()) {
+                    set_output_header_fields(out_headers);
+                }
+                else {
+                    std::cerr << "WARN: configured output headers have " << out_headers.size()
+                              << " fields, but there are " << get_output_variable_names().size()
+                              << " output variables" << std::endl;
+                    set_output_header_fields(get_output_variable_names());
+                }
             }
             else {
                 set_output_header_fields(get_output_variable_names());

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -287,7 +287,54 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
     return output_var_name;
 }
 
-std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
+std::vector<utils::OutputField> Bmi_Multi_Formulation::get_output_fields() const {
+    // Index the submodules' own output fields by source variable. Each submodule already describes
+    // each variable it produces as a complete OutputField (source name, units, and any attributes),
+    // so this is one lookup covering every variable any submodule can produce.
+    std::unordered_map<std::string, utils::OutputField> field_by_source;
+    for (const auto &module : modules) {
+        for (const auto &field : module->get_output_fields()) {
+            field_by_source.emplace(field.source_name, field);
+        }
+    }
+
+    // Emit this formulation's selected outputs, in its configured order. The multi selects a subset
+    // of the submodules' variables (output_variable_names) and gives them its own output names
+    // (output_header_fields, 1:1 with the variables, enforced at construction). For each, reuse the
+    // producing submodule's field -- keeping its units and metadata -- but relabel output_name with
+    // this formulation's header, which may alias differently than the submodule's. A selected
+    // variable that no submodule produces yields a bare field with no units.
+    const std::vector<std::string> &variables = get_output_variable_names();
+    boost::span<const std::string> headers = get_output_header_field_names();
+    std::vector<utils::OutputField> fields;
+    fields.reserve(variables.size());
+    for (std::size_t i = 0; i < variables.size(); ++i) {
+        const auto it = field_by_source.find(variables[i]);
+        if (it != field_by_source.end()) {
+            // Reuse the producing submodule's field (its units and metadata), relabeled with this
+            // formulation's output name.
+            fields.push_back(it->second);
+            fields.back().output_name = headers[i];
+        }
+        else {
+            // Reached when a configured output variable is valid (check_output_var_names verified it
+            // is in availableData at construction) but is not produced by any submodule -- most
+            // commonly a forcing variable echoed to output. Such a variable is supplied by a non-
+            // submodule provider (e.g. the forcing provider), which is not indexed in
+            // field_by_source, so we have no units for it here: the DataProvider interface exposes
+            // values (get_value/get_values) but not a variable's native units. We therefore emit the
+            // column with no units (nullopt) rather than dropping it -- the variable still produces a
+            // value each timestep via get_output_values_for_timestep, and get_output_fields must stay
+            // 1:1 with those values or the header and data rows misalign.
+            // TODO: source units for provider-supplied (e.g. forcing) output variables once the
+            // provider interface can report them.
+            fields.emplace_back(variables[i], headers[i], std::nullopt);
+        }
+    }
+    return fields;
+}
+
+std::vector<double> Bmi_Multi_Formulation::get_output_values_for_timestep(int timestep) {
     // TODO: have to do some figuring out to make sure this isn't ambiguous (i.e., same output var name from two modules)
     // TODO: need to verify that output variable names are valid, or else warn and return default
 
@@ -299,20 +346,23 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
 
     // Start by first checking whether we are NOT just using the last module's values
     if (!is_out_vars_from_last_mod) {
-        std::string output_str;
+        // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
+        const std::vector<std::string> &output_var_names = get_output_variable_names();
+        std::vector<double> values;
+        values.reserve(output_var_names.size());
+        // Fetch values through the unit-checked/converting get_value path; output_units is empty, so
+        // values are returned unconverted, positionally aligned with the names.
         time_t model_time = convert_model_time(get_model_current_time()) + get_bmi_model_start_time_forcing_offset_s();
-        for (const std::string& name : get_output_variable_names()) {
-            // Placeholder to request no conversion
+        for (const std::string &name : output_var_names) {
             std::string output_units = "";
-            double value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, model_time, 3600, output_units), MEAN);
-            output_str += (output_str.empty() ? "" : ",") + std::to_string(value);
+            values.push_back(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, model_time, 3600, output_units), MEAN));
         }
-        return output_str;
+        return values;
     }
     // Otherwise, use the default behavior, which means we either
     //   - were originally set to use the default of getting the output of the last module
     //   - tried a more complex config, but ran into an error, and are needing to revert to the default
-    return modules.back()->get_output_line_for_timestep(timestep, delimiter);
+    return modules.back()->get_output_values_for_timestep(timestep);
 }
 
 void Bmi_Multi_Formulation::update(time_step_t t_index, time_step_t t_delta) {

--- a/src/realizations/catchment/Catchment_Formulation.cpp
+++ b/src/realizations/catchment/Catchment_Formulation.cpp
@@ -47,10 +47,6 @@ namespace realization {
         }
     }
 
-    std::string Catchment_Formulation::get_output_header_line(std::string delimiter) const {
-        return "Total Discharge";
-    }
-
     void Catchment_Formulation::finalize()
     {
         if (forcing) {

--- a/src/utilities/output/CMakeLists.txt
+++ b/src/utilities/output/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(ngen_output
         PerNexusCsvOutputMgr.cpp
+        CatchmentCsvOutputMgr.cpp
 )
 add_library(NGen::output ALIAS ngen_output)
 

--- a/src/utilities/output/CatchmentCsvOutputMgr.cpp
+++ b/src/utilities/output/CatchmentCsvOutputMgr.cpp
@@ -1,0 +1,190 @@
+/*
+Copyright (C) 2026 Lynker
+------------------------------------------------------------------------
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+------------------------------------------------------------------------
+*/
+
+#include "CatchmentCsvOutputMgr.hpp"
+
+#include <cstddef>
+#include <iomanip>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+using utils::CatchmentCsvOutputMgr;
+
+namespace {
+    static constexpr std::string_view DELIMITER = ",";
+
+    //! Join the column output names with commas for a CSV header. CSV writes only each column's
+    //! output_name; the source_name, units, and other OutputField metadata are not emitted here.
+    std::string join_columns(const std::vector<utils::OutputField> &columns)
+    {
+        std::string out;
+        for (const auto &c : columns) {
+            out += (out.empty() ? "" : DELIMITER);
+            out += c.output_name;
+        }
+        return out;
+    }
+
+    //! Build the CSV header line. When include_id is true a leading "catchment_id"
+    //! column is prepended (aggregated output, where one file holds many catchments);
+    //! otherwise the layout is the long-standing "Time Step,Time,<vars>". The column
+    //! order is kept identical to catchment_output_data_row so header and data rows
+    //! always agree.
+    std::string catchment_output_header_line(bool include_id,
+                                             const std::string_view variable_header,
+                                             const std::string_view delimiter = DELIMITER)
+    {
+        std::string line;
+        if (include_id) {
+            line += "catchment_id";
+            line += delimiter;
+        }
+        line += "Time Step";
+        line += delimiter;
+        line += "Time";
+        line += delimiter;
+        line += variable_header;
+        return line;
+    }
+
+}
+
+CatchmentCsvOutputMgr::CatchmentCsvOutputMgr(std::string output_root, std::optional<std::string> aggregated_filename,
+                                             int precision, std::vector<FeatureDescriptor> features)
+    : output_root_(std::move(output_root))
+    , aggregated_filename_(std::move(aggregated_filename))
+    , precision_(precision)
+{
+    // The full set of catchments is known up front, so open every file and write its header now;
+    // the manager is ready to receive data immediately after construction.
+    for (const auto &feature : features) {
+        add_feature(feature);
+    }
+}
+
+CatchmentCsvOutputMgr::~CatchmentCsvOutputMgr()
+{
+    // Best-effort backstop for callers who don't close() explicitly. close() is the path that
+    // surfaces commit/finalize errors; a destructor must never let one escape (here it cannot, but
+    // the guard sets the pattern for backends whose commit can fail).
+    try {
+        close();
+    } catch (...) {
+        // nothing actionable during destruction
+    }
+}
+
+std::filesystem::path CatchmentCsvOutputMgr::output_path(const std::string &formulation_id, const std::string &catchment_id)
+{
+    // Aggregated output shares one file per formulation (the catchment id becomes a column);
+    // per-feature output uses one file per catchment. Either way the default formulation keeps the
+    // flat layout and any other formulation id gets its own subdirectory, so independent setups --
+    // and, when aggregating, each formulation's uniform column set -- never collide.
+    const std::string filename = aggregated_filename_ ? *aggregated_filename_ : catchment_id + ".csv";
+    if (formulation_id == default_formulation_id()) {
+        return output_root_ + filename;
+    }
+    return output_root_ + formulation_id + "/" + filename;
+}
+
+std::ofstream* CatchmentCsvOutputMgr::stream_for(const std::string &formulation_id, const std::string &catchment_id)
+{
+    const auto it = streams_.find(output_path(formulation_id, catchment_id));
+    return it == streams_.end() ? nullptr : it->second.get();
+}
+
+void CatchmentCsvOutputMgr::add_feature(const FeatureDescriptor &feature)
+{
+    const auto path = output_path(feature.formulation_id, feature.catchment_id);
+    // When aggregating, several catchments of one formulation resolve to the same file: the first
+    // opens it and writes the header, the rest share the already-open stream. Per-feature paths are
+    // unique. Opening a file and writing its header therefore happen together, exactly once per file.
+    if (streams_.find(path) != streams_.end()) {
+        return;
+    }
+    // output_path owns the layout; derive the directory from it so the two can't drift.
+    if (const auto dir = path.parent_path(); !dir.empty()) {
+        std::filesystem::create_directories(dir);
+    }
+    auto stream = std::make_shared<std::ofstream>();
+    stream->open(path, std::ios::trunc);
+    // Aggregated files carry a leading catchment_id column; per-feature files do not.
+    (*stream) << catchment_output_header_line(aggregated_filename_.has_value(), join_columns(feature.fields)) << "\n";
+    (*stream) << std::setprecision(precision_);
+    streams_[path] = std::move(stream);
+}
+
+void CatchmentCsvOutputMgr::receive_data_entry(const std::string &formulation_id, const std::string &catchment_id,
+                                               const time_marker &data_time_marker, const std::vector<double> &values)
+{
+    if (closed_) {
+        throw std::runtime_error("Can't receive data on a closed CatchmentCsvOutputMgr");
+    }
+
+    std::ofstream* out = stream_for(formulation_id, catchment_id);
+    if (out == nullptr) {
+        throw std::runtime_error("CatchmentCsvOutputMgr received data for an unknown catchment '" + catchment_id + "'");
+    }
+    // In aggregated output each row carries the (full) catchment id so rows stay attributable.
+    if( aggregated_filename_.has_value() ) {
+        (*out) << catchment_id << DELIMITER;
+    }
+    // Add time step/timestamp
+    (*out) << data_time_marker.sim_time_index << DELIMITER
+           << data_time_marker.time_stamp;
+    // Add values, precision set on the stream at construction.
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        (*out) << DELIMITER;
+        (*out) << values[i];
+    }
+    // Use \n so we don't force a flush
+    (*out) << "\n";
+}
+
+void CatchmentCsvOutputMgr::commit_writes()
+{
+    // Rows are written immediately on receipt; just flush what is buffered.
+    if (closed_) {
+        return;
+    }
+    for (auto &entry : streams_) {
+        entry.second->flush();
+    }
+}
+
+void CatchmentCsvOutputMgr::close()
+{
+    if (closed_) {
+        return;
+    }
+    // close() == commit + finalize: flush everything received, then close the files. Committing via
+    // commit_writes() (rather than relying on ofstream::close to flush) makes the "close commits"
+    // contract explicit and sets the shape for backends whose finalize differs from their flush.
+    commit_writes();
+    for (auto &entry : streams_) {
+        if (entry.second->is_open()) {
+            entry.second->close();
+        }
+    }
+    closed_ = true;
+}
+
+bool CatchmentCsvOutputMgr::is_closed()
+{
+    return closed_;
+}

--- a/src/utilities/output/PerFormulationNexusOutputMgr.cpp
+++ b/src/utilities/output/PerFormulationNexusOutputMgr.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 
 #if NGEN_WITH_MPI && !NGEN_WITH_PARALLEL_NETCDF
 #include "utilities/parallel_utils.h"
@@ -82,6 +83,13 @@ utils::PerFormulationNexusOutputMgr::PerFormulationNexusOutputMgr(
     }
 
     nexus_outfile = output_root + "/formulation_" + this->formulation_id + "_nexuses.nc";
+
+    // Ensure the output directory exists before creating files in it. Like the sibling output
+    // managers, this class owns creating what it writes into -- config parsing only normalizes the
+    // root and no caller is required to pre-create it.
+    if (!output_root.empty()) {
+        std::filesystem::create_directories(output_root);
+    }
 
     // To support unit testing when not running via MPI, but when MPI and parallel netcdf are compiled in, we
     // have to detect things.

--- a/src/utilities/output/PerNexusCsvOutputMgr.cpp
+++ b/src/utilities/output/PerNexusCsvOutputMgr.cpp
@@ -18,8 +18,16 @@ limitations under the License.
 
 #include "PerNexusCsvOutputMgr.hpp"
 
+#include <filesystem>
+#include <stdexcept>
+
 utils::PerNexusCsvOutputMgr::PerNexusCsvOutputMgr(const std::vector<std::string>& nexus_ids,
                                                   const std::string& output_root) {
+    // output_root is the effective directory this manager writes to;
+    // ensure it exists, then open one file per nexus directly in it.
+    if (!output_root.empty()) {
+        std::filesystem::create_directories(output_root);
+    }
     for(const auto& id : nexus_ids) {
         nexus_outfiles[id].open(output_root + id + "_output.csv", std::ios::trunc);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -370,6 +370,7 @@ ngen_add_test(
         bmi/Bmi_Cpp_Adapter_Test.cpp
         realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
     LIBRARIES
+        gmock
         NGen::core
         NGen::realizations_catchment
         NGen::core_mediator
@@ -405,6 +406,7 @@ ngen_add_test(
         bmi/Bmi_Fortran_Adapter_Test.cpp
         realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
     LIBRARIES
+        gmock
         NGen::core
         NGen::realizations_catchment
         NGen::core_mediator
@@ -424,6 +426,7 @@ ngen_add_test(
         realizations/catchments/Bmi_Py_Formulation_Test.cpp
         utils/python/InterpreterUtil_Test.cpp
     LIBRARIES
+        gmock
         NGen::core
         NGen::realizations_catchment
         NGen::core_mediator
@@ -440,6 +443,7 @@ ngen_add_test(
         realizations/catchments/Bmi_Multi_Formulation_Test.cpp
         realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
     LIBRARIES
+        gmock
         NGen::core
         NGen::realizations_catchment
         NGen::core_mediator

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -265,6 +265,15 @@ ngen_add_test(
         NGen::core_nexus
 )
 
+########################## Nexus CSV Output Manager Tests
+ngen_add_test(
+    test_nexus_output
+    OBJECTS
+        utilities/output/PerNexusCsvOutputMgr_Test.cpp
+    LIBRARIES
+        NGen::output
+)
+
 ########################## Catchment CSV Output Manager Tests
 ngen_add_test(
     test_catchment_output_mgr

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -168,6 +168,7 @@ ngen_add_test(
     test_realization_config
     OBJECTS
         realizations/Formulation_Manager_Test.cpp
+        realizations/config/Output_Test.cpp
     LIBRARIES
         NGen::core
         NGen::realizations_catchment

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -262,6 +262,15 @@ ngen_add_test(
         NGen::core_nexus
 )
 
+########################## Catchment CSV Output Manager Tests
+ngen_add_test(
+    test_catchment_output_mgr
+    OBJECTS
+        utilities/output/CatchmentCsvOutputMgr_Test.cpp
+    LIBRARIES
+        NGen::output
+)
+
 ########################## MPI Remote Nexus Tests
 ngen_add_test(
     test_remote_nexus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,12 +169,14 @@ ngen_add_test(
     OBJECTS
         realizations/Formulation_Manager_Test.cpp
         realizations/config/Output_Test.cpp
+        realizations/config/CatchmentOutput_Test.cpp
     LIBRARIES
         NGen::core
         NGen::realizations_catchment
         NGen::core_mediator
         NGen::forcing
         NGen::ngen_bmi
+        NGen::output
     DEPENDS
         testbmicppmodel
 )

--- a/test/realizations/Formulation_Manager_Test.cpp
+++ b/test/realizations/Formulation_Manager_Test.cpp
@@ -11,9 +11,12 @@
 #include <features/Features.hpp>
 #include <JSONGeometry.hpp>
 #include <JSONProperty.hpp>
+#include <HY_Features.hpp>
+#include "realizations/config/catchment_output.hpp"
 
 #include <iostream>
 #include <memory>
+#include <filesystem>
 
 #include <iostream>
 
@@ -913,7 +916,7 @@ TEST_F(Formulation_Manager_Test, basic_reading_1) {
 
     ASSERT_TRUE(manager.contains("cat-52"));
     ASSERT_TRUE(manager.contains("cat-67"));
-    ASSERT_EQ(manager.get_output_root(), "./");
+    ASSERT_EQ(manager.get_output_config().root, "./");
 }
 
 TEST_F(Formulation_Manager_Test, basic_reading_2) {
@@ -946,7 +949,129 @@ TEST_F(Formulation_Manager_Test, basic_reading_2) {
 
     ASSERT_TRUE(manager.contains("cat-52"));
     ASSERT_TRUE(manager.contains("cat-67"));
-    ASSERT_EQ(manager.get_output_root(), "./output_dir/");
+    ASSERT_EQ(manager.get_output_config().root, "./output_dir/");
+}
+
+namespace {
+    realization::Formulation_Manager manager_from_json(const std::string& json) {
+        boost::property_tree::ptree tree;
+        std::stringstream ss(json);
+        boost::property_tree::json_parser::read_json(ss, tree);
+        return realization::Formulation_Manager(tree);
+    }
+}
+
+// Output config parsing (grouping / enable / root / legacy keys) is covered by Output_Test, and
+// the factory's config->mode selection by CatchmentOutput_Test. What remains genuinely FM's is that
+// it parses the output config at construction and validates it against build support:
+
+// netcdf nexus output maps to per-formulation files when supported, and is
+// rejected at construction when NGEN was built without NetCDF.
+TEST_F(Formulation_Manager_Test, nexus_netcdf_format_respects_build_support)
+{
+    const std::string json = R"({ "output": { "nexus": { "format": "netcdf" } } })";
+#if NGEN_WITH_NETCDF
+    auto manager = manager_from_json(json);
+    EXPECT_EQ(manager.get_output_config().nexus.format, realization::config::OutputFormat::netcdf);
+#else
+    EXPECT_THROW(manager_from_json(json), std::runtime_error);
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Integration: a real (BMI C++) formulation built by Formulation_Manager feeds the catchment
+// output manager the driver builds via the factory. This is the one place the full composition
+// (Formulation_Manager -> formulation -> factory -> manager -> file) is exercised end to end; the
+// factory's mode selection lives in CatchmentOutput_Test and the CSV layout in
+// CatchmentCsvOutputMgr_Test. A mocked (programmatic) hydrofabric avoids on-disk geojson data; the
+// manager is scoped so its streams flush/close before the file is read.
+// ---------------------------------------------------------------------------
+
+namespace {
+    const std::string MOCK_LINK_KEY = "toid";
+
+    // Catchment-only collection (each draining to nexus_id), as manager.read()
+    // expects -- read() builds a formulation for every feature it is given.
+    geojson::GeoJSON build_catchments(const std::vector<std::string>& catchment_ids,
+                                      const std::string& nexus_id)
+    {
+        geojson::three_dimensional_coordinates coords{
+            {{1.0,2.0},{3.0,4.0},{5.0,6.0}}, {{7.0,8.0},{9.0,10.0},{11.0,12.0}}
+        };
+        auto fabric = std::make_shared<geojson::FeatureCollection>();
+        for (const auto& id : catchment_ids) {
+            geojson::PropertyMap props{ {MOCK_LINK_KEY, geojson::JSONProperty(MOCK_LINK_KEY, nexus_id)} };
+            fabric->add_feature(std::make_shared<geojson::PolygonFeature>(
+                geojson::PolygonFeature(geojson::polygon(coords), id, props)));
+        }
+        return fabric;
+    }
+
+    std::vector<std::string> read_lines(const std::string& path) {
+        std::vector<std::string> lines;
+        std::ifstream f(path);
+        std::string line;
+        while (std::getline(f, line)) lines.push_back(line);
+        return lines;
+    }
+
+    // A global test-BMI-C++ realization config with an output block, driven
+    // through fix_paths() by the caller.
+    std::string bmi_cpp_output_config(const std::string& output_root, const std::string& catchment_grouping) {
+        return std::string("{ ")
+          + "\"global\": { \"formulations\": [ { \"name\":\"bmi_c++\", \"params\": {"
+          +   "\"model_type_name\": \"test_bmi_cpp\","
+          +   "\"library_file\": \"{{EXTERN_LIB_DIR_PATH}}" BMI_TEST_CPP_LIB_NAME "\","
+          +   "\"init_config\": \"{{BMI_C_INIT_DIR_PATH}}/test_bmi_c_config_0.txt\","
+          +   "\"main_output_variable\": \"OUTPUT_VAR_2\","
+          +   "\"" BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "\": { \"INPUT_VAR_2\": \"" AORC_FIELD_NAME_TEMP_2M_AG "\", \"INPUT_VAR_1\": \"" AORC_FIELD_NAME_PRECIP_RATE "\" },"
+          +   "\"create_function\": \"bmi_model_create\", \"destroy_function\": \"bmi_model_destroy\", \"uses_forcing_file\": false"
+          + "} } ], \"forcing\": { \"file_pattern\": \".*{{id}}.*.csv\", \"path\": \"./data/forcing/\", \"provider\": \"CsvPerFeature\" } }, "
+          + "\"time\": { \"start_time\": \"2015-12-01 00:00:00\", \"end_time\": \"2015-12-30 23:00:00\", \"output_interval\": 3600 }, "
+          + "\"output\": { \"root\": \"" + output_root + "\", \"catchment\": { \"grouping\": \"" + catchment_grouping + "\" } } "
+          + "}";
+    }
+}
+
+TEST_F(Formulation_Manager_Test, aggregated_catchment_output_writes_single_file)
+{
+    namespace fs = std::filesystem;
+    const std::string out_dir = "./test_agg_output_agg";
+    fs::remove_all(out_dir);
+
+    std::stringstream stream;
+    stream << fix_paths(bmi_cpp_output_config(out_dir, "per_formulation"));
+    boost::property_tree::ptree cfg;
+    boost::property_tree::json_parser::read_json(stream, cfg);
+    auto sim_time = realization::config::Time(*cfg.get_child_optional("time")).make_params();
+
+    std::ostream* raw = &std::cout;
+    std::shared_ptr<std::ostream> s_ptr(raw, [](void*){});
+    utils::StreamHandler out(s_ptr);
+
+    {
+        auto manager = std::make_shared<realization::Formulation_Manager>(cfg);
+        manager->read(sim_time, build_catchments({"cat-52", "cat-67"}, "nex-1"), out);
+        // Mirror the driver's per_formulation wiring: gather every catchment's columns, then
+        // construct the manager with the full set (output is owned by the driver, not HY_Features);
+        // the aggregated file name defaults.
+        std::vector<utils::FeatureDescriptor> registrations;
+        for (const std::string id : {"cat-52", "cat-67"}) {
+            registrations.emplace_back(id, manager->get_formulation(id)->get_output_fields());
+        }
+        auto mgr = realization::config::make_catchment_output_mgr(
+            manager->get_output_config(), std::move(registrations));
+    } // streams flush/close on destruction
+
+    const std::string agg_file = out_dir + "/cat_output.csv";
+    ASSERT_TRUE(fs::exists(agg_file));
+    auto lines = read_lines(agg_file);
+    ASSERT_EQ(lines.size(), 1u);                              // header written exactly once
+    EXPECT_EQ(lines[0].rfind("catchment_id,Time Step,Time,", 0), 0u);
+    EXPECT_FALSE(fs::exists(out_dir + "/cat-52.csv"));        // not per-feature
+    EXPECT_FALSE(fs::exists(out_dir + "/cat-67.csv"));
+
+    fs::remove_all(out_dir);
 }
 
 TEST_F(Formulation_Manager_Test, basic_run_1) {
@@ -1182,8 +1307,6 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
     utils::StreamHandler catchment_output(s_ptr);
 
     time_step_t ts = 2;
-    std::array<double, 5> values;
-    std::vector<std::string> str_values;
 
     /**
      * Lambda to add a feature to the fabric, and then assert that its properties exists.
@@ -1203,24 +1326,18 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
      * 
      * Assertions:
      * - Asserts that the formulation manager contains the given catchment ID.
-     * - Asserts that the expected values are contained within the output line at
-     *   timestep `ts`.
+     * - Asserts that each expected value appears in the formulation's output
+     *   values vector at timestep `ts`.
      *
-     * @note The output line is checked by splitting it along its delimiter,
-     *       and parsing the resulting strings to doubles. Then, `std::find`
-     *       is used to check for the existence of the expected doubles.
+     * @note The output values are retrieved as a vector of doubles
+     *       (get_output_values_for_timestep) and checked directly with
+     *       `std::find` -- no line formatting or string parsing.
      */
     auto check_formulation_values = [&](auto fm, const std::string& id, std::initializer_list<double> expected) {
         ASSERT_TRUE(fm.contains(id));
         auto formulation = fm.get_formulation(id);
         formulation->get_response(ts, 3600);
-        boost::algorithm::split(str_values, formulation->get_output_line_for_timestep(ts), [](auto c) -> bool { return c == ','; });
-        auto values_it = values.begin();
-        for (auto& str : str_values) {
-          auto end = &str[0] + str.size();
-          *values_it = strtod(str.c_str(), &end);
-          values_it++;
-        }
+        std::vector<double> values = formulation->get_output_values_for_timestep(ts);
 
         for (auto& expect : expected) {
             ASSERT_NE(std::find(values.begin(), values.end(), expect), values.end());
@@ -1296,97 +1413,4 @@ TEST_F(Formulation_Manager_Test, read_external_attributes) {
     
     check_formulation_values(manager, "cat-27",    { 3.00000, 18.0 });
     check_formulation_values(manager, "cat-67", { 7.41722, 9231 });
-}
-
-/** Test that is_disable_catchment_output works properly when explicitly set to ``true`` in config. */
-TEST_F(Formulation_Manager_Test, test_is_disable_catchment_output_1_a) {
-    std::stringstream stream;
-
-    stream << fix_paths(EXAMPLE_1);
-
-    boost::property_tree::ptree realization_config;
-    boost::property_tree::json_parser::read_json(stream, realization_config);
-
-    auto possible_simulation_time = realization_config.get_child_optional("time");
-    if (!possible_simulation_time) {
-        throw std::runtime_error("ERROR: No simulation time period defined.");
-    }
-
-    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
-
-    std::ostream* raw_pointer = &std::cout;
-    std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
-    utils::StreamHandler catchment_output(s_ptr);
-
-    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
-
-    ASSERT_TRUE(manager.is_empty());
-
-    this->add_feature("cat-52");
-    this->add_feature("cat-67");
-    manager.read(simulation_time_config, this->fabric, catchment_output);
-
-    ASSERT_TRUE(manager.is_disable_catchment_output());
-}
-
-/** Test that is_disable_catchment_output works properly (``false``) when not explicitly set in config. */
-TEST_F(Formulation_Manager_Test, test_is_disable_catchment_output_2_a) {
-    std::stringstream stream;
-
-    stream << fix_paths(EXAMPLE_2);
-
-    boost::property_tree::ptree realization_config;
-    boost::property_tree::json_parser::read_json(stream, realization_config);
-
-    auto possible_simulation_time = realization_config.get_child_optional("time");
-    if (!possible_simulation_time) {
-        throw std::runtime_error("ERROR: No simulation time period defined.");
-    }
-
-    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
-
-    std::ostream* raw_pointer = &std::cout;
-    std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
-    utils::StreamHandler catchment_output(s_ptr);
-
-    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
-
-    ASSERT_TRUE(manager.is_empty());
-
-    this->add_feature("cat-52");
-    this->add_feature("cat-67");
-    manager.read(simulation_time_config, this->fabric, catchment_output);
-
-    ASSERT_FALSE(manager.is_disable_catchment_output());
-}
-
-/** Test that is_disable_catchment_output works properly when explicitly set to ``false`` in config. */
-TEST_F(Formulation_Manager_Test, test_is_disable_catchment_output_6_a) {
-    std::stringstream stream;
-
-    stream << fix_paths(EXAMPLE_6);
-
-    boost::property_tree::ptree realization_config;
-    boost::property_tree::json_parser::read_json(stream, realization_config);
-
-    auto possible_simulation_time = realization_config.get_child_optional("time");
-    if (!possible_simulation_time) {
-        throw std::runtime_error("ERROR: No simulation time period defined.");
-    }
-
-    auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
-
-    std::ostream* raw_pointer = &std::cout;
-    std::shared_ptr<std::ostream> s_ptr(raw_pointer, [](void*) {});
-    utils::StreamHandler catchment_output(s_ptr);
-
-    realization::Formulation_Manager manager = realization::Formulation_Manager(realization_config);
-
-    ASSERT_TRUE(manager.is_empty());
-
-    this->add_feature("cat-52");
-    this->add_feature("cat-67");
-    manager.read(simulation_time_config, this->fabric, catchment_output);
-
-    ASSERT_FALSE(manager.is_disable_catchment_output());
 }

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -244,11 +244,12 @@ TEST_F(Bmi_C_Formulation_Test, Initialize_1_a) {
     Bmi_C_Formulation form_2(catchment_ids[1], std::make_shared<CsvPerFeatureForcingProvider>(*forcing_params_examples[1]), utils::StreamHandler());
     form_2.create_formulation(config_prop_ptree[1]);
 
-    std::string header_1 = form_1.get_output_header_line(",");
-    std::string header_2 = form_2.get_output_header_line(",");
+    std::vector<std::string> header_1, header_2;
+    for (const auto& f : form_1.get_output_fields()) header_1.push_back(f.output_name);
+    for (const auto& f : form_2.get_output_fields()) header_2.push_back(f.output_name);
 
-    ASSERT_EQ(header_1, "OUTPUT_VAR_1,OUTPUT_VAR_2");
-    ASSERT_EQ(header_2, "OUTPUT_VAR_2,OUTPUT_VAR_1");
+    EXPECT_THAT(header_1, ::testing::ElementsAre("OUTPUT_VAR_1", "OUTPUT_VAR_2"));
+    EXPECT_THAT(header_2, ::testing::ElementsAre("OUTPUT_VAR_2", "OUTPUT_VAR_1"));
 }
 
 /** Simple test of get response. */
@@ -321,8 +322,8 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
-    EXPECT_THAT(output, MatchesRegex("0.000000,571.600037"));
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 571.60003662109375}));
 }
 
 /** Simple test of output with modified variables. */
@@ -332,13 +333,12 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_1_a) {
     Bmi_C_Formulation formulation(catchment_ids[ex_index], std::make_shared<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
-    // Notably--this test could fail if both output vars were not the same. get_output_line_for_timestep assumes
-    // the return order of get_output_variable_names() is consistent but it apparently is not. In tracing this
-    // test, it was actually outputing OUTPUT_VAR_2 first, while the other two comparable tests are outputting
-    // OUTPUT_VAR_1 first.
+    // ex_index=1 configures output_variables as [OUTPUT_VAR_2, OUTPUT_VAR_1], so the values come out in
+    // that order (OUTPUT_VAR_2's value first) — the same order asserted for header_2 in Initialize_1_a.
+
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
-    EXPECT_THAT(output, MatchesRegex("571.600037,0.000000"));
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{571.60003662109375, 0.0}));
 }
 
 /** Simple test of output with modified variables, picking time step when there was non-zero rain rate. */
@@ -352,8 +352,8 @@ TEST_F(Bmi_C_Formulation_Test, GetOutputLineForTimestep_1_b) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
-    EXPECT_THAT(output, MatchesRegex("580.799988,0.000001"));
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{580.79998779296875, 1.1124674593096233e-06}));
 }
 
 TEST_F(Bmi_C_Formulation_Test, determine_model_time_offset_0_a) {

--- a/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
@@ -16,6 +16,7 @@
 #include "Bmi_Module_Formulation.hpp"
 #include "Bmi_Cpp_Formulation.hpp"
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include <iostream>
 #include <vector>
 #include <boost/property_tree/ptree.hpp>
@@ -233,11 +234,12 @@ TEST_F(Bmi_Cpp_Formulation_Test, Initialize_1_a) {
     Bmi_Cpp_Formulation form_2(catchment_ids[1], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[1]), utils::StreamHandler());
     form_2.create_formulation(config_prop_ptree[1]);
 
-    std::string header_1 = form_1.get_output_header_line(",");
-    std::string header_2 = form_2.get_output_header_line(",");
+    std::vector<std::string> header_1, header_2;
+    for (const auto& f : form_1.get_output_fields()) header_1.push_back(f.output_name);
+    for (const auto& f : form_2.get_output_fields()) header_2.push_back(f.output_name);
 
-    ASSERT_EQ(header_1, "OUTPUT_VAR_1,OUTPUT_VAR_2");
-    ASSERT_EQ(header_2, "OUTPUT_VAR_2,OUTPUT_VAR_1");
+    EXPECT_THAT(header_1, ::testing::ElementsAre("OUTPUT_VAR_1", "OUTPUT_VAR_2"));
+    EXPECT_THAT(header_2, ::testing::ElementsAre("OUTPUT_VAR_2", "OUTPUT_VAR_1"));
 }
 
 /** When output_header_fields is set, the header must use those labels, not the output variable names. */
@@ -260,7 +262,18 @@ TEST_F(Bmi_Cpp_Formulation_Test, Initialize_output_header_fields) {
     Bmi_Cpp_Formulation form(catchment_ids[0], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[0]), utils::StreamHandler());
     form.create_formulation(tree.get_child("bmi_c++"));
 
-    EXPECT_EQ(form.get_output_header_line(","), "custom_1,custom_2");
+    // Each field maps a source variable to its configured output (header) name; units come from the
+    // model (OUTPUT_VAR_1 -> "mm/s", OUTPUT_VAR_2 -> "m/s"), positionally aligned with the values.
+    const std::vector<utils::OutputField> fields = form.get_output_fields();
+    ASSERT_EQ(fields.size(), 2u);
+    EXPECT_EQ(fields[0].source_name, "OUTPUT_VAR_1");
+    EXPECT_EQ(fields[0].output_name, "custom_1");
+    ASSERT_TRUE(fields[0].units.has_value());
+    EXPECT_EQ(*fields[0].units, "mm/s");
+    EXPECT_EQ(fields[1].source_name, "OUTPUT_VAR_2");
+    EXPECT_EQ(fields[1].output_name, "custom_2");
+    ASSERT_TRUE(fields[1].units.has_value());
+    EXPECT_EQ(*fields[1].units, "m/s");
 }
 
 /** Simple test of get response. */
@@ -314,8 +327,8 @@ TEST_F(Bmi_Cpp_Formulation_Test, GetOutputLineForTimestep_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
-    ASSERT_EQ(output, "0.000000,571.600037");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 571.60003662109375}));
 }
 
 /** Simple test of output with modified variables. */
@@ -325,13 +338,12 @@ TEST_F(Bmi_Cpp_Formulation_Test, GetOutputLineForTimestep_1_a) {
     Bmi_Cpp_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
-    // Notably--this test could fail if both output vars were not the same. get_output_line_for_timestep assumes
-    // the return order of get_output_variable_names() is consistent but it apparently is not. In tracing this
-    // test, it was actually outputing OUTPUT_VAR_2 first, while the other two comparable tests are outputting
-    // OUTPUT_VAR_1 first.
+    // ex_index=1 configures output_variables as [OUTPUT_VAR_2, OUTPUT_VAR_1], so the values come out in
+    // that order (OUTPUT_VAR_2's value first) — the same order asserted for header_2 in Initialize_1_a.
+
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
-    ASSERT_EQ(output, "571.600037,0.000000");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{571.60003662109375, 0.0}));
 }
 
 /** Simple test of output with modified variables, picking time step when there was non-zero rain rate. */
@@ -345,8 +357,8 @@ TEST_F(Bmi_Cpp_Formulation_Test, GetOutputLineForTimestep_1_b) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
-    ASSERT_EQ(output, "580.799988,0.000001");
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{580.79998779296875, 1.1124674593096233e-06}));
 }
 
 TEST_F(Bmi_Cpp_Formulation_Test, determine_model_time_offset_0_a) {

--- a/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Multi_Array_Test.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <vector>
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "Bmi_Multi_Formulation.hpp"
 #include "Bmi_Cpp_Formulation.hpp"
 #include "Bmi_Module_Formulation.hpp"
@@ -377,8 +378,8 @@ TEST_F(Bmi_Cpp_Multi_Array_Test, GetOutputLineForTimestep_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
-    ASSERT_EQ(output, "0.000000,200620.000000");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 200620.0}));
 }
 
 /**
@@ -394,8 +395,8 @@ TEST_F(Bmi_Cpp_Multi_Array_Test, GetOutputLineForTimestep_0_b) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
-    ASSERT_EQ(output, "0.000001,199280.000000");
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{1.1124674593096233e-06, 199280.0}));
 }
 
 

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -17,6 +17,7 @@
 #include "Bmi_Fortran_Formulation.hpp"
 #include "Bmi_Fortran_Adapter.hpp"
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include <iostream>
 #include <vector>
 #include <boost/property_tree/ptree.hpp>
@@ -66,10 +67,6 @@ protected:
 
     static double get_friend_var_value_as_double(Bmi_Fortran_Formulation& formulation, const std::string& var_name) {
         return formulation.get_var_value_as_double(0, var_name);
-    }
-
-    static std::string get_friend_output_header_line(Bmi_Fortran_Formulation& formulation, std::string delim) {
-        return formulation.get_output_header_line(delim);
     }
 
     static time_t parse_forcing_time(const std::string& date_time_str) {
@@ -247,11 +244,12 @@ TEST_F(Bmi_Fortran_Formulation_Test, Initialize_1_a) {
     Bmi_Fortran_Formulation form_2(catchment_ids[1], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[1]), utils::StreamHandler());
     form_2.create_formulation(config_prop_ptree[1]);
 
-    std::string header_1 = get_friend_output_header_line(form_1,",");
-    std::string header_2 = get_friend_output_header_line(form_2,",");
+    std::vector<std::string> header_1, header_2;
+    for (const auto& f : form_1.get_output_fields()) header_1.push_back(f.output_name);
+    for (const auto& f : form_2.get_output_fields()) header_2.push_back(f.output_name);
 
-    ASSERT_EQ(header_1, "OUTPUT_VAR_1,OUTPUT_VAR_2,OUTPUT_VAR_3,GRID_VAR_2,GRID_VAR_3,GRID_VAR_4");
-    ASSERT_EQ(header_2, "OUTPUT_VAR_2,OUTPUT_VAR_1,OUTPUT_VAR_3");
+    EXPECT_THAT(header_1, ::testing::ElementsAre("OUTPUT_VAR_1", "OUTPUT_VAR_2", "OUTPUT_VAR_3", "GRID_VAR_2", "GRID_VAR_3", "GRID_VAR_4"));
+    EXPECT_THAT(header_2, ::testing::ElementsAre("OUTPUT_VAR_2", "OUTPUT_VAR_1", "OUTPUT_VAR_3"));
 }
 
 /** Simple test of get response. */
@@ -310,10 +308,10 @@ TEST_F(Bmi_Fortran_Formulation_Test, GetOutputLineForTimestep_0_a) {
     shape = {2,2,3};
     model_adapter->SetValue("grid_2_shape", shape.data());
     double response = formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
     //NOTE these answers are dependent on the INPUT vars selected and the data in the forcing file
     //Also, for grid vars, just gets the first value in the returned flattened array...
-    ASSERT_EQ(output, "0.000000,0.018600,0.000000,2.000000,10.000000,10.000000");
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 0.018600000068545341, 0.0, 2.0, 10.0, 10.0}));
 }
 
 /** Simple test of output with modified variables. */
@@ -324,9 +322,9 @@ TEST_F(Bmi_Fortran_Formulation_Test, GetOutputLineForTimestep_1_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     double response = formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
     //NOTE these answers are dependent on the INPUT vars selected and the data in the forcing file
-    ASSERT_EQ(output, "0.018600,0.000000,0.000000");
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.018600000068545341, 0.0, 0.0}));
 }
 
 /** Simple test of output with modified variables, picking time step when there was non-zero rain rate. */
@@ -340,9 +338,9 @@ TEST_F(Bmi_Fortran_Formulation_Test, GetOutputLineForTimestep_1_b) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     double response = formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
     //NOTE these answers are dependent on the INPUT vars selected and the data in the forcing file
-    ASSERT_EQ(output, "0.025400,0.000001,0.000000");
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.025399999693036079, 1.1124674593096233e-06, 0.0}));
 }
 
 TEST_F(Bmi_Fortran_Formulation_Test, determine_model_time_offset_0_a) {

--- a/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Multi_Formulation_Test.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <vector>
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "Bmi_Multi_Formulation.hpp"
 #include "Bmi_Module_Formulation.hpp"
 #include "Bmi_Fortran_Formulation.hpp"
@@ -615,7 +616,9 @@ TEST_F(Bmi_Multi_Formulation_Test, Initialize_output_header_fields) {
     Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
     formulation.create_formulation(props);
 
-    EXPECT_EQ(formulation.get_output_header_line(","), "h0,h1,h2,h3,h4,h5");
+    std::vector<std::string> names;
+    for (const auto& f : formulation.get_output_fields()) names.push_back(f.output_name);
+    EXPECT_EQ(names, labels);
 }
 
 /** Test to make sure the a non-existent variable name is not allowed in `output_variables` (see issue #535). */
@@ -776,8 +779,8 @@ TEST_F(Bmi_Multi_Formulation_Test, GetOutputLineForTimestep_0_a) {
     formulation.create_formulation(config_prop_ptree[ex_index]);
 
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
-    ASSERT_EQ(output, "0.000000,200620.000000");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 200620.0}));
 }
 
 /**
@@ -793,8 +796,8 @@ TEST_F(Bmi_Multi_Formulation_Test, GetOutputLineForTimestep_0_b) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
-    ASSERT_EQ(output, "0.000001,199280.000000");
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{1.1124674593096233e-06, 199280.0}));
 }
 
 /**
@@ -816,11 +819,11 @@ TEST_F(Bmi_Multi_Formulation_Test, GetOutputLineForTimestep_1_a) {
     std::vector<int> shape = {2,3};
     model_adapter->SetValue("grid_1_shape", shape.data());
     formulation.get_response(0, 3600);
-    std::string output = formulation.get_output_line_for_timestep(0, ",");
+    std::vector<double> output = formulation.get_output_values_for_timestep(0);
     //FIXME the last two outputs are the first value from the GRID_VAR in the python module...couldn't get the output variables
     //configured in the example realization generation to not query those, so hacked in here.  See comment above about not worrying about
     //initializing/using the grid vars in this test, and try to find a better way in the future.
-    ASSERT_EQ(output, "0.000000,200620.000000,1.000000,2.000000,3.000000");
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 200620.0, 1.0, 2.0, 3.0}));
 #endif // NGEN_WITH_PYTHON
 }
 
@@ -846,11 +849,11 @@ TEST_F(Bmi_Multi_Formulation_Test, GetOutputLineForTimestep_1_b) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
     //FIXME the last two outputs are the first value from the GRID_VAR in the python module...couldn't get the output variables
     //configured in the example realization generation to not query those, so hacked in here.  See comment above about not worrying about
     //initializing/using the grid vars in this test, and try to find a better way in the future.
-    ASSERT_EQ(output, "0.000001,199280.000000,543.000000,2.000001,3.000001");
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{1.1124674593096233e-06, 199280.0, 543.0, 2.0000011124674595, 3.0000011124674595}));
 #endif // NGEN_WITH_PYTHON
 }
 
@@ -867,8 +870,21 @@ TEST_F(Bmi_Multi_Formulation_Test, GetOutputLineForTimestep_3_a) {
     while (i < 542)
         formulation.get_response(i++, 3600);
     formulation.get_response(i, 3600);
-    std::string output = formulation.get_output_line_for_timestep(i, ",");
-    ASSERT_EQ(output, "0.000001,199280.000000,199240.000000,199280.000000,0.000000,0.000001");
+    std::vector<double> output = formulation.get_output_values_for_timestep(i);
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{1.1124674593096233e-06, 199280.0, 199240.0, 199280.0, 0.0, 1.001327023947647e-06}));
+}
+
+/** The output header fields line up positionally with get_output_values_for_timestep -- i.e. they
+ *  match the configured output_variables in the same order (guards multi-module output ordering). */
+TEST_F(Bmi_Multi_Formulation_Test, OutputHeaderFieldsMatchConfiguredOrder_3) {
+    int ex_index = 3;
+
+    Bmi_Multi_Formulation formulation(catchment_ids[ex_index], std::make_unique<CsvPerFeatureForcingProvider>(*forcing_params_examples[ex_index]), utils::StreamHandler());
+    formulation.create_formulation(config_prop_ptree[ex_index]);
+
+    std::vector<std::string> names;
+    for (const auto& f : formulation.get_output_fields()) names.push_back(f.output_name);
+    EXPECT_EQ(names, specified_output_variables[ex_index]);
 }
 
 /**

--- a/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Py_Formulation_Test.cpp
@@ -1,6 +1,7 @@
 #ifdef NGEN_BMI_PY_TESTS_ACTIVE
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include <boost/date_time.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -390,9 +391,9 @@ TEST_F(Bmi_Py_Formulation_Test, GetOutputLineForTimestep_0_a) {
     int ex_index = 0;
 
     double response = examples[ex_index].formulation->get_response(0, 3600);
-    std::string output = examples[ex_index].formulation->get_output_line_for_timestep(0, ",");
+    std::vector<double> output = examples[ex_index].formulation->get_output_values_for_timestep(0);
     //NOTE the last two values are simply the FIRST element of the grid vars
-    ASSERT_EQ(output, "0.000000,571.600037,1.000000,2.000000,3.000000");
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15), std::vector<double>{0.0, 571.60003662109375, 1.0, 2.0, 3.0}));
 }
 
 /**
@@ -406,10 +407,10 @@ TEST_F(Bmi_Py_Formulation_Test, GetOutputLineForTimestep_0_b) {
         examples[ex_index].formulation->get_response(i++, 3600);
 
     double response = examples[ex_index].formulation->get_response(543, 3600);
-    std::string output = examples[ex_index].formulation->get_output_line_for_timestep(543, ",");
+    std::vector<double> output = examples[ex_index].formulation->get_output_values_for_timestep(543);
     //NOTE the last two values are simply the FIRST element of the grid vars
-    std::regex expected ("0.000001,582.000000,544.000000,2.000001,3.000001");
-    ASSERT_TRUE(std::regex_match(output, expected));
+    EXPECT_THAT(output, ::testing::Pointwise(::testing::DoubleNear(1e-15),
+                std::vector<double>{1.001327023947647e-06, 582.0, 544.0, 2.000001001327024, 3.000001001327024}));
 }
 
 /**

--- a/test/realizations/config/CatchmentOutput_Test.cpp
+++ b/test/realizations/config/CatchmentOutput_Test.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <unistd.h>   // getpid
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "realizations/config/output.hpp"
+#include "realizations/config/catchment_output.hpp"
+#include <CatchmentOutputsMgr.hpp>
+
+// Unit tests for the catchment output factory (realization::config::make_catchment_output_mgr):
+// that it selects the manager's mode from the configuration. The CSV layout details themselves
+// (header-once, precision, id column, per-formulation subdirs) are covered by
+// CatchmentCsvOutputMgr_Test; config parsing by Output_Test. Here we assert only the selection,
+// so no Formulation_Manager or BMI model is involved -- catchments are registered with explicit
+// fields.
+
+using realization::config::Output;
+using realization::config::OutputFormat;
+using realization::config::make_catchment_output_mgr;
+
+namespace {
+    // A column whose output name is its source and has no units -- terse shorthand for building test
+    // column lists (production OutputField construction states source, output, and units explicitly).
+    utils::OutputField col(const std::string& name) { return {name, name, std::nullopt}; }
+
+    Output config_with(const std::string& root, const std::string& catchment_grouping) {
+        std::stringstream ss(std::string("{\"output\":{\"root\":\"") + root
+            + "\",\"catchment\":{\"grouping\":\"" + catchment_grouping + "\"}}}");
+        boost::property_tree::ptree tree;
+        boost::property_tree::json_parser::read_json(ss, tree);
+        return Output::from_realization(tree);   // normalizes the root (the manager creates it on use)
+    }
+
+    std::vector<std::string> read_lines(const std::filesystem::path& p) {
+        std::vector<std::string> lines;
+        std::ifstream in(p);
+        std::string line;
+        while (std::getline(in, line)) lines.push_back(line);
+        return lines;
+    }
+
+    // The parent for this binary's temp output roots. PID-scoped so concurrent test binaries don't
+    // collide over fixed names.
+    std::filesystem::path pid_test_root() {
+        return std::filesystem::temp_directory_path() / ("ngen_cat_factory_test_" + std::to_string(getpid()));
+    }
+
+    // A unique output root (trailing slash) under pid_test_root(). Not created here -- the manager
+    // creates it, which is part of what we exercise; TempDirCleanup owns wiping the tree.
+    std::string fresh_root() {
+        static int counter = 0;
+        return (pid_test_root() / std::to_string(counter++) / "").string();
+    }
+
+    // Own the PID-scoped temp tree's lifecycle: clear any residue from a prior same-PID run up front,
+    // and remove this run's tree at exit (which also covers a root left behind by a test that failed
+    // an assertion before its own cleanup). This is the only thing that touches the tree wholesale.
+    struct TempDirCleanup : ::testing::Environment {
+        void SetUp() override    { std::filesystem::remove_all(pid_test_root()); }
+        void TearDown() override { std::filesystem::remove_all(pid_test_root()); }
+    };
+    const auto* temp_dir_cleanup = ::testing::AddGlobalTestEnvironment(new TempDirCleanup);
+}
+
+// per_formulation grouping -> aggregated manager: one shared file with a leading catchment_id
+// column, not one file per catchment. The aggregated file name defaults (cat_output.csv) since the
+// caller supplies none.
+TEST(CatchmentOutput_Factory_Test, PerFormulationConfigSelectsAggregatedFile)
+{
+    namespace fs = std::filesystem;
+    const std::string root = fresh_root();
+
+    {
+        auto mgr = make_catchment_output_mgr(config_with(root, "per_formulation"),
+                                             { {"cat-1", {col("Q_OUT")}},
+                                               {"cat-2", {col("Q_OUT")}} });
+        mgr->commit_writes();
+        mgr->close();
+    }
+
+    ASSERT_TRUE(fs::exists(root + "cat_output.csv"));         // single aggregated file
+    const auto lines = read_lines(root + "cat_output.csv");
+    ASSERT_EQ(lines.size(), 1u);                             // header written once, no data pushed
+    EXPECT_EQ(lines[0].rfind("catchment_id,", 0), 0u);      // leading catchment_id column
+    EXPECT_FALSE(fs::exists(root + "cat-1.csv"));            // not per-feature
+    EXPECT_FALSE(fs::exists(root + "cat-2.csv"));
+}
+
+// per_feature (no file name) -> per-feature manager: one file per catchment, no aggregated file
+// and no catchment_id column.
+TEST(CatchmentOutput_Factory_Test, PerFeatureConfigSelectsFilePerCatchment)
+{
+    namespace fs = std::filesystem;
+    const std::string root = fresh_root();
+
+    {
+        auto mgr = make_catchment_output_mgr(config_with(root, "per_feature"),
+                                             { {"cat-1", {col("Q_OUT")}},
+                                               {"cat-2", {col("Q_OUT")}} });
+        mgr->commit_writes();
+        mgr->close();
+    }
+
+    ASSERT_TRUE(fs::exists(root + "cat-1.csv"));              // one file per catchment
+    ASSERT_TRUE(fs::exists(root + "cat-2.csv"));
+    const auto lines = read_lines(root + "cat-1.csv");
+    ASSERT_EQ(lines.size(), 1u);
+    EXPECT_EQ(lines[0].rfind("Time Step,", 0), 0u);         // no catchment_id column
+    EXPECT_FALSE(fs::exists(root + "cat_output.csv"));
+}
+
+// A supplied file name does not force aggregation: with per_feature grouping the factory stays
+// consistent with the config and writes per-feature files, ignoring the name.
+TEST(CatchmentOutput_Factory_Test, FileNameDoesNotOverridePerFeatureGrouping)
+{
+    namespace fs = std::filesystem;
+    const std::string root = fresh_root();
+
+    {
+        auto mgr = make_catchment_output_mgr(config_with(root, "per_feature"),
+                                             { {"cat-1", {col("Q_OUT")}} }, "cat_output.csv");
+        mgr->commit_writes();
+        mgr->close();
+    }
+
+    EXPECT_TRUE(fs::exists(root + "cat-1.csv"));
+    EXPECT_FALSE(fs::exists(root + "cat_output.csv"));        // name ignored; grouping wins
+}
+
+// A non-CSV catchment output format is not implemented and is rejected.
+TEST(CatchmentOutput_Factory_Test, NonCsvFormatThrows)
+{
+    Output cfg;
+    cfg.catchment.format = OutputFormat::netcdf;
+    EXPECT_THROW(make_catchment_output_mgr(cfg, {}), std::runtime_error);   // format rejected before use
+}

--- a/test/realizations/config/Output_Test.cpp
+++ b/test/realizations/config/Output_Test.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "realizations/config/output.hpp"
+
+using realization::config::Output;
+using realization::config::OutputDomain;
+using realization::config::OutputFormat;
+using realization::config::OutputGrouping;
+using realization::config::rank_output_root;
+
+namespace {
+    boost::property_tree::ptree parse(const std::string& json) {
+        boost::property_tree::ptree tree;
+        std::stringstream ss(json);
+        boost::property_tree::json_parser::read_json(ss, tree);
+        return tree;
+    }
+}
+
+// Defaults when no output settings are present at all.
+TEST(Output_Config_Test, DefaultsWhenAbsent)
+{
+    auto out = Output::from_realization(parse(R"({"time": {}})"));
+    EXPECT_FALSE(out.from_legacy_keys);
+    EXPECT_EQ(out.root, "./");   // an unset root resolves to "./"
+    EXPECT_TRUE(out.catchment.enable);
+    EXPECT_TRUE(out.nexus.enable);
+    EXPECT_EQ(out.catchment.format, OutputFormat::csv);
+    EXPECT_EQ(out.nexus.format, OutputFormat::csv);
+    EXPECT_EQ(out.catchment.grouping, OutputGrouping::per_feature);
+    EXPECT_EQ(out.nexus.grouping, OutputGrouping::per_feature);
+    EXPECT_FALSE(out.catchment.rank_subdir);   // rank subdirectories are opt-in
+    EXPECT_FALSE(out.nexus.rank_subdir);
+}
+
+// The modern "output" block is parsed across both domains, including grouping and rank_subdir.
+TEST(Output_Config_Test, ParsesModernBlock)
+{
+    const std::string json = R"({
+        "output": {
+            "root": "/tmp/out/",
+            "catchment": { "enable": false, "format": "csv", "grouping": "per_formulation", "rank_subdir": true },
+            "nexus":     { "enable": true,  "format": "netcdf", "grouping": "per_feature" }
+        }
+    })";
+    auto out = Output::from_realization(parse(json));
+    EXPECT_FALSE(out.from_legacy_keys);
+    EXPECT_EQ(out.root, "/tmp/out/");
+    EXPECT_FALSE(out.catchment.enable);
+    EXPECT_EQ(out.catchment.grouping, OutputGrouping::per_formulation);
+    EXPECT_TRUE(out.catchment.rank_subdir);
+    EXPECT_TRUE(out.nexus.enable);
+    EXPECT_EQ(out.nexus.format, OutputFormat::netcdf);
+    EXPECT_EQ(out.nexus.grouping, OutputGrouping::per_feature);
+    EXPECT_FALSE(out.nexus.rank_subdir);
+}
+
+// Legacy top-level keys map onto the new structure and flag deprecation.
+TEST(Output_Config_Test, LegacyKeysMapped)
+{
+    const std::string json = R"({
+        "output_root": "./legacy_dir",
+        "disable_catchment_output": true,
+        "per_formulation_nexus_files": true
+    })";
+    auto out = Output::from_realization(parse(json));
+    EXPECT_TRUE(out.from_legacy_keys);
+    EXPECT_EQ(out.root, "./legacy_dir/");                // resolved: normalized to a trailing slash
+    EXPECT_FALSE(out.catchment.enable);                  // disable_catchment_output: true
+    EXPECT_EQ(out.nexus.format, OutputFormat::netcdf);   // per_formulation_nexus_files: true
+}
+
+// Legacy disable_catchment_output=false explicitly keeps catchment output enabled.
+TEST(Output_Config_Test, LegacyDisableCatchmentFalseKeepsEnabled)
+{
+    auto out = Output::from_realization(parse(R"({ "disable_catchment_output": false })"));
+    EXPECT_TRUE(out.from_legacy_keys);
+    EXPECT_TRUE(out.catchment.enable);
+}
+
+// The modern block takes precedence; legacy keys are ignored when it is present.
+TEST(Output_Config_Test, ModernBlockWinsOverLegacy)
+{
+    const std::string json = R"({
+        "output_root": "./legacy_dir",
+        "disable_catchment_output": true,
+        "output": { "root": "./modern_dir" }
+    })";
+    auto out = Output::from_realization(parse(json));
+    EXPECT_FALSE(out.from_legacy_keys);
+    EXPECT_EQ(out.root, "./modern_dir/");   // resolved: normalized to a trailing slash
+    EXPECT_TRUE(out.catchment.enable);   // legacy disable ignored
+}
+
+// Invalid enum values are rejected with a clear error.
+TEST(Output_Config_Test, InvalidValuesThrow)
+{
+    EXPECT_THROW(Output::from_realization(parse(R"({"output":{"nexus":{"format":"parquet"}}})")),
+                 std::runtime_error);
+    EXPECT_THROW(Output::from_realization(parse(R"({"output":{"catchment":{"grouping":"per_node"}}})")),
+                 std::runtime_error);
+}
+
+// rank_output_root: serial runs are never rank-partitioned, regardless of settings.
+TEST(Output_Config_Test, RankRootUnchangedInSerial)
+{
+    OutputDomain d;
+    d.rank_subdir = true;
+    d.grouping = OutputGrouping::per_formulation;
+    EXPECT_EQ(rank_output_root("/out/", d, /*rank*/0, /*num_procs*/1), "/out/");
+}
+
+// rank_output_root: per_feature only nests under rank_<N>/ when rank_subdir is set (MPI).
+TEST(Output_Config_Test, RankRootPerFeatureHonorsFlag)
+{
+    OutputDomain d;   // per_feature, rank_subdir defaults false
+    EXPECT_EQ(rank_output_root("/out/", d, 3, 4), "/out/");
+    d.rank_subdir = true;
+    EXPECT_EQ(rank_output_root("/out/", d, 3, 4), "/out/rank_3/");
+}
+
+// rank_output_root: per_formulation forces rank_<N>/ under MPI even with rank_subdir off,
+// so ranks never collide on a shared aggregated file.
+TEST(Output_Config_Test, RankRootPerFormulationForcesSubdir)
+{
+    OutputDomain d;
+    d.grouping = OutputGrouping::per_formulation;
+    d.rank_subdir = false;
+    EXPECT_EQ(rank_output_root("/out/", d, 2, 8), "/out/rank_2/");
+}

--- a/test/utilities/output/CatchmentCsvOutputMgr_Test.cpp
+++ b/test/utilities/output/CatchmentCsvOutputMgr_Test.cpp
@@ -1,0 +1,210 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <unistd.h>   // getpid
+
+#include <CatchmentCsvOutputMgr.hpp>
+
+namespace {
+    std::vector<std::string> read_lines(const std::filesystem::path& p) {
+        std::vector<std::string> lines;
+        std::ifstream in(p);
+        std::string line;
+        while (std::getline(in, line)) lines.push_back(line);
+        return lines;
+    }
+
+    utils::time_marker marker(long index, const std::string& stamp) {
+        return utils::time_marker(index, 0, stamp);
+    }
+
+    // A column whose output name is its source and has no units -- terse shorthand for building test
+    // column lists (production OutputField construction states source, output, and units explicitly).
+    utils::OutputField col(const std::string& name) { return {name, name, std::nullopt}; }
+
+    // A fresh, empty temp directory unique to this process (and each call), so tests never collide
+    // with a concurrently running test binary or with each other over fixed file names.
+    std::filesystem::path fresh_dir() {
+        static int counter = 0;
+        std::filesystem::path d = std::filesystem::temp_directory_path()
+            / ("ngen_cat_csv_test_" + std::to_string(getpid())) / std::to_string(counter++);
+        std::filesystem::remove_all(d);
+        std::filesystem::create_directories(d);
+        return d;
+    }
+}
+
+// Aggregated: all catchments share one file, the header (with the id column) is
+// written once, and every row carries the full catchment id. Values are joined
+// from the typed vector at the manager's configured precision.
+TEST(CatchmentCsvOutputMgr_Test, AggregatedSharesFileHeaderOnce)
+{
+    const auto dir  = fresh_dir();
+    const std::string root  = (dir / "").string();
+    const std::string fname = "ngen_cat_agg_mgr_test.csv";
+
+    {
+        utils::CatchmentCsvOutputMgr mgr(root, fname, /*precision=*/6,
+                                         { {"cat-1", {col("Q_OUT")}},
+                                           {"cat-2", {col("Q_OUT")}} });   // header written once
+        mgr.receive_data_entry("cat-1", marker(0, "t0"), {1.5});
+        mgr.receive_data_entry("cat-2", marker(0, "t0"), {2.25});
+        mgr.receive_data_entry("cat-1", marker(1, "t1"), {3.5});
+        mgr.commit_writes();
+        mgr.close();
+        EXPECT_TRUE(mgr.is_closed());
+    }
+
+    const auto lines = read_lines(dir / fname);
+    ASSERT_EQ(lines.size(), 4u);
+    EXPECT_EQ(lines[0], "catchment_id,Time Step,Time,Q_OUT");
+    EXPECT_EQ(lines[1], "cat-1,0,t0,1.5");
+    EXPECT_EQ(lines[2], "cat-2,0,t0,2.25");
+    EXPECT_EQ(lines[3], "cat-1,1,t1,3.5");
+
+    std::filesystem::remove_all(dir);
+}
+
+// Aggregated with more than one formulation: each formulation's catchments aggregate into their
+// own file (per-formulation subdirectory), so every file's header is that formulation's own column
+// set -- distinct formulations with different columns never share a file or a header. Rows route to
+// the file for the (formulation, catchment) they were received under.
+TEST(CatchmentCsvOutputMgr_Test, AggregatedSplitsByFormulation)
+{
+    const auto dir = fresh_dir();
+    const std::string root = (dir / "").string();
+    const std::string fname = "agg.csv";
+
+    {
+        utils::CatchmentCsvOutputMgr mgr(root, fname, /*precision=*/6,
+                                         { {"formA", "cat-1", {col("Q_OUT")}},
+                                           {"formA", "cat-2", {col("Q_OUT")}},
+                                           {"formB", "cat-3", {col("Q_OUT"), col("ET")}} });   // different columns
+        mgr.receive_data_entry("formA", "cat-1", marker(0, "t0"), {1.0});
+        mgr.receive_data_entry("formB", "cat-3", marker(0, "t0"), {2.0, 0.5});
+        mgr.receive_data_entry("formA", "cat-2", marker(0, "t0"), {3.0});
+        mgr.close();
+    }
+
+    const auto a = read_lines(dir / "formA" / fname);
+    const auto b = read_lines(dir / "formB" / fname);
+    ASSERT_EQ(a.size(), 3u);                                     // header + two catchments
+    EXPECT_EQ(a[0], "catchment_id,Time Step,Time,Q_OUT");       // formA's single-column schema
+    EXPECT_EQ(a[1], "cat-1,0,t0,1");
+    EXPECT_EQ(a[2], "cat-2,0,t0,3");
+    ASSERT_EQ(b.size(), 2u);                                     // header + one catchment
+    EXPECT_EQ(b[0], "catchment_id,Time Step,Time,Q_OUT,ET");    // formB's own two-column schema
+    EXPECT_EQ(b[1], "cat-3,0,t0,2,0.5");
+
+    std::filesystem::remove_all(dir);
+}
+
+// Per-feature: one file per catchment, each with its own header; multiple
+// columns join in order.
+TEST(CatchmentCsvOutputMgr_Test, PerFeatureOneFilePerCatchment)
+{
+    const auto dir = fresh_dir();
+    const std::string root = (dir / "").string();
+
+    {
+        utils::CatchmentCsvOutputMgr mgr(root, std::nullopt, /*precision=*/6,
+                                         { {"cat-1", {col("Q_OUT"), col("ET")}},
+                                           {"cat-2", {col("Q_OUT"), col("ET")}} });
+        mgr.receive_data_entry("cat-1", marker(0, "t0"), {1.5, 0.25});
+        mgr.receive_data_entry("cat-2", marker(0, "t0"), {2.25, 0.5});
+        mgr.close();
+    }
+
+    const auto l1 = read_lines(dir / "cat-1.csv");
+    const auto l2 = read_lines(dir / "cat-2.csv");
+    ASSERT_EQ(l1.size(), 2u);
+    EXPECT_EQ(l1[0], "Time Step,Time,Q_OUT,ET");
+    EXPECT_EQ(l1[1], "0,t0,1.5,0.25");
+    ASSERT_EQ(l2.size(), 2u);
+    EXPECT_EQ(l2[1], "0,t0,2.25,0.5");
+
+    std::filesystem::remove_all(dir);
+}
+
+// A non-default formulation id routes output into a per-formulation subdirectory, so independent
+// formulation setups over the same catchment id do not collide. The default id stays flat.
+TEST(CatchmentCsvOutputMgr_Test, PerFormulationSubdirectoryAvoidsCollisions)
+{
+    const auto dir = fresh_dir();
+    const std::string root = (dir / "").string();
+
+    {
+        utils::CatchmentCsvOutputMgr mgr(root, std::nullopt, /*precision=*/6,
+                                         { {"formA", "cat-1", {col("Q_OUT")}},
+                                           {"formB", "cat-1", {col("Q_OUT")}},
+                                           {"cat-1", {col("Q_OUT")}} });   // default id -> flat layout
+        mgr.receive_data_entry("formA", "cat-1", marker(0, "t0"), {1.0});
+        mgr.receive_data_entry("formB", "cat-1", marker(0, "t0"), {2.0});
+        mgr.receive_data_entry("cat-1", marker(0, "t0"), {3.0});    // default id
+        mgr.close();
+    }
+
+    const auto a = read_lines(dir / "formA" / "cat-1.csv");
+    const auto b = read_lines(dir / "formB" / "cat-1.csv");
+    const auto d = read_lines(dir / "cat-1.csv");
+    ASSERT_EQ(a.size(), 2u);
+    EXPECT_EQ(a[1], "0,t0,1");
+    ASSERT_EQ(b.size(), 2u);
+    EXPECT_EQ(b[1], "0,t0,2");
+    ASSERT_EQ(d.size(), 2u);
+    EXPECT_EQ(d[1], "0,t0,3");
+
+    std::filesystem::remove_all(dir);
+}
+
+// Once closed, receiving more data is an error (mirrors NexusOutputsMgr semantics).
+TEST(CatchmentCsvOutputMgr_Test, ThrowsAfterClose)
+{
+    const auto dir = fresh_dir();
+    const std::string root = (dir / "").string();
+
+    utils::CatchmentCsvOutputMgr mgr(root, std::nullopt, /*precision=*/6, { {"cat-1", {col("Q_OUT")}} });
+    mgr.close();
+    EXPECT_TRUE(mgr.is_closed());
+    EXPECT_THROW(mgr.receive_data_entry("cat-1", marker(0, "t0"), {1.0}), std::runtime_error);
+
+    std::filesystem::remove_all(dir);
+}
+
+// Receiving data for a (formulation, catchment) that was not in the set the manager was constructed
+// with is an error: the manager only writes the features it was told about up front.
+TEST(CatchmentCsvOutputMgr_Test, ThrowsForUnregisteredCatchment)
+{
+    const auto dir = fresh_dir();
+    const std::string root = (dir / "").string();
+
+    utils::CatchmentCsvOutputMgr mgr(root, std::nullopt, /*precision=*/6, { {"cat-1", {col("Q_OUT")}} });
+    EXPECT_THROW(mgr.receive_data_entry("cat-unknown", marker(0, "t0"), {1.0}), std::runtime_error);
+
+    std::filesystem::remove_all(dir);
+}
+
+// Values are rendered at the manager's configured significant-digit precision (set once on each
+// stream at open). A value with more significant digits than the precision is rounded to it.
+TEST(CatchmentCsvOutputMgr_Test, ValuesRenderAtConfiguredPrecision)
+{
+    const auto dir = fresh_dir();
+    const std::string root = (dir / "").string();
+
+    {
+        utils::CatchmentCsvOutputMgr mgr(root, std::nullopt, /*precision=*/6, { {"cat-1", {col("A"), col("B")}} });
+        mgr.receive_data_entry("cat-1", marker(0, "t0"), {1.0 / 3.0, 2.0 / 3.0});
+        mgr.close();
+    }
+
+    const auto l = read_lines(dir / "cat-1.csv");
+    ASSERT_EQ(l.size(), 2u);
+    EXPECT_EQ(l[1], "0,t0,0.333333,0.666667");   // 6 significant digits; the second value rounds up
+
+    std::filesystem::remove_all(dir);
+}

--- a/test/utilities/output/PerNexusCsvOutputMgr_Test.cpp
+++ b/test/utilities/output/PerNexusCsvOutputMgr_Test.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+#include "PerNexusCsvOutputMgr.hpp"
+
+namespace fs = std::filesystem;
+using utils::PerNexusCsvOutputMgr;
+using utils::time_marker;
+
+namespace {
+    fs::path fresh_temp_dir() {
+        fs::path d = fs::temp_directory_path() / "ngen_per_nexus_csv_test";
+        fs::remove_all(d);
+        fs::create_directories(d);
+        return d;
+    }
+}
+
+// Default behavior: one CSV per nexus, written directly under output_root.
+TEST(PerNexusCsvOutputMgr_Test, WritesPerNexusFilesInOutputRoot)
+{
+    const fs::path root = fresh_temp_dir();
+    const std::vector<std::string> ids = {"nex-1", "nex-2"};
+    {
+        PerNexusCsvOutputMgr mgr(ids, root.string() + "/");
+        // Use the base-class convenience overload (as callers do via the
+        // NexusOutputsMgr interface); the derived 4-arg override otherwise hides it.
+        utils::NexusOutputsMgr& base = mgr;
+        base.receive_data_entry("nex-1", time_marker(0, 0, "2020-01-01 00:00:00"), 1.5);
+        mgr.commit_writes();
+
+        EXPECT_TRUE(fs::exists(root / "nex-1_output.csv"));
+        EXPECT_TRUE(fs::exists(root / "nex-2_output.csv"));
+
+        std::ifstream f((root / "nex-1_output.csv").string());
+        std::stringstream ss; ss << f.rdbuf();
+        EXPECT_NE(ss.str().find("1.5"), std::string::npos);
+    }
+    fs::remove_all(root);
+}
+
+// rank_subdir layout: the caller folds the rank subdirectory into the effective root (as the driver
+// does via rank_output_root); the manager creates that directory and places the per-nexus files
+// there.
+TEST(PerNexusCsvOutputMgr_Test, CreatesAndUsesPerRankSubdirectory)
+{
+    const fs::path root = fresh_temp_dir();
+    const std::vector<std::string> ids = {"nex-1"};
+    {
+        PerNexusCsvOutputMgr mgr(ids, root.string() + "/rank_7/");
+        mgr.commit_writes();
+
+        EXPECT_TRUE(fs::is_directory(root / "rank_7"));
+        EXPECT_TRUE(fs::exists(root / "rank_7" / "nex-1_output.csv"));
+        EXPECT_FALSE(fs::exists(root / "nex-1_output.csv"));
+    }
+    fs::remove_all(root);
+}


### PR DESCRIPTION
This PR features a core optimization needed for CONUS scale runs on a distributed file system, namely output aggregation. In its current form, ngen will create a single catchment output file for each divide being modeled, and put them in `output_root`.  On a distributed file system, this consumes a lot of open file handles, and introduces contention at initialization in creating all the output files.

A *simple* aggregation method was implemented to work around this, but required touching a lot of the output code to bring into a form that was mergable (e.g. configurability, testing, ect...).

So this PR was motivated primarily by two distributed-filesystem optimizations: per-rank catchment output aggregation, and a per-rank subdirectory for nexus CSV output:

d7680649a feat(output): per-rank subdirectory for nexus CSV output

(the nexus optimization being somewhat subsumed by the netcdf nexus output feature).

Since getting the catchment aggregation mechanism properly implemented would have touched a significant portion of the catchment I/O code, it was decided to tackle a long overdue refactor of the model output mechanics.  The refactor establishes an abstract output-manager interface (similar to the NexusOutputManager) and cuts all csv/string output handling out of the core formulations, which now deal in typed (double) outputs and a positionally aligned header vector.  The catchment aggregation mechanism rides directly on this manager, so it lands together with the abstraction:

9965a7635 feat(output): add catchment output manager abstraction (CSV backend)

The ability to actually *use* aggregation requires some configuration management, introduced in

5e72e762f feat(output): add the output configuration block

which encapsulates output configuration for parsing from the realization configuration file (and it maintains backwards compatibility, for now).

With the configuration in place, a factory selects and constructs the appropriate manager from that configuration:

257d982dd feat(output): select and route catchment output through the configuration

The driver and layers are then wired to build output managers via that factory and route formulation output through them (formulations supply typed values; the manager owns the file layout, including aggregation):

42909c46f refactor(output): route catchment output through the manager

The last functional part is the distributed-filesystem optimization for nexus csv outputs, letting each rank store its outputs in a sub-directory to reduce locking contention:

d7680649a feat(output): per-rank subdirectory for nexus CSV output

this feature was implemented on the existing nexus csv manager, with configuration mechanics built on top of 5e72e762f.

Finally, documentation for the new output configuration block:

6a01598dc docs(config): document the output configuration block

Sorry for the roundabout history/description there.  All that to say, reviewing in commit order may be most helpful, using this description as the guide post.


## Additions

- `utils::CatchmentOutputsMgr` — an abstract, typed catchment-output interface modeled on `NexusOutputsMgr`, keyed by `(formulation_id, catchment_id)`, with a CSV backend `CatchmentCsvOutputMgr`.
- Per-rank aggregated catchment CSV: all of a rank's catchments in one shared file (leading `catchment_id` column, header written once) as an alternative to one file per catchment.
- `realizations::config::Output` — a parsed `output` config block: per-domain (catchment/nexus) `enable` / `format` / `grouping` / `rank_subdir` plus a global value `precision`, with fallback to the deprecated top-level keys; also normalizes the output root (trailing-slash) at construction, without touching the filesystem — the managers create their own directories.
- `realization::config::make_catchment_output_mgr` — factory that builds the backend and layout from the parsed config.
- Per-rank subdirectory (`rank_<N>/`) for nexus CSV output under MPI.
- Unit tests: `Output_Test` (config parsing/resolution), `CatchmentOutput_Test` (factory selection), `CatchmentCsvOutputMgr_Test` (CSV layouts), `PerNexusCsvOutputMgr_Test` (nexus subdir).

## Removals

- Catchment-output responsibility removed from `HY_Features` / `HY_Features_MPI` — features are now topology-only; the driver owns the manager.
- Legacy string-projection formulation output API (`get_output_header_line` / `get_output_line_for_timestep`) and the dead `HY_CatchmentArea::set_output_stream` / `write_output`.
- Per-field output accessors on `Formulation_Manager` (`get_output_root`, `is_disable_catchment_output`, `is_using_per_formulation_nexus_files`) — consolidated into a single `get_output_config()`.

## Changes

- Formulations now expose typed output — `get_output_fields()` (hoisted to `Catchment_Formulation`) and a new `get_output_values_for_timestep()` returning `vector<double>` — replacing the string/stream path.
- `NGen` constructs, registers per catchment, and injects the catchment output manager into the layers; output is committed once at end-of-run.
- `DomainLayer` output is keyed as `(formulation_id="layer_<id>", catchment_id=<name>)`, writing to `<root>layer_<id>/<name>.csv`.
- The parsed `Output` struct is the single source of truth; deprecated top-level keys are honored only through its construction, so existing configs are unaffected (with a one-time deprecation warning).

## Testing

1. Build from the build root, then run the affected suites (verified locally, macOS/Clang with MPI + NetCDF + Python):
   - `test_realization_config` — **24 passed** (Output parsing/resolution, factory selection, `Formulation_Manager` construction + one real-formulation integration)
   - `test_catchment_output_mgr` — **7 passed** (per-feature, aggregated header-once + split-by-formulation, per-formulation subdir, throw-after-close, throw-on-unregistered-catchment, precision rendering)
   - `test_nexus_output` — **2 passed** (nexus per-rank subdir)
2. The BMI formulation suites (`Bmi_*_Formulation_Test`) were updated for the typed output API; run the full set via `ctest` / CI for the remaining suites.

## Notes

- Behavior-preserving by default: `grouping=per_feature` keeps the long-standing flat `<root><catchment_id>.csv`; aggregation and rank subdirs are opt-in via config.
- CSV is the only backend today. The interface is data-push (no formulation-type dependency), so a NetCDF/parquet backend can be added as a sibling without touching formulations; non-CSV formats currently throw.

## Todos

- Once merged, the wiki will need updated as well based on the configuration keys/changes.
- This refactor enables several possible next steps which should come as separate PR's
- One critical TODO: There is now significant dead code that should be removed, but I think that's best left as a follow up PR to keep this reviewable. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts) — branch is based on current `origin/master` (0 commits behind)
- [x] Code follows project standards
- [x] Passes all existing automated tests — *output-related suites verified locally; full suite via CI (see Testing)*
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

All newly added and refactored tests have been run/passed locally

### Target Environment support

- [x] Linux
- [x] MacOS
