### PR TITLE
Default to building automated things with BMI C enabled, to catch more build failures

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -18,7 +18,7 @@ inputs:
     bmi_c:
       required: false
       description: 'Activate C BMI library support'
-      default: 'OFF'
+      default: 'ON'
     bmi_fortran:
       required: false
       description: 'Activate Fortran BMI library support'

--- a/docker/ngen.dockerfile
+++ b/docker/ngen.dockerfile
@@ -29,7 +29,7 @@ RUN cmake -S . \
           -DNGEN_WITH_SQLITE:BOOL=OFF \
           -DNGEN_WITH_UDUNITS:BOOL=ON \
           -DNGEN_WITH_BMI_FORTRAN:BOOL=OFF \
-          -DNGEN_WITH_BMI_C:BOOL=OFF \
+          -DNGEN_WITH_BMI_C:BOOL=ON \
           -DNGEN_WITH_PYTHON:BOOL=OFF \
           -DNGEN_WITH_TESTS:BOOL=ON \
           -DNGEN_QUIET:BOOL=ON \


### PR DESCRIPTION
## Changes

- Enable BMI C support in Dockerfile
- Enable BMI C support in CI workflows

## Testing

1. Local build
2. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: