### PR TITLE
refactor: netcdf cache offsetting and index manipulation logic

### DIFF
--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -494,18 +494,86 @@ size_t NetCDFPerFeatureDataProvider::get_ts_index_for_time(const time_t &epoch_t
     }
 }
 
+namespace cache {
+    std::size_t page_count(std::size_t c_size, std::size_t line_size) {
+        return (c_size / line_size) + std::min<std::size_t>(1, c_size % line_size);
+    }
+
+    std::size_t page_p_idx(std::size_t c_idx, std::size_t line_size) {
+        return c_idx / line_size;
+    }
+
+    std::size_t page_c_idx(std::size_t c_idx, std::size_t line_size) {
+        std::size_t p_idx = page_p_idx(c_idx, line_size);
+        return p_idx * line_size;
+    }
+
+    std::size_t page_p_idx_to_c_idx(std::size_t p_idx, std::size_t line_size) {
+        return p_idx * line_size;
+    }
+
+    std::size_t page_entry_j_idx(std::size_t c_idx, std::size_t line_size) {
+        return c_idx - page_c_idx(c_idx, line_size);
+    }
+
+    std::size_t page_cache_line_size(std::size_t c_idx, std::size_t c_size, std::size_t line_size) {
+        std::size_t ps = page_count(c_size, line_size);
+        std::size_t p_idx = page_p_idx(c_idx, line_size);
+        assert(p_idx < ps);
+        if (p_idx < ps - 1) {
+            return line_size;
+        }
+        std::size_t ts = page_c_idx(c_idx, line_size);
+        return c_size - ts;
+    }
+
+    std::size_t page_entry_idx(std::size_t i_idx, std::size_t c_idx, std::size_t c_size, std::size_t line_size) {
+        std::size_t pls = page_cache_line_size(c_idx, c_size, line_size);
+        // NOTE: this is relative to the default line size
+        std::size_t pj_idx = page_entry_j_idx(c_idx, line_size);
+        return (pls * i_idx) + pj_idx;
+    }
+}
+
+
 double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& selector, ReSampleMethod m) 
 {
+    /*
+     * this cache is made up of pages.
+     * each page contains cache lines.
+     * a page is a flattened 2d array with dimensions catchment-id, time (i, j).
+     * connecting pages contiguously along cache lines (left-to-right), forms the time series.
+     * this implicit dimension is named the 'c' dimension.
+     * the 'c' dimension is the (page idx + page relative cache line j idx) * cache line size.
+     * 'c' is a forcing time step idx.
+     *
+     * each line, dim i, contains forcing data for a cache line sized time period for a single catchment.
+     * there are n cache lines in a page.
+     * n is the number of catchments a single ngen process is responsible for.
+     * pages are divided by _cache line size_ (index p).
+     * cache line size equates to n forcing time steps.
+     * a page only contains data for a single forcing variable.
+     *
+     * if the forcing time dim size is not divisible by the cache line size,
+     * the last cache page will have a cache line length = forcing time dim size % cache line size.
+     *
+     * dimensions and index naming conventions:
+     * i dim: cache line index (rows)
+     * j dim: cache line columns relative to page
+     * c dim: columns across all cache lines (not relative to page)
+     * p dim: page index
+     */
+
     auto init_time = selector.get_init_time();
     auto stop_time = init_time + selector.get_duration_secs(); // scope hiding! BAD JUJU!
     
-    size_t idx1 = get_ts_index_for_time(init_time);
-    size_t idx2;
+    size_t c_idx1 = get_ts_index_for_time(init_time);
+    size_t c_idx2;
     try {
-        idx2 = get_ts_index_for_time(stop_time-1); // Don't include next timestep when duration % timestep = 0
+        c_idx2 = get_ts_index_for_time(stop_time-1); // Don't include next timestep when duration % timestep = 0
     }
     catch(const std::out_of_range &e){
-        idx2 = get_ts_index_for_time(this->stop_time-1); //to the edge
+        c_idx2 = get_ts_index_for_time(this->stop_time-1); //to the edge
     }
 
     // update chunks during the first timestep
@@ -515,14 +583,14 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
         maybe_update_chunks_with_hints();
     }
 
-    auto stride = idx2 - idx1;
+    auto stride = c_idx2 - c_idx1;
 
     std::vector<std::size_t> start, count;
 
-    auto cat_idx = id_pos[selector.get_id()];
+    auto i_idx = id_pos[selector.get_id()];
 
-    double t1 = time_vals[idx1];
-    double t2 = time_vals[idx2];
+    double t1 = time_vals[c_idx1];
+    double t2 = time_vals[c_idx2];
 
     double rvalue = 0.0;
     
@@ -530,43 +598,36 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
 
     std::string native_units = get_ncvar_units(selector.get_variable_name());
 
-    const std::size_t read_len = idx2 - idx1 + 1;
+    const std::size_t read_len = c_idx2 - c_idx1 + 1;
 
     std::vector<double> raw_values;
     raw_values.reserve(read_len);
 
-    std::size_t idx1_cache_slice_start = idx1 - (idx1 % cache_slice_t_size);
-    std::size_t time_idx = idx1 % cache_slice_t_size;
+    std::size_t cache_line_size = cache_slice_t_size;
+    std::size_t p_idx = cache::page_p_idx(c_idx1, cache_line_size);
+    // pages spanned by [c_idx1, c_idx2]; ceil(read_len / line_size) undercounts
+    // when the range starts mid-page and crosses a page boundary
+    std::size_t n_page_accesses = cache::page_p_idx(c_idx2, cache_line_size) - p_idx + 1;
 
-    std::size_t n_cache_slices = (read_len / cache_slice_t_size) + std::min(read_len % cache_slice_t_size, std::size_t(1));
-    size_t value_idx = idx1;
+    std::size_t c_idx = c_idx1;
     // For reference: https://stackoverflow.com/a/72030286
-    for( size_t i = 0; i < n_cache_slices; i++ ) {
+    for( size_t i = 0; i < n_page_accesses; i++ ) {
         // rows: catchments; columns: time;
-        // stride between rows is 'cache_slice_t_size'
+        // stride between rows is 'cache_line_size'
         std::shared_ptr<std::vector<double>> cached;
 
-        std::size_t cache_slice_start = idx1_cache_slice_start + (i * cache_slice_t_size);
-        std::size_t adjusted_size = cache_slice_t_size;
-        // Read up to the end of the data, but not beyond
-        if(cache_slice_start + cache_slice_t_size > time_vals.size() ){
-            adjusted_size = time_vals.size() - cache_slice_start;
-        }
-        std::string key = ncvar.getName() + "|" + std::to_string(cache_slice_start);
+	std::size_t ith_p_idx = p_idx + i;
+	std::size_t page_c_idx = cache::page_p_idx_to_c_idx(ith_p_idx, cache_line_size);
+	std::size_t page_cache_line_size = cache::page_cache_line_size(page_c_idx, time_vals.size(), cache_line_size);
+
+        std::string key = ncvar.getName() + "|" + std::to_string(page_c_idx);
         if(value_cache.contains(key)){
             cached = value_cache.get(key).get();
         } else {
-            // NOTE: aaraney: I am leaning towards just 'over allocating'
-            /* size_t last_bucket = get_ts_index_for_time(this->stop_time-1) / bucket_size; */
-            /* assert(bucket_idx <= last_bucket); */
-            /* size_t n_time = bucket_size; */
-            /* if (bucket_idx == last_bucket){ */
-            /*     n_time = (get_ts_index_for_time(this->stop_time-1) % bucket_size) + 1; */
-            /* } */
-            cached = std::make_shared<std::vector<double>>(get_ids().size() *  cache_slice_t_size);
+            cached = std::make_shared<std::vector<double>>(get_ids().size() * page_cache_line_size);
 
             // read each chunk and add it to "cached"
-            std::size_t next_cache_idx = 0;
+            std::size_t idx = 0;
             for(auto const& chunk: chunks){
                 // chunk start index = chunk.first;
                 // chunk length      = chunk.second;
@@ -575,27 +636,29 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
 
                 // NOTE: in the first iteration, we might read more data in the Time
                 // dimension than we 'need'. b.c. we read from:
-                // 'idx1 - (idx1 % cache_slice_t_size)' to the end of the cache line.
-                // so, if 'idx1 % cache_slice_t_size > 0' we will read
-                // 'idx1 % cache_slice_t_size * next_chunk_idx' more values than we 'need' to.
-                start.push_back(cache_slice_start);
+                // 'c_idx1 - (c_idx1 % cache_slice_t_size)' to the end of the cache line.
+                // so, if 'c_idx1 % cache_slice_t_size > 0' we will read
+                // 'c_idx1 % cache_slice_t_size * next_chunk_idx' more values than we 'need' to.
+                start.push_back(page_c_idx);
 
                 count.clear();
                 count.push_back(chunk.second);
 
-                count.push_back(adjusted_size);
-                ncvar.getVar(start,count,&(*cached)[next_cache_idx]);
-                next_cache_idx += chunk.second * adjusted_size;
+                count.push_back(page_cache_line_size);
+                ncvar.getVar(start,count,&(*cached)[idx]);
+                idx += chunk.second * page_cache_line_size;
             }
 
             value_cache.insert(key, cached);
         }
         // Find all values in the current cache slice and push them onto raw_values
-        while(value_idx >= cache_slice_start && 
-              value_idx < cache_slice_start + cache_slice_t_size &&
-              value_idx <= idx2){
-            raw_values.push_back(cached->at((cat_idx * cache_slice_t_size) + (value_idx % cache_slice_t_size)));
-            value_idx++;
+        while(c_idx >= page_c_idx &&
+              c_idx < page_c_idx + page_cache_line_size &&
+              c_idx <= c_idx2){
+            std::size_t idx = cache::page_entry_idx(i_idx, c_idx, time_vals.size(), cache_line_size);
+            double value = cached->at(idx);
+            raw_values.push_back(value);
+            c_idx++;
         }
     }
 

--- a/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
+++ b/test/forcing/NetCDFPerFeatureDataProvider_Test.cpp
@@ -2,6 +2,8 @@
 
 #if NGEN_WITH_NETCDF
 #include <vector>
+#include <cstdio>
+#include <netcdf>
 #include "gtest/gtest.h"
 #include "NetCDFPerFeatureDataProvider.hpp"
 #include "StreamHandler.hpp"
@@ -218,6 +220,155 @@ TEST_F(NetCDFPerFeatureDataProviderTest, TestForcingDataRead)
         double val4 = nc_provider.get_value(CatchmentAggrDataSelector(ids[0], "T3D", start_time, duration, "K"), data_access::MEAN);,
         std::runtime_error);
 
+}
+
+// Regression tests for the paged value cache in get_value().
+// Files are generated on the fly so the time dimension size and the NetCDF
+// chunking (which determines the cache line size) can be controlled exactly.
+class NetCDFCacheLayoutTest : public ::testing::Test {
+  protected:
+    void TearDown() override {
+        for (const auto& p : temp_files) {
+            std::remove(p.c_str());
+        }
+    }
+
+    static double cellValue(std::size_t cat, std::size_t t) {
+        return 100.0 * cat + t;
+    }
+
+    // Creates a forcing file with n_cats catchments ("cat-0".."cat-N"), n_times
+    // hourly timesteps starting at kStartEpoch, and one variable "temp" (units K)
+    // holding cellValue(cat, t). time_chunk == 0 leaves the variable contiguous.
+    std::string makeForcing(const std::string& name, std::size_t n_cats, std::size_t n_times, std::size_t time_chunk) {
+        std::string path = "./" + name;
+        temp_files.push_back(path);
+
+        netCDF::NcFile out(path, netCDF::NcFile::replace, netCDF::NcFile::nc4);
+        auto cat_dim = out.addDim("catchment-id", n_cats);
+        auto time_dim = out.addDim("time", n_times);
+        std::vector<netCDF::NcDim> dims = {cat_dim, time_dim};
+
+        std::vector<std::string> id_strs;
+        std::vector<const char*> id_ptrs;
+        for (std::size_t i = 0; i < n_cats; ++i) {
+            id_strs.push_back("cat-" + std::to_string(i));
+        }
+        for (const auto& s : id_strs) {
+            id_ptrs.push_back(s.c_str());
+        }
+        auto ids_var = out.addVar("ids", netCDF::ncString, cat_dim);
+        ids_var.putVar(id_ptrs.data());
+
+        auto time_var = out.addVar("Time", netCDF::ncDouble, dims);
+        time_var.putAtt("units", "seconds since 1970-01-01 00:00:00");
+        std::vector<double> times(n_cats * n_times);
+        for (std::size_t i = 0; i < n_cats; ++i) {
+            for (std::size_t t = 0; t < n_times; ++t) {
+                times[i * n_times + t] = kStartEpoch + t * kStride;
+            }
+        }
+        time_var.putVar(times.data());
+
+        auto temp_var = out.addVar("temp", netCDF::ncDouble, dims);
+        temp_var.putAtt("units", "K");
+        if (time_chunk > 0) {
+            std::vector<std::size_t> chunk_sizes = {n_cats, time_chunk};
+            temp_var.setChunking(netCDF::NcVar::nc_CHUNKED, chunk_sizes);
+        }
+        std::vector<double> vals(n_cats * n_times);
+        for (std::size_t i = 0; i < n_cats; ++i) {
+            for (std::size_t t = 0; t < n_times; ++t) {
+                vals[i * n_times + t] = cellValue(i, t);
+            }
+        }
+        temp_var.putVar(vals.data());
+
+        return path;
+    }
+
+    static double readStep(NetCDFPerFeatureDataProvider& p, std::size_t cat, std::size_t t) {
+        CatchmentAggrDataSelector sel("cat-" + std::to_string(cat), "temp",
+                                      kStartEpoch + t * kStride, kStride, "K");
+        return p.get_value(sel, data_access::MEAN);
+    }
+
+    static constexpr time_t kStartEpoch = 1500000000;
+    static constexpr time_t kStride = 3600;
+    std::vector<std::string> temp_files;
+};
+
+// A file with fewer timesteps than the default cache line size (24) produces a
+// single page whose line length is the whole time dimension.
+TEST_F(NetCDFCacheLayoutTest, SinglePageShorterThanCacheLine)
+{
+    const std::size_t n_cats = 3, n_times = 10;
+    auto path = makeForcing("nc_cache_single_page.nc", n_cats, n_times, 0);
+    NetCDFPerFeatureDataProvider provider(path, kStartEpoch, kStartEpoch + n_times * kStride, utils::getStdErr());
+
+    for (std::size_t cat = 0; cat < n_cats; ++cat) {
+        for (std::size_t t = 0; t < n_times; ++t) {
+            EXPECT_DOUBLE_EQ(readStep(provider, cat, t), cellValue(cat, t))
+                << "cat=" << cat << " t=" << t;
+        }
+    }
+
+    // whole-range aggregate read within the single page
+    CatchmentAggrDataSelector all("cat-1", "temp", kStartEpoch, n_times * kStride, "K");
+    double expected_sum = 0;
+    for (std::size_t t = 0; t < n_times; ++t) {
+        expected_sum += cellValue(1, t);
+    }
+    EXPECT_DOUBLE_EQ(provider.get_value(all, data_access::SUM), expected_sum);
+}
+
+// A time dimension not divisible by the cache line size leaves a shorter final
+// page; per-catchment reads there must use the final page's row stride.
+TEST_F(NetCDFCacheLayoutTest, PartialLastPageRead)
+{
+    const std::size_t n_cats = 3, n_times = 50, chunk = 24; // pages: 24, 24, 2
+    auto path = makeForcing("nc_cache_partial_page.nc", n_cats, n_times, chunk);
+    NetCDFPerFeatureDataProvider provider(path, kStartEpoch, kStartEpoch + n_times * kStride, utils::getStdErr());
+
+    for (std::size_t cat = 0; cat < n_cats; ++cat) {
+        for (std::size_t t = 0; t < n_times; ++t) {
+            EXPECT_DOUBLE_EQ(readStep(provider, cat, t), cellValue(cat, t))
+                << "cat=" << cat << " t=" << t;
+        }
+    }
+}
+
+// A multi-timestep read whose range starts mid-page and crosses a page
+// boundary must access every page the range spans.
+TEST_F(NetCDFCacheLayoutTest, ReadStraddlesPageBoundary)
+{
+    const std::size_t n_cats = 3, n_times = 50, chunk = 24; // pages: 24, 24, 2
+    auto path = makeForcing("nc_cache_straddle.nc", n_cats, n_times, chunk);
+    NetCDFPerFeatureDataProvider provider(path, kStartEpoch, kStartEpoch + n_times * kStride, utils::getStdErr());
+
+    double tol = 1e-9;
+
+    // timesteps 23..24 straddle the boundary between pages 0 and 1
+    CatchmentAggrDataSelector two("cat-1", "temp", kStartEpoch + 23 * kStride, 2 * kStride, "K");
+    EXPECT_NEAR(provider.get_value(two, data_access::MEAN),
+                (cellValue(1, 23) + cellValue(1, 24)) / 2.0, tol);
+
+    // timesteps 44..49 span page 1 and the partial final page
+    CatchmentAggrDataSelector six("cat-2", "temp", kStartEpoch + 44 * kStride, 6 * kStride, "K");
+    double expected_mean = 0;
+    for (std::size_t t = 44; t < 50; ++t) {
+        expected_mean += cellValue(2, t);
+    }
+    expected_mean /= 6.0;
+    EXPECT_NEAR(provider.get_value(six, data_access::MEAN), expected_mean, tol);
+
+    // the whole series spans all three pages
+    CatchmentAggrDataSelector all("cat-0", "temp", kStartEpoch, n_times * kStride, "K");
+    double expected_sum = 0;
+    for (std::size_t t = 0; t < n_times; ++t) {
+        expected_sum += cellValue(0, t);
+    }
+    EXPECT_NEAR(provider.get_value(all, data_access::SUM), expected_sum, tol);
 }
 
 // Each recognized time `units` token maps to the expected unit and scale factor,


### PR DESCRIPTION
Refactor the netcdf cache offsetting and index manipulation functions. This hopefully cleans up the logic a bit and makes it a little easier to follow and reason about (please be the judge of that :)). This also fixes a bug when the total forcing time steps are not divisible by the cache line size.

I still need to add tests, but a first review would be great! Thanks!