### PR TITLE
CatchmentCsvOutputManager: Avoid hash<std::filesytem::path> compatibility pitfall

### DIFF
--- a/docker/ngen.dockerfile
+++ b/docker/ngen.dockerfile
@@ -7,9 +7,10 @@ RUN dnf update -y \
     && dnf install -y --allowerasing tar git gcc-toolset-12 make cmake udunits2-devel coreutils \
     && dnf clean all
 
-# Rocky 8's system compiler is GCC 8, whose libstdc++ lacks complete C++17 <filesystem>
-# support (notably std::hash<std::filesystem::path>). Build with the gcc-toolset-12 SCL
-# toolchain instead, and point the runtime loader at its libstdc++.
+# Rocky 8's system compiler is GCC 8, which doesn't support C++20 and
+# whose libstdc++ lacks complete C++17 <filesystem> support.
+# Build with the gcc-toolset-12 SCL toolchain instead, and point the
+# runtime loader at its libstdc++.
 ENV PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/rh/gcc-toolset-12/root/usr/lib64:/opt/rh/gcc-toolset-12/root/usr/lib" \
     CC="/opt/rh/gcc-toolset-12/root/usr/bin/gcc" \

--- a/include/utilities/output/CatchmentCsvOutputMgr.hpp
+++ b/include/utilities/output/CatchmentCsvOutputMgr.hpp
@@ -24,7 +24,7 @@ limitations under the License.
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -93,7 +93,7 @@ namespace utils
         // Open output streams keyed by resolved file path. In per-feature mode each (formulation,
         // catchment) has its own path; in aggregated mode every catchment of a formulation resolves
         // to the same path and shares one stream.
-        std::unordered_map<std::filesystem::path, std::shared_ptr<std::ofstream>> streams_;
+        std::map<std::filesystem::path, std::shared_ptr<std::ofstream>> streams_;
 
         //! Resolve the output file path for a (formulation, catchment). The file name is the
         //! catchment ("<catchment>.csv") per-feature, or the shared aggregated filename when


### PR DESCRIPTION
Switch use of an `unordered_map<std::filesystem::path, stream*>` to `map<path, stream*>` to avoid the need for a hash function for `std::filesystem::path`. This is an issue because C++17 inadvertently omitted that requirement, and compilers' standard libraries conforming to C++17 didn't implement it until several versions later. For instance, GCC 9 supports full C++17, but the hash isn't implemented until 11.4.0, and is missing even in 11.2.0.

Cf:
https://cplusplus.github.io/LWG/issue3657
And the very last table row here:
https://en.cppreference.com/cpp/compiler_support/17

## Testing

1. Local build
2. CI

## Notes

- I think the hypothetical performance impact of this should be negligible, especially since we should move away from CSV-per-catchment output when we care about performance anyway.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
