### PR TITLE
Move Formulation_Constructor's dependence on individual forcing implementations from header to source file

### DIFF
--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -13,11 +13,6 @@
 // Formulations
 #include "Bmi_Formulation.hpp"
 #include <GenericDataProvider.hpp>
-#include "CsvPerFeatureForcingProvider.hpp"
-#include "NullForcingProvider.hpp"
-#if NGEN_WITH_NETCDF
-    #include "NetCDFPerFeatureDataProvider.hpp"
-#endif
 
 namespace realization {
     using constructor = std::shared_ptr<Catchment_Formulation> (*)(std::string, std::shared_ptr<data_access::GenericDataProvider>, utils::StreamHandler);
@@ -36,61 +31,11 @@ namespace realization {
         return formulation_constructors.count(formulation_type) > 0;
     }
 
-    static std::shared_ptr<Catchment_Formulation> construct_formulation(
+    std::shared_ptr<Catchment_Formulation> construct_formulation(
         std::string formulation_type,
         std::string identifier,
         forcing_params &forcing_config,
-        utils::StreamHandler output_stream
-    ) {
-        constructor formulation_constructor = formulation_constructors.at(formulation_type);
-
-        std::shared_ptr<data_access::GenericDataProvider> fp;
-        if (forcing_config.provider == "CsvPerFeature" || forcing_config.provider == ""){
-            fp = std::make_shared<CsvPerFeatureForcingProvider>(forcing_config);
-        }
-#if NGEN_WITH_NETCDF
-        else if (forcing_config.provider == "NetCDF"){
-            // Note: The stream mechanics of the formulations and formulation manager are
-            // are strictly speaking indepdent of the log output stream here.  The "default" output
-            // stream likely coming into this function is the null stream, but we don't want to force the forcing provider 
-            // to also use the null stream for any logging it may do, 
-            // so we use the standard output stream for the forcing provider by default.
-            // TODO: this likely needs to be rethought and refactored, but for now, 
-            // this allows the NetCDF provider to log to standard output while still allowing
-            // formulations to log to their own output streams as needed.
-            std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> f;
-            f = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
-            // TODO: this is not _ideal_ but implements the idea.
-            // refactor in the future.
-            f->hint_shared_provider_id(identifier);
-            fp = f;
-        }
-#endif
-        else if (forcing_config.provider == "NullForcingProvider"){
-            fp = std::make_shared<NullForcingProvider>();
-        }
-        else { // Some unknown string in the provider field?
-            throw std::runtime_error(
-                    "Invalid formulation forcing provider configuration! identifier: \"" + identifier +
-                    "\", formulation_type: \"" + formulation_type +
-                    "\", provider: \"" + forcing_config.provider + "\"");
-        }
-        return formulation_constructor(identifier, fp, output_stream);
-    }
-
-    static std::string get_formulation_key(const boost::property_tree::ptree &tree) {
-        /*for (auto &node : tree) {
-            if (formulation_exists(node.first)) {
-                return node.first;
-            }
-        }*/
-        boost::optional<std::string> key = tree.get_optional<std::string>("name");
-        if(key && formulation_exists(*key)){
-          return *key;
-        }
-
-        throw std::runtime_error("No valid formulation for " + *key + " was described in the passed in tree.");
-    }
+        utils::StreamHandler output_stream);
 }
 
 #endif // NGEN_FORMULATION_CONSTRUCTORS_H

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -28,10 +28,6 @@
 #include "realizations/config/layer.hpp"
 #include "realizations/config/output.hpp"
 
-#if NGEN_WITH_NETCDF
-    #include "NetCDFPerFeatureDataProvider.hpp"
-#endif
-
 namespace realization {
 
     class Formulation_Manager {
@@ -257,30 +253,7 @@ namespace realization {
              *
              * In particular, this should be called before MPI_Finalize()
              */
-            void finalize() {
-                // The calls in these loops are staticly dispatched to
-                // Catchment_Formulation::finalize(). That does not
-                // inherit from DataProvider, with its virtual member
-                // function of the same name.
-                //
-                // If any formulation class needs to customize this
-                // behavior through this becoming a virtual dispatch,
-                // take care. Bmi_Multi_Formulation was a concern, but
-                // does not currently need to because none of its
-                // constituent formulations points to any forcing
-                // object other than the enclosing
-                // Bmi_Multi_Formulation instance itself.
-                for (auto const& fmap: formulations) {
-                    fmap.second->finalize();
-                }
-                for (auto const& fmap: domain_formulations) {
-                    fmap.second->finalize();
-                }
-
-#if NGEN_WITH_NETCDF
-                data_access::NetCDFPerFeatureDataProvider::cleanup_shared_providers();
-#endif
-            }
+            void finalize();
 
             /**
              * Parse the output configuration from the realization tree (preferring

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -28,6 +28,10 @@
 #include "realizations/config/layer.hpp"
 #include "realizations/config/output.hpp"
 
+#if NGEN_WITH_NETCDF
+    #include "NetCDFPerFeatureDataProvider.hpp"
+#endif
+
 namespace realization {
 
     class Formulation_Manager {

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -61,6 +61,8 @@
 #include "utilities/output/PerFormulationNexusOutputMgr.hpp"
 #endif
 
+#include <mediator/UnitsHelper.hpp>
+
 void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept
 {
     stream << "Runtime configuration summary:\n";

--- a/src/realizations/catchment/CMakeLists.txt
+++ b/src/realizations/catchment/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(realizations_catchment PUBLIC
         ${CMAKE_DL_LIBS}
         NGen::config_header
         NGen::core_catchment
+        NGen::forcing
         NGen::geojson
         NGen::logging
         NGen::ngen_bmi

--- a/src/realizations/catchment/Formulation_Constructors.cpp
+++ b/src/realizations/catchment/Formulation_Constructors.cpp
@@ -29,6 +29,62 @@ namespace realization {
         };
     }
 
+    static std::string get_formulation_key(const boost::property_tree::ptree &tree) {
+        /*for (auto &node : tree) {
+            if (formulation_exists(node.first)) {
+                return node.first;
+            }
+        }*/
+        boost::optional<std::string> key = tree.get_optional<std::string>("name");
+        if(key && formulation_exists(*key)){
+          return *key;
+        }
+
+        throw std::runtime_error("No valid formulation for " + *key + " was described in the passed in tree.");
+    }
+
+    std::shared_ptr<Catchment_Formulation> construct_formulation(
+        std::string formulation_type,
+        std::string identifier,
+        forcing_params &forcing_config,
+        utils::StreamHandler output_stream
+    ) {
+        constructor formulation_constructor = formulation_constructors.at(formulation_type);
+
+        std::shared_ptr<data_access::GenericDataProvider> fp;
+        if (forcing_config.provider == "CsvPerFeature" || forcing_config.provider == ""){
+            fp = std::make_shared<CsvPerFeatureForcingProvider>(forcing_config);
+        }
+#if NGEN_WITH_NETCDF
+        else if (forcing_config.provider == "NetCDF"){
+            // Note: The stream mechanics of the formulations and formulation manager are
+            // are strictly speaking indepdent of the log output stream here.  The "default" output
+            // stream likely coming into this function is the null stream, but we don't want to force the forcing provider
+            // to also use the null stream for any logging it may do,
+            // so we use the standard output stream for the forcing provider by default.
+            // TODO: this likely needs to be rethought and refactored, but for now,
+            // this allows the NetCDF provider to log to standard output while still allowing
+            // formulations to log to their own output streams as needed.
+            std::shared_ptr<data_access::NetCDFPerFeatureDataProvider> f;
+            f = data_access::NetCDFPerFeatureDataProvider::get_shared_provider(forcing_config.path, forcing_config.simulation_start_t, forcing_config.simulation_end_t, utils::getStdOut());
+            // TODO: this is not _ideal_ but implements the idea.
+            // refactor in the future.
+            f->hint_shared_provider_id(identifier);
+            fp = f;
+        }
+#endif
+        else if (forcing_config.provider == "NullForcingProvider"){
+            fp = std::make_shared<NullForcingProvider>();
+        }
+        else { // Some unknown string in the provider field?
+            throw std::runtime_error(
+                    "Invalid formulation forcing provider configuration! identifier: \"" + identifier +
+                    "\", formulation_type: \"" + formulation_type +
+                    "\", provider: \"" + forcing_config.provider + "\"");
+        }
+        return formulation_constructor(identifier, fp, output_stream);
+    }
+
     std::map<std::string, constructor> formulation_constructors = {
         {"bmi_c++", create_formulation_constructor<Bmi_Cpp_Formulation>()},
 #if NGEN_WITH_BMI_C

--- a/src/realizations/catchment/Formulation_Manager.cpp
+++ b/src/realizations/catchment/Formulation_Manager.cpp
@@ -1,6 +1,36 @@
 #include <Formulation_Manager.hpp>
 
+#if NGEN_WITH_NETCDF
+    #include "NetCDFPerFeatureDataProvider.hpp"
+#endif
+
 using namespace realization;
+
+void Formulation_Manager::finalize() {
+    // The calls in these loops are staticly dispatched to
+    // Catchment_Formulation::finalize(). That does not
+    // inherit from DataProvider, with its virtual member
+    // function of the same name.
+    //
+    // If any formulation class needs to customize this
+    // behavior through this becoming a virtual dispatch,
+    // take care. Bmi_Multi_Formulation was a concern, but
+    // does not currently need to because none of its
+    // constituent formulations points to any forcing
+    // object other than the enclosing
+    // Bmi_Multi_Formulation instance itself.
+    for (auto const& fmap: formulations) {
+        fmap.second->finalize();
+    }
+    for (auto const& fmap: domain_formulations) {
+        fmap.second->finalize();
+    }
+
+#if NGEN_WITH_NETCDF
+    data_access::NetCDFPerFeatureDataProvider::cleanup_shared_providers();
+#endif
+}
+
 /*
 template<class realization_type>
 Realization_Manager<realization_type>::Realization_Manager(std::stringstream &data) {

--- a/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_C_Formulation_Test.cpp
@@ -25,6 +25,7 @@
 #include "Formulation_Manager.hpp"
 #include <boost/date_time.hpp>
 #include "../../utils/bmi/MockConfig.hpp"
+#include <forcing/CsvPerFeatureForcingProvider.hpp>
 using ::testing::MatchesRegex;
 using namespace realization;
 

--- a/test/realizations/catchments/Bmi_C_Pet_IT.cpp
+++ b/test/realizations/catchments/Bmi_C_Pet_IT.cpp
@@ -18,6 +18,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include "FileChecker.h"
 #include "Formulation_Manager.hpp"
+#include <forcing/CsvPerFeatureForcingProvider.hpp>
 
 using namespace realization;
 using namespace std;

--- a/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Cpp_Formulation_Test.cpp
@@ -24,6 +24,7 @@
 #include "FileChecker.h"
 #include "Formulation_Manager.hpp"
 #include <boost/date_time.hpp>
+#include <forcing/CsvPerFeatureForcingProvider.hpp>
 
 using namespace realization;
 

--- a/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
+++ b/test/realizations/catchments/Bmi_Fortran_Formulation_Test.cpp
@@ -16,6 +16,7 @@
 #include "Bmi_Module_Formulation.hpp"
 #include "Bmi_Fortran_Formulation.hpp"
 #include "Bmi_Fortran_Adapter.hpp"
+#include "CsvPerFeatureForcingProvider.hpp"
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include <iostream>


### PR DESCRIPTION
## Changes

- Move code from `Formulation_Constructors` header to source file, so we don't need to include all of the Forcing's headers in it.

## Testing

1. Local build
2. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
