### PR TITLE
Small changes to make later multithreading work easier

### DIFF
--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -67,9 +67,9 @@ namespace ngen
          * is not yet implemented in this class.
         */
         void update_models(boost::span<double> catchment_outflows, 
-                           std::unordered_map<std::string, int> &catchment_indexes,
+                           std::unordered_map<std::string, int> const& catchment_indexes,
                            boost::span<double> nexus_downstream_flows,
-                           std::unordered_map<std::string, int> &nexus_indexes,
+                           std::unordered_map<std::string, int> const& nexus_indexes,
                            int current_step) override {
             std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
             try{

--- a/include/core/HY_Features.hpp
+++ b/include/core/HY_Features.hpp
@@ -77,21 +77,6 @@ namespace hy_features {
         HY_Features( geojson::GeoJSON catchments, std::string* link_key, std::shared_ptr<Formulation_Manager> formulations);
 
         /**
-         * @brief Get the HY_CatchmentRealization pointer identified by @p id
-         * 
-         * If no realization exists for @p id, a nullptr is returned.
-         * 
-         * @param id 
-         * @return std::shared_ptr<HY_CatchmentRealization> 
-         */
-        std::shared_ptr<HY_CatchmentRealization> catchment_at(std::string id)
-        {
-          if( _catchments.find(id) != _catchments.end() )
-            return _catchments[id]->realization;
-          return nullptr;
-        }
-
-        /**
          * @brief Construct a new HY_Features object from a Network and a set of formulations.
          * 
          * Constructs the HY_Catchment objects for each catchment feature in the network, and attaches tha formaulation
@@ -103,6 +88,22 @@ namespace hy_features {
         HY_Features( network::Network network, std::shared_ptr<Formulation_Manager> formulations, geojson::GeoJSON fabric);
 
         /**
+         * @brief Get the HY_CatchmentRealization pointer identified by @p id
+         * 
+         * If no realization exists for @p id, a nullptr is returned.
+         * 
+         * @param id 
+         * @return std::shared_ptr<HY_CatchmentRealization> 
+         */
+        std::shared_ptr<HY_CatchmentRealization> catchment_at(std::string id) const
+        {
+          auto iter = _catchments.find(id);
+          if( iter != _catchments.end() )
+            return iter->second->realization;
+          return nullptr;
+        }
+
+        /**
          * @brief Get the HY_HydroNexus pointer identifed by @p id
          * 
          * If no nexus exists for @p id, a nullptr is returned.
@@ -110,10 +111,11 @@ namespace hy_features {
          * @param id 
          * @return std::shared_ptr<HY_HydroNexus> 
          */
-        std::shared_ptr<HY_HydroNexus> nexus_at(const std::string& id)
+        std::shared_ptr<HY_HydroNexus> nexus_at(const std::string& id) const
         {
-          if( _nexuses.find(id) != _nexuses.end() )
-            return _nexuses[id];
+          auto iter = _nexuses.find(id);
+          if( iter != _nexuses.end() )
+            return iter->second;
           return nullptr;
         }
 
@@ -154,14 +156,16 @@ namespace hy_features {
          * @param id 
          * @return std::vector<std::shared_ptr<HY_HydroNexus>> 
          */
-        inline std::vector<std::shared_ptr<HY_HydroNexus>> destination_nexuses(const std::string&  id)
+        inline std::vector<std::shared_ptr<HY_HydroNexus>> destination_nexuses(const std::string&  id) const
         {
           std::vector<std::shared_ptr<HY_HydroNexus>> downstream;
-          if( _catchments.find(id) != _catchments.end())
+          auto iter = _catchments.find(id);
+          if( iter != _catchments.end())
           {
-            for(const auto& nex_id : _catchments[id]->get_outflow_nexuses())
+            auto const& catchment = iter->second;
+            for(const auto& nex_id : catchment->get_outflow_nexuses())
             {
-              downstream.push_back(_nexuses[nex_id]);
+              downstream.push_back(_nexuses.at(nex_id));
             }
           }
           return downstream;

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -112,9 +112,9 @@ namespace ngen
          * @brief Run one simulation timestep for each model in this layer
         */
         virtual void update_models(boost::span<double> catchment_outflows, 
-                                   std::unordered_map<std::string, int> &catchment_indexes,
+                                   std::unordered_map<std::string, int> const& catchment_indexes,
                                    boost::span<double> nexus_downstream_flows,
-                                   std::unordered_map<std::string, int> &nexus_indexes,
+                                   std::unordered_map<std::string, int> const& nexus_indexes,
                                    int current_step);
 
         protected:

--- a/include/core/SurfaceLayer.hpp
+++ b/include/core/SurfaceLayer.hpp
@@ -29,9 +29,9 @@ namespace ngen
          * @brief Run one simulation timestep for each model in this layer
         */
         void update_models(boost::span<double> catchment_outflows, 
-                           std::unordered_map<std::string, int> &catchment_indexes,
+                           std::unordered_map<std::string, int> const& catchment_indexes,
                            boost::span<double> nexus_downstream_flows,
-                           std::unordered_map<std::string, int> &nexus_indexes,
+                           std::unordered_map<std::string, int> const& nexus_indexes,
                            int current_step) override;
 
         private:

--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -61,9 +61,7 @@ namespace geojson {
          * 
          * @param property JSONProperty to add to the back of the List
          */
-        void push_back(const JSONProperty& property){
-            values->push_back(property);
-        }
+        void push_back(const JSONProperty& property);
 
         /**
          * @brief A stream overload to represent this type as a LIST
@@ -84,9 +82,7 @@ namespace geojson {
          * @return true If the JSONProperty vector \ref values is equal to \ref other vector of JSONProperty.
          * @return false If the JSONProperty vectors are not equivalent.
          */
-        bool inline operator==(const List& other) const{
-            return *values == *(other.values);
-        }
+        bool operator==(const List& other) const;
     };
 
     /**

--- a/include/simulation_time/Simulation_Time.hpp
+++ b/include/simulation_time/Simulation_Time.hpp
@@ -78,7 +78,7 @@ class Simulation_Time
      * @brief Accessor to the total number of time steps
      * @return total_output_times
      */
-    int get_total_output_times()
+    int get_total_output_times() const
     {
         return total_output_times;
     }
@@ -87,7 +87,7 @@ class Simulation_Time
      * @brief Accessor to the output_interval_seconds
      * @return output_interval_seconds
      */
-    int get_output_interval_seconds()
+    int get_output_interval_seconds() const
     {
         return output_interval_seconds;
     }
@@ -97,7 +97,7 @@ class Simulation_Time
      * @return current_date_time_epoch
     */
 
-    time_t get_current_epoch_time()
+    time_t get_current_epoch_time() const
     {
         return current_date_time_epoch;
     }   
@@ -125,25 +125,28 @@ class Simulation_Time
         return current_timestamp;
     }
 
-    inline int next_timestep_index(int epoch_time_seconds)
+    inline int next_timestep_index(int epoch_time_seconds) const
     {
         return int(epoch_time_seconds - start_date_time_epoch) / output_interval_seconds;
     }
 
-    inline int next_timestep_index()
+    inline int next_timestep_index() const
     {
         return next_timestep_index(current_date_time_epoch);
     }
 
-    inline time_t next_timestep_epoch_time(int epoch_time_seconds){
+    inline time_t next_timestep_epoch_time(int epoch_time_seconds) const
+    {
         return start_date_time_epoch + ( next_timestep_index(epoch_time_seconds) * output_interval_seconds );
     }
 
-    inline time_t next_timestep_epoch_time(){
+    inline time_t next_timestep_epoch_time() const
+    {
         return next_timestep_epoch_time(current_date_time_epoch);
     }
 
-    inline int diff(const Simulation_Time& other){
+    inline int diff(const Simulation_Time& other) const
+    {
         return start_date_time_epoch - other.start_date_time_epoch;
     }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -33,6 +33,10 @@ if (NGEN_WITH_PYTHON)
     target_link_libraries(core PUBLIC NGen::python)
 endif ()
 
+if (NGEN_WITH_ROUTING)
+    target_link_libraries(core PUBLIC NGen::routing)
+endif ()
+
 if(NGEN_WITH_MPI)
     target_link_libraries(core PUBLIC MPI::MPI_CXX)
 endif()

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -13,9 +13,9 @@
 ngen::Layer::~Layer() = default;
 
 void ngen::Layer::update_models(boost::span<double> catchment_outflows,
-                                std::unordered_map<std::string, int> &catchment_indexes,
+                                std::unordered_map<std::string, int> const & catchment_indexes,
                                 boost::span<double> nexus_downstream_flows,
-                                std::unordered_map<std::string, int> &nexus_indexes,
+                                std::unordered_map<std::string, int> const& nexus_indexes,
                                 int current_step)
 {
     auto idx = simulation_time.next_timestep_index();
@@ -56,7 +56,7 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
             throw std::runtime_error(msg);
         }
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
-        int results_index = catchment_indexes[id];
+        int results_index = catchment_indexes.at(id);
         // XXX: This is currently accumulating in meters of depth, which may not be desirable
         catchment_outflows[results_index] += response;
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -27,7 +27,6 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
     utils::time_marker current_time_marker(
         output_time_index, simulation_time.get_current_epoch_time(), current_timestamp);
     for(const auto& id : processing_units) {
-        int sub_time = output_time_index;
         //std::cout<<"Running cat "<<id<<std::endl;
         auto r = features.catchment_at(id);
         //TODO redesign to avoid this cast

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -18,9 +18,6 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
                                 std::unordered_map<std::string, int> const& nexus_indexes,
                                 int current_step)
 {
-    auto idx = simulation_time.next_timestep_index();
-    auto step = simulation_time.get_output_interval_seconds();
-            
     //std::cout<<"Output Time Index: "<<output_time_index<<std::endl;
     if(output_time_index%1000 == 0) std::cout<<"Running timestep " << output_time_index <<std::endl;
     std::string current_timestamp = simulation_time.get_timestamp(output_time_index);

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -7,9 +7,9 @@
 #endif
 
 void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows, 
-                                       std::unordered_map<std::string, int> &catchment_indexes,
+                                       std::unordered_map<std::string, int> const& catchment_indexes,
                                        boost::span<double> nexus_downstream_flows,
-                                       std::unordered_map<std::string, int> &nexus_indexes,
+                                       std::unordered_map<std::string, int> const& nexus_indexes,
                                        int current_step)
 {
     long current_time_index = output_time_index;
@@ -65,7 +65,7 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
 
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
-        int nexus_index = nexus_indexes[id];
+        int nexus_index = nexus_indexes.at(id);
         nexus_downstream_flows[nexus_index] += contribution_at_t;
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
 

--- a/src/geojson/JSONProperty.cpp
+++ b/src/geojson/JSONProperty.cpp
@@ -2,6 +2,14 @@
 
 using namespace geojson;
 
+void List::push_back(const JSONProperty& property) {
+    values->push_back(property);
+}
+
+bool List::operator==(const List& other) const {
+    return *values == *(other.values);
+}
+
 /**
  * @brief Attempt to get the natural numeric value stored within the property
  * 


### PR DESCRIPTION
Make more stuff `const`, delete unused things, and resolve a compiler compatibility issue, to facilitate adding multithreading support.

## Changes

- Mark numerous member functions in key classes as `const`
- Make several parameters of relevant functions `const` references
- Adapt some of the now-`const`-qualified functions to use `std::map::at()` or iterators directly, and avoid the possibly-inserting `operator[]`
- Delete unused variables in key places
- Add a missing CMake dependency that was missed by not compiling with routing enabled
- `HY_Features`: Reorder a constructor declaration to put it with all the others

## Testing

1. Local builds
2. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: