### PR TITLE
Move to require C++20

### DIFF
--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -190,6 +190,11 @@ runs:
             export CXXFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -pedantic-errors -Werror -Wpessimizing-move -Wparentheses -Wrange-loop-construct -Wsuggest-override"
             if [ ${{ runner.os }} == 'macOS' ]
             then
+              if [ ${{ matrix.compiler }} == 'gcc' ]
+              then
+                export CC=gcc-13
+                export CXX=g++-13
+              fi
               echo "fun:PyType_FromMetaclass" > /tmp/asan_ignore.txt
               export CFLAGS="$CFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
               export CXXFLAGS="$CXXFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -194,6 +194,11 @@ runs:
               export CFLAGS="$CFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
               export CXXFLAGS="$CXXFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
             else
+              if [ ${{ matrix.compiler }} == 'clang' ]
+              then
+                export CC=clang
+                export CXX=clang++
+              fi
               export CFLAGS="$CFLAGS -O1"
               export CXXFLAGS="$CXXFLAGS -O1"
             fi

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -190,14 +190,18 @@ runs:
             export CXXFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -pedantic-errors -Werror -Wpessimizing-move -Wparentheses -Wrange-loop-construct -Wsuggest-override"
             if [ ${{ runner.os }} == 'macOS' ]
             then
+              echo "fun:PyType_FromMetaclass" > /tmp/asan_ignore.txt
+              export CFLAGS="$CFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
+              export CXXFLAGS="$CXXFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
+
+              # Don't bother wth ASan stuff for macOS-gcc - it's covered well enough by macOS-clang, and linux-gcc
               if [ ${{ matrix.compiler }} == 'gcc' ]
               then
                 export CC=gcc-13
                 export CXX=g++-13
+                export CFLAGS=" -g -fno-omit-frame-pointer -Werror"
+                export CXXFLAGS="-g -fno-omit-frame-pointer -pedantic-errors -Werror -Wpessimizing-move -Wparentheses -Wrange-loop-construct -Wsuggest-override"
               fi
-              echo "fun:PyType_FromMetaclass" > /tmp/asan_ignore.txt
-              export CFLAGS="$CFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
-              export CXXFLAGS="$CXXFLAGS -O0 -fsanitize-ignorelist=/tmp/asan_ignore.txt -fno-common"
             else
               if [ ${{ matrix.compiler }} == 'clang' ]
               then

--- a/.github/actions/ngen-build/action.yaml
+++ b/.github/actions/ngen-build/action.yaml
@@ -85,7 +85,11 @@ runs:
               echo "NETCDF=/usr" >> $GITHUB_ENV
             elif [ ${{ runner.os }} == 'macOS' ]
             then
-              brew install netcdf netcdf-cxx netcdf-fortran
+              brew install netcdf netcdf-fortran
+              if [ ${{ matrix.compiler }} == 'clang' ]
+              then
+                brew install netcdf-cxx
+              fi
               echo "LIBRARY_PATH=$(brew --prefix)/lib/:$LIBRARY_PATH" >> $GITHUB_ENV
               echo "LD_LIBRARY_PATH=$(brew --prefix)/lib/:$LD_LIBRARY_PATH" >> $GITHUB_ENV
               echo "LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-15]
+        compiler: [gcc, clang]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -118,6 +119,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
+        compiler: [gcc, clang]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ endif()
 
 # -----------------------------------------------------------------------------
 # Set global C++ options
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -49,21 +49,21 @@ If CMake is unable to find a compiler automatically, the CMake `CMAKE_C_COMPILER
 
 ### Version Requirements
 
-Project C++ code needs to be compliant with the C++ 17 standard.  Supported compilers need to be of a recent enough version to be compatible.  
+Project C++ code needs to be compliant with the C++ 20 standard. Supported compilers need to be of a recent enough version to be compatible.
 
 Additionally, C++ compilers needs to be compatible (ideally officially *tested* as such) with other project C++ dependencies.
 
 #### GCC
 
-Based on [this page](https://gcc.gnu.org/projects/cxx-status.html#cxx17), C++ 17 *language* support alone equates to some GCC version `7` release or later. However, the project also relies on a complete C++ 17 `<filesystem>` implementation (e.g. `std::hash<std::filesystem::path>`), which GCC `8`'s libstdc++ does not fully provide, so the effective minimum is GCC `9` or later.
+Based on [this page](https://gcc.gnu.org/projects/cxx-status.html#cxx20), C++ 20 support equates to some GCC version `11` release or later.
 
 On RHEL/Rocky/AlmaLinux `8`, whose system compiler is GCC `8`, install and enable a newer [`gcc-toolset`](https://developers.redhat.com/products/developertoolset/overview) rather than the base `gcc` (the project's container image, `docker/ngen.dockerfile`, uses `gcc-toolset-12`).
 
 #### Clang
 
-The Clang versioning scheme is a little convoluted.  Using the official scheme, Clang 5 and later should support all C++ 17 features.
+The Clang versioning scheme is a little convoluted.  Using the official scheme, Clang versions 10 and later should sufficiently support C++ 20 features.
 
-However, Apple likes to apply their own versioning to Clang and LLVM.  The `Apple LLVM version 10.0.1 (clang-1001.0.46.4)` version released with MacOS 10.14.x should do fine.  Recent, earlier version likely will as well, but YMMV.
+However, Apple likes to apply their own versioning to Clang and LLVM.  The Apple LLVM version 12.0.5 should do fine.  Recent, earlier version likely will as well, but YMMV.
 
 ## CMake
 

--- a/include/geojson/features/FeatureBase.hpp
+++ b/include/geojson/features/FeatureBase.hpp
@@ -559,7 +559,7 @@ namespace geojson {
 
             virtual void visit(FeatureVisitor &visitor) = 0;
 
-            inline bool operator==(const FeatureBase& rhs) {
+            inline bool operator==(const FeatureBase& rhs) const {
                 if (this->get_id() != rhs.get_id()) {
                     return false;
                 }

--- a/test/core/nexus/NexusRemoteTests.cpp
+++ b/test/core/nexus/NexusRemoteTests.cpp
@@ -899,7 +899,7 @@ TEST_F(Nexus_Remote_Test, DISABLED_TestRawMpiDeadlockPattern)
     if (mpi_rank == 1) {
         volatile double dummy = 0.0;
         for (int i = 0; i < 100000000; ++i) {
-            dummy += std::sin(i * 0.0001) * std::cos(i * 0.0002);
+            dummy = dummy + std::sin(i * 0.0001) * std::cos(i * 0.0002);
         }
     }
     
@@ -1065,7 +1065,7 @@ TEST_F(Nexus_Remote_Test, TestRemoteNexusDeadlockFree)
     if (mpi_rank == 1) {
         volatile double dummy = 0.0;
         for (int i = 0; i < 100000000; ++i) {
-            dummy += std::sin(i * 0.0001) * std::cos(i * 0.0002);
+            dummy = dummy + std::sin(i * 0.0001) * std::cos(i * 0.0002);
         }
     }
 


### PR DESCRIPTION
C++20 adds a variety of features that will make our development more convenient and the resulting code more reliable and performant.

E.g.
* `std::span`
* Ranges
* Container heterogeneous lookup
* Container `contains()` members
* Floating-point atomics
* `std::atomic_ref`
* String `begins_with` and `ends_with`
* Text formatting with `std::format`
* Calendar and Time Zone support in `std::chrono`

The latter two unfortunately aren't implemented until later compiler/library releases, so we may need to hold off on adoption for a bit.

## Changes

- Top-level CMake: set C++ standard from 17 to 20
- Code tweaks to fix up deprecated and ill-formed code that no longer compiles
- Documentation updates to match the necessary compiler versions
- CI: Add jobs using Clang 14 on Ubuntu 22.04 and GCC 13 on macOS 15, to get more cross-version compatibility coverage

## Testing

1. AppleClang and GCC locally and in CI workflows
2. Clang and GCC on Ubuntu 22.04 in CI workflow

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: