### PR TITLE
add a compound_id which can compose a feature identifier along with with module identifiers into a single id

### DIFF
--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -140,6 +140,43 @@ namespace realization {
         }
 
         /**
+         * Get this formulation instance's compound identity.
+         *
+         * Default composition for a single-BMI formulation:
+         *   "<this->id>:<model_type_name>"             e.g. "cat-1:bmi_c_cfe"
+         *
+         * For a Bmi_Multi_Formulation submodule, `Bmi_Multi_Formulation`
+         * injects a three-part compound via `set_compound_id()` before
+         * `create_formulation()` runs:
+         *   "<this->id>:<submodule-mtn>:<multi-mtn>"   e.g. "cat-1.0:bmi_c_cfe:bmi_multi_noahowp_cfe"
+         *
+         * Uniqueness
+         * ------------------------------
+         * The composition is unique in practice: single-BMI keys are
+         * unique because `id` is a catchment identifier and one catchment
+         * has at most one realization; multi-submodule keys are unique
+         * because the submodule index suffix in `this->id` (e.g. the `.0`
+         * in `cat-1.0`) already disambiguates siblings even when two
+         * submodules share a `model_type_name`.
+         *
+         * One scenario that could break that assumption in the future:
+         * if the engine ever instantiates two *different* multi
+         * formulations for the same `id` (e.g. A/B comparison runs on
+         * the same catchment within a single process), the outer
+         * `<multi-mtn>` suffix becomes the sole discriminator and must
+         * actually differ. Callers would need to set distinct
+         * `model_type_name` values on the two multi formulations, or
+         * pass a unique string via `set_compound_id()`.
+         *
+         * @return The compound identity string, or the default composition
+         *         when `set_compound_id` was never called.
+         */
+        std::string compound_id() const {
+            if (!compound_id_.empty()) return compound_id_;
+            return id + ":" + model_type_name;
+        }
+
+        /**
          * Get the names of variables in formulation output.
          *
          * Get the names of the variables to include in the output from this formulation, which should be some ordered
@@ -210,6 +247,18 @@ namespace realization {
             model_type_name = std::move(type_name);
         }
 
+        /**
+         * Override this formulation's compound identity.
+         *
+         * Callable (notably `Bmi_Multi_Formulation` during
+         * submodule setup) when the default `compound_id()` composition
+         * isn't appropriate — e.g., to prepend multi-formulation context
+         * An empty string restores the default.
+         */
+        void set_compound_id(std::string id_string) {
+            compound_id_ = std::move(id_string);
+        }
+
         void set_output_header_fields(const std::vector<std::string> &output_headers) {
             output_header_fields = output_headers;
         }
@@ -239,6 +288,9 @@ namespace realization {
 
         std::string bmi_main_output_var;
         std::string model_type_name;
+        /** Explicit compound identity override. Empty string signals the default
+         *  `<id>:<model_type_name>` in `compound_id()`. */
+        std::string compound_id_;
         /**
          * Output header field strings corresponding to the variables output by the realization, as defined in
          * `output_variable_names`.

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -607,6 +607,17 @@ namespace realization {
             Catchment_Formulation::config_pattern_substitution(properties, BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG,
                                                                "{{id}}", id);
 
+            // Inject a three-part compound identity on the submodule BEFORE
+            // create_formulation runs, so that compound_id() is fully qualified
+            // during submodule construction with the following structure:
+            // "<catchment.submodule_index>:<submodule-mtn>:<multi-mtn>"
+            // Peek the submodule's own model_type_name from the config map —
+            // we cannot wait for create_formulation() to populate it on
+            // the submodule because we need the compound in place first.
+            std::string submodule_mtn =
+                properties.at(BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE).as_string();
+            mod->set_compound_id(identifier + ":" + submodule_mtn + ":" + get_model_type_name());
+
             // Call create_formulation to perform the rest of the typical initialization steps for the formulation.
             mod->create_formulation(properties);
 


### PR DESCRIPTION
Introduce an engine-level compound identity for BMI formulation instances. Designed as a unique per-formulation key.

Default composition for a single-BMI formulation:

    "<this->id>:<model_type_name>"
    e.g. "cat-1:bmi_c_cfe"

For a Bmi_Multi_Formulation submodule, the parent injects a three-part compound via `set_compound_id()` inside `init_nested_module`, BEFORE the submodule's `create_formulation()` runs — so any engine-level consumer that reads `compound_id()` during submodule construction sees the full key:

    "<this->id>:<submodule-mtn>:<multi-mtn>"
    e.g. "cat-1.0:bmi_c_cfe:bmi_multi_noahowp_cfe"

The submodule's `this->id` is already `<catchment>.<index>` from Bmi_Multi_Formulation's existing identifier construction; we append its own `model_type_name` (peeked from the config map so it's available pre-create_formulation) and the enclosing multi's `model_type_name`.

`this->id` is not mutated — it stays the feature identifier used by current code paths (output naming, forcing lookup, logs). The compound is a read-only view of the formulation's place in the realization, built from fields already in hand.

This is used in #957, and was extracted as an independent feature from that effort. 

## Additions

- a formulation compound_id_ member and getter/setters

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
