### PR TITLE
Make all code called under Layer::update_models thread-safe

### DIFF
--- a/include/core/nexus/HY_PointHydroNexus.hpp
+++ b/include/core/nexus/HY_PointHydroNexus.hpp
@@ -43,6 +43,7 @@ class HY_PointHydroNexus : public HY_HydroNexus
     time_step_t min_timestep{0};
     std::unordered_set<time_step_t> completed;
 
+    std::mutex contribution_mutex;
 };
 
 #endif // HY_POINTHYDRONEXUS_H

--- a/include/utilities/output/CatchmentCsvOutputMgr.hpp
+++ b/include/utilities/output/CatchmentCsvOutputMgr.hpp
@@ -18,12 +18,14 @@ limitations under the License.
 #ifndef NGEN_CATCHMENTCSVOUTPUTMGR_HPP
 #define NGEN_CATCHMENTCSVOUTPUTMGR_HPP
 
+#include <mutex>
 #include <filesystem>
 #include <fstream>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "CatchmentOutputsMgr.hpp"
@@ -85,6 +87,8 @@ namespace utils
         const std::optional<std::string> aggregated_filename_;
         const int precision_;
         bool closed_ = false;
+        // Just use one mutex until we can see contention is actually an issue
+        std::mutex all_streams_mutex_;
 
         // Open output streams keyed by resolved file path. In per-feature mode each (formulation,
         // catchment) has its own path; in aggregated mode every catchment of a formulation resolves
@@ -97,8 +101,8 @@ namespace utils
         //! id nests under "<root><formulation>/".
         std::filesystem::path output_path(const std::string &formulation_id, const std::string &catchment_id);
 
-        //! Resolve the stream a (formulation, catchment)'s rows are written to, or nullptr if not registered.
-        std::ofstream* stream_for(const std::string &formulation_id, const std::string &catchment_id);
+        //! Resolve the stream a (formulation, catchment)'s rows are written to, or nullptr if not registered, and the mutex guarding that stream.
+        std::pair<std::ofstream*, std::mutex*> stream_for(const std::string &formulation_id, const std::string &catchment_id);
 
         //! Open the file(s) and write the header for one descriptor; called for each at construction.
         void add_feature(const FeatureDescriptor &descriptor);

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -58,7 +58,7 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         {
             origins = network.get_origination_ids(feat_id);
             _nexuses.emplace(feat_id, std::make_unique<HY_PointHydroNexus>(
-                                          HY_PointHydroNexus(feat_id, destinations, origins) ));
+                                          feat_id, destinations, origins ));
         }
         else
         {

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -18,8 +18,6 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
                                 std::unordered_map<std::string, int> const& nexus_indexes,
                                 int current_step)
 {
-    std::mutex accumulation_mutex;
-
     //std::cout<<"Output Time Index: "<<output_time_index<<std::endl;
     if(output_time_index%1000 == 0) std::cout<<"Running timestep " << output_time_index <<std::endl;
     std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
@@ -56,12 +54,7 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         int results_index = catchment_indexes.at(id);
         // XXX: This is currently accumulating in meters of depth, which may not be desirable
-        {
-            // XXX: Switch when we can use C++20
-            //std::atomic_ref(catchment_outflows[results_index]) += response;
-            std::lock_guard g(accumulation_mutex);
-            catchment_outflows[results_index] += response;
-        }
+        std::atomic_ref(catchment_outflows[results_index]) += response;
 
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         if (catchment_output_mgr) {

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -18,6 +18,8 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
                                 std::unordered_map<std::string, int> const& nexus_indexes,
                                 int current_step)
 {
+    std::mutex accumulation_mutex;
+
     //std::cout<<"Output Time Index: "<<output_time_index<<std::endl;
     if(output_time_index%1000 == 0) std::cout<<"Running timestep " << output_time_index <<std::endl;
     std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
@@ -54,7 +56,12 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         int results_index = catchment_indexes.at(id);
         // XXX: This is currently accumulating in meters of depth, which may not be desirable
-        std::atomic_ref(catchment_outflows[results_index]) += response;
+        {
+            // XXX: Switch when we can use C++20
+            //std::atomic_ref(catchment_outflows[results_index]) += response;
+            std::lock_guard g(accumulation_mutex);
+            catchment_outflows[results_index] += response;
+        }
 
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         if (catchment_output_mgr) {

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -54,7 +54,8 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
 #if NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         int results_index = catchment_indexes.at(id);
         // XXX: This is currently accumulating in meters of depth, which may not be desirable
-        catchment_outflows[results_index] += response;
+        std::atomic_ref(catchment_outflows[results_index]) += response;
+
 #endif // NGEN_WITH_ROUTING && NGEN_WITH_ROUTING_TROUTE_BMI
         if (catchment_output_mgr) {
             catchment_output_mgr->receive_data_entry(

--- a/src/core/nexus/HY_PointHydroNexus.cpp
+++ b/src/core/nexus/HY_PointHydroNexus.cpp
@@ -144,7 +144,9 @@ double HY_PointHydroNexus::get_downstream_flow(std::string catchment_id, time_st
 
 void HY_PointHydroNexus::add_upstream_flow(double val, std::string catchment_id, time_step_t t)
 {
-     if ( t < min_timestep ) BOOST_THROW_EXCEPTION(invalid_time_step());
+    std::lock_guard<std::mutex> lock(contribution_mutex);
+
+    if ( t < min_timestep ) BOOST_THROW_EXCEPTION(invalid_time_step());
     if ( completed.find(t) != completed.end() ) BOOST_THROW_EXCEPTION(completed_time_step());
 
     auto s1 = upstream_flows.find(t);

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -2,6 +2,8 @@
 #include "utilities/logging_utils.h"
 #include <UnitsHelper.hpp>
 
+#include <atomic>
+
 namespace realization {
 
         std::set<Bmi_Var_Details> Bmi_Module_Formulation::known_bmi_input_vars;
@@ -25,9 +27,8 @@ namespace realization {
             if (timestep != (next_time_step_index - 1)) {
                 throw std::invalid_argument("Only current time step valid when getting output for BMI C++ formulation");
             }
-            static bool no_conversion_message_logged = false;
-            if (!no_conversion_message_logged) {
-                no_conversion_message_logged = true;
+            static std::atomic_flag no_conversion_message_logged;
+            if (!no_conversion_message_logged.test_and_set()) {
                 logging::warning("Output variables do not have unit conversion. Capability not yet implemented in ngen.");
             }
 

--- a/src/utilities/logging/logging_utils.cpp
+++ b/src/utilities/logging/logging_utils.cpp
@@ -1,9 +1,12 @@
 #include <iostream>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include "logging_utils.h"
 
 namespace logging {
+
+    std::mutex logging_mutex;
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +15,7 @@ extern "C" {
     void debug(const char* msg)
     {
         #ifndef NGEN_QUIET
+            std::lock_guard l(logging_mutex);
             std::cerr<<"DEBUG: " << std::string(msg);
         #endif
     }
@@ -19,6 +23,7 @@ extern "C" {
     void info(const char* msg)
     {
         #ifndef NGEN_QUIET
+            std::lock_guard l(logging_mutex);
             std::cerr<<"INFO: " << std::string(msg);
         #endif
     }
@@ -26,17 +31,20 @@ extern "C" {
     void warning(const char* msg)
     {
         #ifndef NGEN_QUIET
+            std::lock_guard l(logging_mutex);
             std::cerr<<"WARNING: " <<std::string(msg);
         #endif
     }
 
     void error(const char* msg)
     {
+        std::lock_guard l(logging_mutex);
         std::cerr<<"ERROR: " <<std::string(msg);
     }
 
     void critical(const char* msg)
     {
+        std::lock_guard l(logging_mutex);
         std::cerr<<"CRITICAL: " <<std::string(msg);
     }
 

--- a/src/utilities/output/CatchmentCsvOutputMgr.cpp
+++ b/src/utilities/output/CatchmentCsvOutputMgr.cpp
@@ -102,10 +102,10 @@ std::filesystem::path CatchmentCsvOutputMgr::output_path(const std::string &form
     return output_root_ + formulation_id + "/" + filename;
 }
 
-std::ofstream* CatchmentCsvOutputMgr::stream_for(const std::string &formulation_id, const std::string &catchment_id)
+std::pair<std::ofstream*, std::mutex*> CatchmentCsvOutputMgr::stream_for(const std::string &formulation_id, const std::string &catchment_id)
 {
     const auto it = streams_.find(output_path(formulation_id, catchment_id));
-    return it == streams_.end() ? nullptr : it->second.get();
+    return {it == streams_.end() ? nullptr : it->second.get(), &all_streams_mutex_};
 }
 
 void CatchmentCsvOutputMgr::add_feature(const FeatureDescriptor &feature)
@@ -136,10 +136,11 @@ void CatchmentCsvOutputMgr::receive_data_entry(const std::string &formulation_id
         throw std::runtime_error("Can't receive data on a closed CatchmentCsvOutputMgr");
     }
 
-    std::ofstream* out = stream_for(formulation_id, catchment_id);
+    auto [out, mutex] = stream_for(formulation_id, catchment_id);
     if (out == nullptr) {
         throw std::runtime_error("CatchmentCsvOutputMgr received data for an unknown catchment '" + catchment_id + "'");
     }
+    std::lock_guard stream_lock(*mutex);
     // In aggregated output each row carries the (full) catchment id so rows stay attributable.
     if( aggregated_filename_.has_value() ) {
         (*out) << catchment_id << DELIMITER;


### PR DESCRIPTION
This is the set of changes necessary to safely run the loop over catchment formulations in multiple threads.

I manually walked down the call graph to identify these changes, relying on the earlier `const` additions and other changes in #1012 and #1013 to cut off inspections.

In runs not using multi-threading, the changes in this PR add two kinds of overhead
* Memory footprint of the mutexes and such
* Execution time overhead of un-contended atomic operations to increment, lock, and unlock

I believe both should be negligible for our purposes.

This is separate from a PR introducing the mechanism for actual parallel execution, because that should come with greater scrutiny of the design choice and performance impacts.

## Changes

- Add `std::mutex` members to the nexus and catchment CSV output classes, and the logging namespace
- Lock on those mutexes when accessing shared state from member functions of those classes
- Catchment CSV output's stream lookup was modified to potentially use more than a shared mutex (e.g. per-stream, or picked from a lock pool)
- Atomic accumulation of catchment outflows
- Turn a boolean flag for whether a particular warning has been printed once into an atomic flag

## Testing

1. CI
2. I provisionally added multithreading as seen in #1006 and ran with ThreadSanitizer, to observe a clean run. Thus, I believe this PR is comprehensive in its coverage.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing Notes

Actually applying ThreadSanitizer (TSan) usefully was a bit of a challenge. The issue is that the implementation of `std::for_each(std::execution::par, ...)` is rather janky in libstdc++ (as provided by GCC), and so is GCC's implementation of TSan. The library depends on the open-sourced version of Intel TBB, but silently falls back to a serial implementation if that is not linked into the final binary. GCC does not properly instrument `atomic_thread_fence` operations for TSan, while TBB uses such operations heavily for synchronization. Thus, a build of the ngen code with GCC, TSan, and naive packaged TBB results in a huge mass of false positives from TBB itself.

To obtain meaningful testing, eventually reporting no issues, I did the following:
* Built TBB from source using Clang with TSan enabled
* Built ngen with Clang and TSan enabled
* Added linkage with `-ltbb` to for the `ngen` executable