### PR TITLE
Simulation_Time thread safety

### DIFF
--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -67,7 +67,6 @@ public:
     double get_nexus_outflow(int nexus_index, int timestep_index) const;
 
     size_t get_num_output_times() const;
-    std::string get_timestamp_for_step(int step) const;
 
 private:
     void advance_models_one_output_step();

--- a/include/simulation_time/Simulation_Time.hpp
+++ b/include/simulation_time/Simulation_Time.hpp
@@ -106,10 +106,11 @@ class Simulation_Time
      * @brief Accessor to the current timestamp string
      * @return current_timestamp
      */ 
-    std::string get_timestamp(int current_output_time_index)
+    std::string get_timestamp(int current_output_time_index) const
     {
-        // "get" method mutates state!
-        current_date_time_epoch = start_date_time_epoch + current_output_time_index * output_interval_seconds;
+        if (start_date_time_epoch + current_output_time_index * output_interval_seconds != current_date_time_epoch) {
+            throw std::runtime_error("Simulation_Time misuse");
+        }
             
         struct tm *temp_gmtime_struct;
 

--- a/include/simulation_time/Simulation_Time.hpp
+++ b/include/simulation_time/Simulation_Time.hpp
@@ -112,14 +112,14 @@ class Simulation_Time
             throw std::runtime_error("Simulation_Time misuse");
         }
             
-        struct tm *temp_gmtime_struct;
+        struct tm temp_gmtime_struct;
 
-        temp_gmtime_struct = gmtime(&current_date_time_epoch);
+        gmtime_r(&current_date_time_epoch, &temp_gmtime_struct);
 
         char current_timestamp[20];
         const char* time_format = "%Y-%m-%d %T";
 
-        if (strftime(current_timestamp, sizeof(current_timestamp), time_format, temp_gmtime_struct) == 0) { 
+        if (strftime(current_timestamp, sizeof(current_timestamp), time_format, &temp_gmtime_struct) == 0) {
             throw std::runtime_error("ERROR: strftime returned 0");
         }
 

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -264,11 +264,6 @@ size_t NgenSimulation::get_num_output_times() const
     return sim_time_->get_total_output_times();
 }
 
-std::string NgenSimulation::get_timestamp_for_step(int step) const
-{
-    return sim_time_->get_timestamp(step);
-}
-
 template <class Archive>
 void NgenSimulation::serialize(Archive& ar) {
     /* Handle `catchment_formulation_manager` specially in the

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -14,6 +14,12 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
 {
     long current_time_index = output_time_index;
     
+    // Grab time details (but only once since the output_time_index doesn't (and shouldn't) change
+    std::string current_timestamp = simulation_time.get_timestamp(current_time_index);
+    time_t current_date_time_epoch = simulation_time.get_current_epoch_time();
+
+    utils::time_marker current_time_marker(current_time_index, current_date_time_epoch, current_timestamp);
+
     Layer::update_models(catchment_outflows, catchment_indexes, nexus_downstream_flows, nexus_indexes, current_step);
 
     // On the first time step, check all the nexuses and warn user about ones have no contributing catchments
@@ -31,13 +37,6 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
             }
         }
     }
-
-    // Grab time details (but only once since the output_time_index doesn' (and shouldn't) change
-    std::string current_timestamp = simulation_time.get_timestamp(current_time_index);
-    // Remember: above call to simulation_time.get_timestamp(current_time_index) has to be made first (see those funcs)
-    time_t current_date_time_epoch = simulation_time.get_current_epoch_time();
-
-    utils::time_marker current_time_marker(current_time_index, current_date_time_epoch, current_timestamp);
 
     // Once contributing catchments are updated for this timestep, dump the nexus output
     for(const auto& id : features.nexuses()) 

--- a/test/simulation_time/Simulation_Time_Test.cpp
+++ b/test/simulation_time/Simulation_Time_Test.cpp
@@ -58,8 +58,11 @@ TEST_F(SimulationTimeTest, TestSimulationTime)
 
     EXPECT_EQ(387, total_output_times);
 
-    std::string current_timestamp;
+    for (int i = 0; i < 5; ++i) {
+        Simulation_Time_Object1->advance_timestep();
+    }
 
+    std::string current_timestamp;
     current_timestamp = Simulation_Time_Object1->get_timestamp(5);
 
     std::string compare_timestamp = "2015-12-15 02:00:00";


### PR DESCRIPTION
Make `Simulation_Time::get_timestamp` non-mutating, and use a thread-safe date/time formatting function.

## Testing

1. Local run of test suite
2. Confirmed output of identical `current_timestamp` values from `SurfaceLayer` before and afterward
3. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: