### PR TITLE
JSON Parsing cleanup

### DIFF
--- a/include/core/Partition_Parser.hpp
+++ b/include/core/Partition_Parser.hpp
@@ -11,7 +11,6 @@
 #include <unordered_set>
 
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <FeatureBuilder.hpp>
 #include "features/Features.hpp"
 #include <FeatureCollection.hpp>
@@ -21,15 +20,6 @@
 class Partitions_Parser {
 
     public:
-        //Constructor that takes an input json file path and points to the root of the tree in json file
-        Partitions_Parser(const std::string &file_path) {
-            boost::property_tree::ptree loaded_tree;
-            boost::property_tree::json_parser::read_json(file_path, loaded_tree);
-            std::cout << "file read success" << std::endl;
-            this->tree = loaded_tree;
-            std::cout << "file_path: " << file_path << std::endl;
-        };
-
         Partitions_Parser(const boost::property_tree::ptree tree){
             this->tree = tree;
         }

--- a/include/geojson/FeatureBuilder.hpp
+++ b/include/geojson/FeatureBuilder.hpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 
 #include <boost/property_tree/ptree.hpp>
+#include "utilities/JSON_Reader.hpp"
 
 namespace geojson {
     /**
@@ -442,9 +443,7 @@ namespace geojson {
     }
 
     static GeoJSON read(const std::string &file_path, const std::vector<std::string> &ids = {}) {
-        boost::property_tree::ptree tree;
-        boost::property_tree::json_parser::read_json(file_path, tree);
-        return build_collection(tree, ids);
+        return build_collection(ptree_from_json_file(file_path), ids);
     }
 
     static GeoJSON read(std::stringstream &data, const std::vector<std::string> &ids = {}) {

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -32,20 +32,6 @@ namespace realization {
 
     class Formulation_Manager {
         public:
-            Formulation_Manager(std::stringstream &data) {
-                boost::property_tree::ptree loaded_tree;
-                boost::property_tree::json_parser::read_json(data, loaded_tree);
-                this->tree = loaded_tree;
-                initialize_output_config();
-            }
-
-            Formulation_Manager(const std::string &file_path) {
-                boost::property_tree::ptree loaded_tree;
-                boost::property_tree::json_parser::read_json(file_path, loaded_tree);
-                this->tree = loaded_tree;
-                initialize_output_config();
-            }
-
             Formulation_Manager(boost::property_tree::ptree &loaded_tree) {
                 this->tree = loaded_tree;
                 initialize_output_config();

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <sstream>
 #include <tuple>
+#include <utility>
 #include <functional>
 #include <dirent.h>
 #include <sys/stat.h>
@@ -31,8 +32,8 @@ namespace realization {
 
     class Formulation_Manager {
         public:
-            Formulation_Manager(boost::property_tree::ptree &loaded_tree)
-                : tree(loaded_tree)
+            Formulation_Manager(boost::property_tree::ptree loaded_tree)
+                : tree(std::move(loaded_tree))
             {
                 initialize_output_config();
             }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -17,7 +17,6 @@
 #include <iostream>
 
 #include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <FeatureBuilder.hpp>
 #include "features/Features.hpp"
 #include "Formulation_Constructors.hpp"

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -32,8 +32,9 @@ namespace realization {
 
     class Formulation_Manager {
         public:
-            Formulation_Manager(boost::property_tree::ptree &loaded_tree) {
-                this->tree = loaded_tree;
+            Formulation_Manager(boost::property_tree::ptree &loaded_tree)
+                : tree(loaded_tree)
+            {
                 initialize_output_config();
             }
 

--- a/include/utilities/JSON_Reader.hpp
+++ b/include/utilities/JSON_Reader.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <boost/property_tree/json_parser.hpp>
+#include <string>
+
+// Trivial wrapper to functionally *return* the parsed ptree, rather
+// than taking an output argument
+inline boost::property_tree::ptree ptree_from_json_file(std::string const& path) {
+    boost::property_tree::ptree ptree;
+    boost::property_tree::json_parser::read_json(path, ptree);
+    return ptree;
+}

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -61,6 +61,8 @@
 #include "utilities/output/PerFormulationNexusOutputMgr.hpp"
 #endif
 
+#include "utilities/JSON_Reader.hpp"
+
 #include <mediator/UnitsHelper.hpp>
 
 void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept
@@ -354,7 +356,7 @@ int main(int argc, char* argv[]) {
     #if NGEN_WITH_MPI
     PartitionData local_data;
     if (mpi_num_procs > 1) {
-        Partitions_Parser partition_parser(PARTITION_PATH);
+        Partitions_Parser partition_parser(ptree_from_json_file(PARTITION_PATH));
         // TODO: add something here to make sure this step worked for every rank, and maybe to checksum the file
         partition_parser.parse_partition_file();
 
@@ -413,8 +415,7 @@ int main(int argc, char* argv[]) {
     //to map features to their primary id as well as the alternative property
     nexus_collection->update_ids("id");
 
-    boost::property_tree::ptree realization_config;
-    boost::property_tree::json_parser::read_json(REALIZATION_CONFIG_PATH, realization_config);
+    boost::property_tree::ptree realization_config = ptree_from_json_file(REALIZATION_CONFIG_PATH);
 
     std::shared_ptr<Simulation_Time> sim_time;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 add_executable(test_all)
 target_link_libraries(test_all PRIVATE gtest gtest_main)
 set_target_properties(test_all PROPERTIES FOLDER test)
-target_include_directories(test_all PRIVATE ${CMAKE_CURRENT_LIST_DIR}/bmi)
+target_include_directories(test_all PRIVATE ${CMAKE_CURRENT_LIST_DIR}/bmi ${NGEN_ROOT_DIR}/include)
 
 # =============================================================================
 
@@ -110,6 +110,7 @@ function(ngen_add_test TESTNAME)
 
     if(NGEN_TEST_CREATE)
         add_executable(${TESTNAME} ${NGEN_TEST_OBJECTS})
+        target_include_directories(${TESTNAME} PRIVATE ${NGEN_ROOT_DIR}/include)
         target_include_directories(${TESTNAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/bmi)
         target_link_libraries(${TESTNAME} PRIVATE gtest gtest_main ${NGEN_TEST_LIBRARIES})
         set_target_properties(${TESTNAME} PROPERTIES FOLDER test)

--- a/test/core/multilayer/MultiLayerParserTest.cpp
+++ b/test/core/multilayer/MultiLayerParserTest.cpp
@@ -3,6 +3,8 @@
 #include "FileChecker.h"
 #include <Formulation_Manager.hpp>
 
+#include "utilities/JSON_Reader.hpp"
+
 class MultiLayerParserTest : public ::testing::Test {
 
     static std::string find_file(std::vector<std::string> dir_opts, const std::string& basename) {
@@ -63,17 +65,14 @@ class MultiLayerParserTest : public ::testing::Test {
 
 TEST_F(MultiLayerParserTest, TestInit0)
 {
-    manager = std::make_shared<realization::Formulation_Manager>(realization_config_path.c_str());
+    manager = std::make_shared<realization::Formulation_Manager>(ptree_from_json_file(realization_config_path));
 
     ASSERT_TRUE(true);
 }
 
 TEST_F(MultiLayerParserTest, TestRead0)
 {
-    std::ifstream stream(realization_config_path);
-
-    boost::property_tree::ptree realization_config;
-    boost::property_tree::json_parser::read_json(stream, realization_config);
+    boost::property_tree::ptree realization_config = ptree_from_json_file(realization_config_path);
 
     auto possible_simulation_time = realization_config.get_child_optional("time");
     if (!possible_simulation_time) {

--- a/test/utils/Partition_Test.cpp
+++ b/test/utils/Partition_Test.cpp
@@ -12,6 +12,8 @@
 #include "core/Partition_Parser.hpp"
 #include "FileChecker.h"
 
+#include "utilities/JSON_Reader.hpp"
+
 
 class PartitionsParserTest: public ::testing::Test {
 
@@ -76,7 +78,7 @@ void PartitionsParserTest::setupArbitraryExampleCase() {
 TEST_F(PartitionsParserTest, TestFileReader)
 {GTEST_SKIP() << "Skipping test"; //test broke, partition file is out of date
   const std::string file_path = file_search(data_paths,"partition_huc01.json");
-  Partitions_Parser partitions_parser = Partitions_Parser(file_path);
+  Partitions_Parser partitions_parser = Partitions_Parser(ptree_from_json_file(file_path));
 
   partitions_parser.parse_partition_file();
 
@@ -87,7 +89,7 @@ TEST_F(PartitionsParserTest, TestFileReader)
 TEST_F(PartitionsParserTest, DisplayPartitionData)
 { GTEST_SKIP() << "Skipping test"; //test broke, partition file is out of date
   const std::string file_path = file_search(data_paths,"partition_huc01.json");
-  Partitions_Parser partitions_parser = Partitions_Parser(file_path);
+  Partitions_Parser partitions_parser = Partitions_Parser(ptree_from_json_file(file_path));
 
   partitions_parser.parse_partition_file();
 


### PR DESCRIPTION
Drop versions of `Formulation_Manager` and `Partitions_Parser` constructors that take JSON files or contents and parse them, rather than just accepting the parsed contents in a `ptree`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: